### PR TITLE
Nixpkgs 23.11 update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1256,22 +1256,6 @@
     },
     "nixpkgs_11": {
       "locked": {
-        "lastModified": 1675249806,
-        "narHash": "sha256-u8Rcqekusl3pMZm68hZqr6zozI8Ug5IxqOiqDLAlu1k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "79feedf38536de2a27d13fe2eaf200a9c05193ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_12": {
-      "locked": {
         "lastModified": 1636823747,
         "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
         "owner": "nixos",
@@ -1430,6 +1414,22 @@
         "type": "github"
       }
     },
+    "opentofu-registry": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701811617,
+        "narHash": "sha256-0RcmJU6qkldb3VOEM37PG02D25LNaA12Oy794dr1Ih8=",
+        "owner": "opentofu",
+        "repo": "registry",
+        "rev": "3d8c146c42fccfcfe89d81a46cd4268bd39aa242",
+        "type": "github"
+      },
+      "original": {
+        "owner": "opentofu",
+        "repo": "registry",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "auth-keys-hub": "auth-keys-hub",
@@ -1450,8 +1450,8 @@
         "nix": "nix_2",
         "nixpkgs": "nixpkgs_9",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "opentofu-registry": "opentofu-registry",
         "sops-nix": "sops-nix",
-        "terraform-providers": "terraform-providers",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix_2"
       }
@@ -1610,30 +1610,12 @@
         "type": "github"
       }
     },
-    "terraform-providers": {
-      "inputs": {
-        "nixpkgs": "nixpkgs_11"
-      },
-      "locked": {
-        "lastModified": 1695893013,
-        "narHash": "sha256-+5EuXNXwxpTiOEGCbZWtZCU75WcVwnS89heLa5xJ2K0=",
-        "owner": "nix-community",
-        "repo": "nixpkgs-terraform-providers-bin",
-        "rev": "6c6865ae6f9bff7aaa4e86c875f520f2aca65c0d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs-terraform-providers-bin",
-        "type": "github"
-      }
-    },
     "terranix": {
       "inputs": {
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_12",
+        "nixpkgs": "nixpkgs_11",
         "terranix-examples": "terranix-examples"
       },
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -960,16 +960,16 @@
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
-        "lastModified": 1693573010,
-        "narHash": "sha256-HBm8mR2skhPtbJ7p+ByrOZjs7SfsfZPwy75MwI1EUmk=",
+        "lastModified": 1701705406,
+        "narHash": "sha256-c7/VJH/3/NdmJQe3X7Hlf/tFQ265n2hXGWA+0conEO8=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "5568ca5ff130a8a0bc3db5878432eb527c74dd60",
+        "rev": "aaeab0040126d7e0bf59886abd4a1e2855482ee9",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "2.17-maintenance",
+        "ref": "2.19-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -1224,11 +1224,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1696577711,
-        "narHash": "sha256-94VRjvClIKDym1QRqPkX5LTQoAwZ1E6QE/3dWtOXSIQ=",
+        "lastModified": 1701626906,
+        "narHash": "sha256-ugr1QyzzwNk505ICE4VMQzonHQ9QS5W33xF2FXzFQ00=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "a2eb207f45e4a14a1e3019d9e3863d1e208e2295",
+        "rev": "0c6d8c783336a59f4c59d4a6daed6ab269c4b361",
         "type": "github"
       },
       "original": {
@@ -1383,32 +1383,32 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1670461440,
-        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
+        "lastModified": 1700748986,
+        "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
+        "rev": "9ba29e2346bc542e9909d1021e8fd7d4b3f64db0",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11-small",
+        "ref": "nixos-23.05-small",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "nixpkgs_9": {
       "locked": {
-        "lastModified": 1691328192,
-        "narHash": "sha256-w59N1zyDQ7SupfMJLFvtms/SIVbdryqlw5AS4+DiH+Y=",
+        "lastModified": 1701539137,
+        "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "61676e4dcfeeb058f255294bcb08ea7f3bc3ce56",
+        "rev": "933d7dc155096e7575d207be6fb7792bc9f34f6d",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-23.05",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -12,7 +12,10 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
     nix.url = "github:nixos/nix/2.19-maintenance";
     sops-nix.url = "github:Mic92/sops-nix";
-    terraform-providers.url = "github:nix-community/nixpkgs-terraform-providers-bin";
+    opentofu-registry = {
+      url = "github:opentofu/registry";
+      flake = false;
+    };
     terranix.url = "github:terranix/terranix";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     inputs-check.url = "github:input-output-hk/inputs-check";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
-    nix.url = "github:nixos/nix/2.17-maintenance";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.11";
+    nix.url = "github:nixos/nix/2.19-maintenance";
     sops-nix.url = "github:Mic92/sops-nix";
     terraform-providers.url = "github:nix-community/nixpkgs-terraform-providers-bin";
     terranix.url = "github:terranix/terranix";

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -94,11 +94,7 @@
     };
 
     services = {
-      chrony = {
-        enable = true;
-        extraConfig = "rtcsync";
-      };
-
+      chrony.enable = true;
       cron.enable = true;
       fail2ban.enable = true;
       openssh = {

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -67,7 +67,7 @@
       nano
       neovim
       ncdu
-      (nushell.override {additionalFeatures = p: p ++ ["dataframe"];})
+      nushellFull
       parted
       pciutils
       procps

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -94,7 +94,12 @@
     };
 
     services = {
-      chrony.enable = true;
+      chrony = {
+        enable = true;
+        extraConfig = "rtcsync";
+        enableRTCTrimming = false;
+      };
+
       cron.enable = true;
       fail2ban.enable = true;
       openssh = {

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -67,7 +67,8 @@
       nano
       neovim
       ncdu
-      nushellFull
+      # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a non-existent pkg failure
+      inputs.nixpkgs.legacyPackages.${system}.nushellFull
       parted
       pciutils
       procps

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -14,141 +14,154 @@
   flake.nixosModules.profile-basic = moduleWithSystem ({system}: {
     name,
     pkgs,
+    lib,
     ...
-  }: {
-    deployment.targetHost = name;
+  }:
+    with builtins;
+    with lib; {
+      deployment.targetHost = name;
 
-    networking = {
-      hostName = name;
-      firewall = {
-        enable = true;
-        allowedTCPPorts = [22];
-        allowedUDPPorts = [];
-      };
-    };
-
-    time.timeZone = "UTC";
-    i18n.supportedLocales = ["en_US.UTF-8/UTF-8" "en_US/ISO-8859-1"];
-
-    boot = {
-      tmp.cleanOnBoot = true;
-      kernelParams = ["boot.trace"];
-      loader.grub.configurationLimit = 10;
-    };
-
-    documentation = {
-      nixos.enable = false;
-      man.man-db.enable = false;
-      info.enable = false;
-      doc.enable = false;
-    };
-
-    environment.systemPackages = with pkgs; [
-      awscli2
-      age
-      bat
-      bind
-      cloud-utils
-      di
-      dnsutils
-      fd
-      fx
-      file
-      git
-      glances
-      helix
-      htop
-      ijq
-      icdiff
-      iptables
-      jiq
-      jq
-      lsof
-      nano
-      neovim
-      ncdu
-      # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a non-existent pkg failure
-      inputs.nixpkgs.legacyPackages.${system}.nushellFull
-      parted
-      pciutils
-      procps
-      ripgrep
-      rsync
-      smem
-      ssh-to-age
-      sops
-      sysstat
-      tcpdump
-      tree
-      wget
-    ];
-
-    programs = {
-      tmux = {
-        enable = true;
-        aggressiveResize = true;
-        clock24 = true;
-        escapeTime = 0;
-        historyLimit = 10000;
-        newSession = true;
-      };
-    };
-
-    services = {
-      chrony = {
-        enable = true;
-        extraConfig = "rtcsync";
-        enableRTCTrimming = false;
-      };
-
-      cron.enable = true;
-      fail2ban.enable = true;
-      openssh = {
-        enable = true;
-        settings = {
-          PasswordAuthentication = false;
-          RequiredRSASize = 2048;
-          PubkeyAcceptedAlgorithms = "-*nist*";
+      networking = {
+        hostName = name;
+        firewall = {
+          enable = true;
+          allowedTCPPorts = [22];
+          allowedUDPPorts = [];
         };
       };
-    };
 
-    system.extraSystemBuilderCmds = ''
-      ln -sv ${pkgs.path} $out/nixpkgs
-    '';
+      time.timeZone = "UTC";
+      i18n.supportedLocales = ["en_US.UTF-8/UTF-8" "en_US/ISO-8859-1"];
 
-    nix = {
-      package = inputs.nix.packages.${system}.nix;
-      registry.nixpkgs.flake = inputs.nixpkgs;
-      optimise.automatic = true;
-      gc.automatic = true;
-
-      settings = {
-        auto-optimise-store = true;
-        builders-use-substitutes = true;
-        experimental-features = ["nix-command" "fetch-closure" "flakes" "cgroups"];
-        keep-derivations = true;
-        keep-outputs = true;
-        max-jobs = "auto";
-        show-trace = true;
-        substituters = ["https://cache.iog.io"];
-        system-features = ["recursive-nix" "nixos-test"];
-        tarball-ttl = 60 * 60 * 72;
-        trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+      boot = {
+        tmp.cleanOnBoot = true;
+        kernelParams = ["boot.trace"];
+        loader.grub.configurationLimit = 10;
       };
-    };
 
-    security.tpm2 = {
-      enable = true;
-      pkcs11.enable = true;
-    };
+      documentation = {
+        nixos.enable = false;
+        man.man-db.enable = false;
+        info.enable = false;
+        doc.enable = false;
+      };
 
-    hardware = {
-      cpu.amd.updateMicrocode = true;
-      cpu.intel.updateMicrocode = true;
-      enableRedistributableFirmware = true;
-    };
+      environment.systemPackages = with pkgs; [
+        awscli2
+        age
+        bat
+        bind
+        cloud-utils
+        di
+        dnsutils
+        fd
+        fx
+        file
+        git
+        glances
+        helix
+        htop
+        ijq
+        icdiff
+        iptables
+        jiq
+        jq
+        lsof
+        nano
+        neovim
+        ncdu
+        # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a non-existent pkg failure
+        inputs.nixpkgs.legacyPackages.${system}.nushellFull
+        parted
+        pciutils
+        procps
+        ripgrep
+        rsync
+        smem
+        ssh-to-age
+        sops
+        sysstat
+        tcpdump
+        tree
+        wget
+      ];
 
-    system.stateVersion = "23.05";
-  });
+      programs = {
+        tmux = {
+          enable = true;
+          aggressiveResize = true;
+          clock24 = true;
+          escapeTime = 0;
+          historyLimit = 10000;
+          newSession = true;
+        };
+      };
+
+      services = {
+        chrony = {
+          enable = true;
+          extraConfig = "rtcsync";
+          enableRTCTrimming = false;
+        };
+
+        cron.enable = true;
+        fail2ban.enable = true;
+        openssh = {
+          enable = true;
+          settings = {
+            PasswordAuthentication = false;
+            RequiredRSASize = 2048;
+            PubkeyAcceptedAlgorithms = "-*nist*";
+          };
+        };
+      };
+
+      system.extraSystemBuilderCmds = ''
+        ln -sv ${pkgs.path} $out/nixpkgs
+      '';
+
+      nix = {
+        package = inputs.nix.packages.${system}.nix;
+        registry.nixpkgs.flake = inputs.nixpkgs;
+        optimise.automatic = true;
+        gc.automatic = true;
+
+        settings = {
+          auto-optimise-store = true;
+          builders-use-substitutes = true;
+          experimental-features = ["nix-command" "fetch-closure" "flakes" "cgroups"];
+          keep-derivations = true;
+          keep-outputs = true;
+          max-jobs = "auto";
+          show-trace = true;
+          substituters = ["https://cache.iog.io"];
+          system-features = ["recursive-nix" "nixos-test"];
+          tarball-ttl = 60 * 60 * 72;
+          trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
+        };
+      };
+
+      security.tpm2 = {
+        enable = true;
+        pkcs11.enable = true;
+      };
+
+      hardware = {
+        cpu.amd.updateMicrocode = true;
+        cpu.intel.updateMicrocode = true;
+        enableRedistributableFirmware = true;
+      };
+
+      system.stateVersion = "23.05";
+
+      warnings = let
+        match' = versionStr: match ''^([[:d:]]+\.[[:d:]]+).*$'' versionStr;
+        sanitize = versionStr:
+          if isList (match' versionStr)
+          then head (match' versionStr)
+          else versionStr;
+      in
+        optional (version != inputs.nixpkgs.lib.version)
+        "cardano-parts nixosModules have been tested with ${sanitize inputs.nixpkgs.lib.version}, whereas this nixosConfiguration is using ${sanitize version}";
+    });
 }

--- a/flake/nixosModules/profile-cardano-db-sync.nix
+++ b/flake/nixosModules/profile-cardano-db-sync.nix
@@ -114,29 +114,35 @@
           '';
         };
 
-        # Profile cardano-postgres is tuned for 70% of RAM, leaving ~20% for node
-        # and 10% for other services (dbsync smash) and overhead.
-        services.cardano-node.totalMaxHeapSizeMiB = cfg.nodeRamAvailableMiB;
-        services.cardano-postgres.ramAvailableMiB = cfg.postgresRamAvailableMiB;
+        services = {
+          # Profile cardano-postgres is tuned for 70% of RAM, leaving ~20% for node
+          # and 10% for other services (dbsync smash) and overhead.
+          cardano-node.totalMaxHeapSizeMiB = cfg.nodeRamAvailableMiB;
+          cardano-postgres.ramAvailableMiB = cfg.postgresRamAvailableMiB;
 
-        services.cardano-db-sync = {
-          enable = true;
-          package = cardano-db-sync;
-          dbSyncPkgs = cardano-db-sync-pkgs;
+          cardano-db-sync = {
+            enable = true;
+            package = cardano-db-sync;
+            dbSyncPkgs = cardano-db-sync-pkgs;
 
-          cluster = environmentName;
-          environment = environmentConfig;
-          socketPath = nodeCfg.socketPath 0;
-          explorerConfig = environmentConfig.dbSyncConfig // {PrometheusPort = cardanoDbSyncPrometheusExporterPort;};
-          logConfig = {};
-          postgres.database = "cexplorer";
+            cluster = environmentName;
+            environment = environmentConfig;
+            socketPath = nodeCfg.socketPath 0;
+            explorerConfig = environmentConfig.dbSyncConfig // {PrometheusPort = cardanoDbSyncPrometheusExporterPort;};
+            logConfig = {};
+            postgres.database = "cexplorer";
+          };
         };
 
         # Ensure access to the cardano-node socket
-        users.groups.cardano-db-sync = {};
-        users.users.cardano-db-sync.extraGroups = ["cardano-node"];
-        users.users.cardano-db-sync.group = "cardano-db-sync";
-        users.users.cardano-db-sync.isSystemUser = true;
+        users = {
+          groups.cardano-db-sync = {};
+          users.cardano-db-sync = {
+            extraGroups = ["cardano-node"];
+            group = "cardano-db-sync";
+            isSystemUser = true;
+          };
+        };
       };
     });
 }

--- a/flake/nixosModules/profile-cardano-db-sync.nix
+++ b/flake/nixosModules/profile-cardano-db-sync.nix
@@ -89,17 +89,12 @@
       config = {
         environment.systemPackages = [cardano-db-tool];
 
-        systemd.services.postgresql.postStart = mkAfter ''
-          # For postgres >= 15
-          $PSQL -tA cexplorer -c 'GRANT ALL ON SCHEMA public TO cexplorer'
-        '';
-
         services.postgresql = {
           ensureDatabases = ["cexplorer"];
           ensureUsers = [
             {
               name = "cexplorer";
-              ensurePermissions."DATABASE cexplorer" = "ALL PRIVILEGES";
+              ensureDBOwnership = true;
             }
           ];
 

--- a/flake/nixosModules/profile-cardano-metadata.nix
+++ b/flake/nixosModules/profile-cardano-metadata.nix
@@ -205,11 +205,6 @@ flake: {
 
       config = {
         systemd.services = {
-          postgresql.postStart = mkAfter ''
-            # For postgres >= 15
-            $PSQL -tA ${cfgSrv.postgres.database} -c 'GRANT ALL ON SCHEMA public TO ${cfgSrv.postgres.user}'
-          '';
-
           # Disallow metadata-server to restart more than 3 times within a 30 minute window
           # This ensures the service stops and an alert will get sent if there is a persistent restart issue
           # This also allows for some additional startup time before failure and restart
@@ -260,7 +255,7 @@ flake: {
             ensureUsers = [
               {
                 name = "${cfgSrv.postgres.user}";
-                ensurePermissions."DATABASE ${cfgSrv.postgres.database}" = "ALL PRIVILEGES";
+                ensureDBOwnership = true;
               }
             ];
             identMap = ''
@@ -282,9 +277,248 @@ flake: {
             enable = true;
             package = metadata-server;
             port = cfg.metadataServerPort;
-            postgres.numConnections = cpuCount;
+
+            postgres = {
+              # To utilize ensureDBOwnership in >= nixpkgs 23.11, the database and username must the same.
+              database = "metadata";
+              user = "metadata";
+              numConnections = cpuCount;
+            };
+          };
+
+          metadata-webhook = {
+            enable = true;
+            package = metadata-webhook;
+            user = "metadata-webhook";
+            port = cfg.metadataWebhookPort;
+            environmentFile = "/run/secrets/cardano-metadata-webhook";
+            postgres = {inherit (cfgSrv.postgres) socketdir port database table user numConnections;};
+          };
+
+          metadata-sync = {
+            enable = true;
+            package = metadata-sync;
+
+            postgres = {inherit (cfgSrv.postgres) socketdir port database table user numConnections;};
+
+            git = {
+              repositoryUrl = cfg.metadataSyncGitUrl;
+              metadataFolder = cfg.metadataSyncGitMetadataFolder;
+            };
+          };
+
+          varnish = {
+            enable = true;
+            extraModules = [pkgs.varnishPackages.modules];
+            extraCommandLine = "-t ${toString (cfg.varnishTtlMinutes * 60)} -s malloc,${toString (roundFloat cfg.varnishRamAvailableMiB)}M";
+            config = ''
+              vcl 4.1;
+
+              import std;
+              import bodyaccess;
+
+              backend default {
+                .host = "127.0.0.1";
+                .port = "${toString cfg.metadataServerPort}";
+              }
+
+              acl purge {
+                "localhost";
+                "127.0.0.1";
+              }
+
+              sub vcl_recv {
+                unset req.http.X-Body-Len;
+                unset req.http.x-cache;
+
+                # Allow PURGE from localhost
+                if (req.method == "PURGE") {
+                  if (!std.ip(req.http.X-Real-Ip, "0.0.0.0") ~ purge) {
+                    return(synth(405,"Not Allowed"));
+                  }
+
+                  # If needed, host can be passed in the curl purge request with -H "Host: $HOST"
+                  # along with an allow listed X-Real-Ip header.
+                }
+
+                # Allow POST caching
+                # PURGE also needs to hash the body to obtain a correct object hash to purge
+                if (req.method == "POST" || req.method == "PURGE") {
+                  # Caches the body which enables POST retries if needed
+                  std.cache_req_body(${toString cfg.varnishMaxPostSizeCachableKiB}KB);
+                  set req.http.X-Body-Len = bodyaccess.len_req_body();
+
+                  if ((std.integer(req.http.X-Body-Len, ${toString (1024 * cfg.varnishMaxPostSizeCachableKiB)}) > ${toString (1024 * cfg.varnishMaxPostSizeBodyKiB)}) ||
+                      (req.http.X-Body-Len == "-1")) {
+                    return(synth(413, "Payload Too Large"));
+                  }
+
+                  if (req.method == "PURGE") {
+                    return(purge);
+                  }
+                  return(hash);
+                }
+              }
+
+              sub vcl_hash {
+                # For caching POSTs, hash the body also
+                if (req.http.X-Body-Len) {
+                  bodyaccess.hash_req_body();
+                }
+                else {
+                  hash_data("");
+                }
+              }
+
+              sub vcl_hit {
+                set req.http.x-cache = "hit";
+              }
+
+              sub vcl_miss {
+                set req.http.x-cache = "miss";
+              }
+
+              sub vcl_pass {
+                set req.http.x-cache = "pass";
+              }
+
+              sub vcl_pipe {
+                set req.http.x-cache = "pipe";
+              }
+
+              sub vcl_synth {
+                set req.http.x-cache = "synth synth";
+                set resp.http.x-cache = req.http.x-cache;
+              }
+
+              sub vcl_deliver {
+                if (obj.uncacheable) {
+                  set req.http.x-cache = req.http.x-cache + " uncacheable";
+                }
+                else {
+                  set req.http.x-cache = req.http.x-cache + " cached";
+                }
+                set resp.http.x-cache = req.http.x-cache;
+              }
+
+              sub vcl_backend_fetch {
+                if (bereq.http.X-Body-Len) {
+                  set bereq.method = "POST";
+                }
+              }
+
+              sub vcl_backend_response {
+                if (beresp.status == 404) {
+                  set beresp.ttl = ${toString (2 * cfg.varnishTtlMinutes / 3)}m;
+                }
+                call vcl_builtin_backend_response;
+                return (deliver);
+              }
+            '';
+          };
+
+          nginx-vhost-exporter.enable = true;
+
+          nginx = {
+            enable = true;
+            eventsConfig = "worker_connections 8192;";
+            recommendedGzipSettings = true;
+            recommendedOptimisation = true;
+            recommendedProxySettings = true;
+
+            commonHttpConfig = ''
+              log_format x-fwd '$remote_addr - $remote_user $sent_http_x_cache [$time_local] '
+                               '"$scheme://$host" "$request" $status $body_bytes_sent '
+                               '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
+
+              access_log syslog:server=unix:/dev/log x-fwd if=$loggable;
+
+              limit_req_zone $binary_remote_addr zone=metadataQueryPerIP:100m rate=10r/s;
+              limit_req_status 429;
+              server_names_hash_bucket_size 128;
+
+              map $sent_http_x_cache $loggable_varnish {
+                default 1;
+                "hit cached" 0;
+              }
+
+              map $request_uri $loggable {
+                /status/format/prometheus 0;
+                default $loggable_varnish;
+              }
+
+              map $request_method $upstream_location {
+                GET     127.0.0.1:6081;
+                default 127.0.0.1:${toString cfg.metadataServerPort};
+              }
+            '';
+
+            virtualHosts = {
+              metadata = {
+                inherit (cfg) serverAliases serverName;
+
+                default = true;
+                enableACME = cfg.enableAcme;
+                forceSSL = cfg.enableAcme;
+
+                locations = let
+                  corsConfig = ''
+                    add_header 'Vary' 'Origin' always;
+                    add_header 'Access-Control-Allow-Methods' 'GET, PATCH, OPTIONS' always;
+                    add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,Content-Type' always;
+
+                    if ($request_method = OPTIONS) {
+                      add_header 'Access-Control-Max-Age' 86400;
+                      add_header 'Content-Type' 'text/plain; charset=utf-8';
+                      add_header 'Content-Length' 0;
+                      return 204;
+                    }
+                  '';
+                  serverEndpoints = [
+                    "/metadata/query"
+                    "/metadata"
+                  ];
+                  webhookEndpoints = [
+                    "/webhook"
+                  ];
+                in
+                  {
+                    "/".root = pkgs.runCommand "nginx-root-dir" {} ''mkdir $out; echo -n "Ready" > $out/index.html'';
+                  }
+                  // (recursiveUpdate (genAttrs serverEndpoints (_: {
+                      proxyPass = "http://$upstream_location";
+                      extraConfig = corsConfig;
+                    })) {
+                      # Uncomment to add varnish caching for all request on `/metadata/query` endpoint:
+                      # "/metadata/query".proxyPass = "http://127.0.0.1:6081";
+                      "/metadata/query".extraConfig = ''
+                        limit_req zone=metadataQueryPerIP burst=20 nodelay;
+                        ${corsConfig}
+                      '';
+                      "/metadata/healthcheck".extraConfig = ''
+                        add_header Content-Type text/plain;
+                        return 200 'OK';
+                      '';
+                    })
+                  // (genAttrs webhookEndpoints (p: {
+                    proxyPass = "http://127.0.0.1:${toString cfg.metadataWebhookPort}${p}";
+                    extraConfig = corsConfig;
+                  }));
+              };
+            };
+          };
+
+          prometheus.exporters = {
+            varnish = {
+              enable = true;
+              listenAddress = "127.0.0.1";
+              port = cfg.varnishExporterPort;
+              group = "varnish";
+            };
           };
         };
+
+        networking.firewall.allowedTCPPorts = mkIf cfg.openFirewallNginx [80 443];
 
         # For the webhook service, a non-dynamic user is required for user and group file assignment to the sops secret,
         # which gets created before a dynamic user and group is available:
@@ -296,139 +530,6 @@ flake: {
           };
         };
 
-        services.metadata-webhook = {
-          enable = true;
-          package = metadata-webhook;
-          user = "metadata-webhook";
-          port = cfg.metadataWebhookPort;
-          environmentFile = "/run/secrets/cardano-metadata-webhook";
-          postgres = {inherit (cfgSrv.postgres) socketdir port database table user numConnections;};
-        };
-
-        services.metadata-sync = {
-          enable = true;
-          package = metadata-sync;
-
-          postgres = {inherit (cfgSrv.postgres) socketdir port database table user numConnections;};
-
-          git = {
-            repositoryUrl = cfg.metadataSyncGitUrl;
-            metadataFolder = cfg.metadataSyncGitMetadataFolder;
-          };
-        };
-
-        services.varnish = {
-          enable = true;
-          extraModules = [pkgs.varnishPackages.modules];
-          extraCommandLine = "-t ${toString (cfg.varnishTtlMinutes * 60)} -s malloc,${toString (roundFloat cfg.varnishRamAvailableMiB)}M";
-          config = ''
-            vcl 4.1;
-
-            import std;
-            import bodyaccess;
-
-            backend default {
-              .host = "127.0.0.1";
-              .port = "${toString cfg.metadataServerPort}";
-            }
-
-            acl purge {
-              "localhost";
-              "127.0.0.1";
-            }
-
-            sub vcl_recv {
-              unset req.http.X-Body-Len;
-              unset req.http.x-cache;
-
-              # Allow PURGE from localhost
-              if (req.method == "PURGE") {
-                if (!std.ip(req.http.X-Real-Ip, "0.0.0.0") ~ purge) {
-                  return(synth(405,"Not Allowed"));
-                }
-
-                # If needed, host can be passed in the curl purge request with -H "Host: $HOST"
-                # along with an allow listed X-Real-Ip header.
-              }
-
-              # Allow POST caching
-              # PURGE also needs to hash the body to obtain a correct object hash to purge
-              if (req.method == "POST" || req.method == "PURGE") {
-                # Caches the body which enables POST retries if needed
-                std.cache_req_body(${toString cfg.varnishMaxPostSizeCachableKiB}KB);
-                set req.http.X-Body-Len = bodyaccess.len_req_body();
-
-                if ((std.integer(req.http.X-Body-Len, ${toString (1024 * cfg.varnishMaxPostSizeCachableKiB)}) > ${toString (1024 * cfg.varnishMaxPostSizeBodyKiB)}) ||
-                    (req.http.X-Body-Len == "-1")) {
-                  return(synth(413, "Payload Too Large"));
-                }
-
-                if (req.method == "PURGE") {
-                  return(purge);
-                }
-                return(hash);
-              }
-            }
-
-            sub vcl_hash {
-              # For caching POSTs, hash the body also
-              if (req.http.X-Body-Len) {
-                bodyaccess.hash_req_body();
-              }
-              else {
-                hash_data("");
-              }
-            }
-
-            sub vcl_hit {
-              set req.http.x-cache = "hit";
-            }
-
-            sub vcl_miss {
-              set req.http.x-cache = "miss";
-            }
-
-            sub vcl_pass {
-              set req.http.x-cache = "pass";
-            }
-
-            sub vcl_pipe {
-              set req.http.x-cache = "pipe";
-            }
-
-            sub vcl_synth {
-              set req.http.x-cache = "synth synth";
-              set resp.http.x-cache = req.http.x-cache;
-            }
-
-            sub vcl_deliver {
-              if (obj.uncacheable) {
-                set req.http.x-cache = req.http.x-cache + " uncacheable";
-              }
-              else {
-                set req.http.x-cache = req.http.x-cache + " cached";
-              }
-              set resp.http.x-cache = req.http.x-cache;
-            }
-
-            sub vcl_backend_fetch {
-              if (bereq.http.X-Body-Len) {
-                set bereq.method = "POST";
-              }
-            }
-
-            sub vcl_backend_response {
-              if (beresp.status == 404) {
-                set beresp.ttl = ${toString (2 * cfg.varnishTtlMinutes / 3)}m;
-              }
-              call vcl_builtin_backend_response;
-              return (deliver);
-            }
-          '';
-        };
-
-        networking.firewall.allowedTCPPorts = mkIf cfg.openFirewallNginx [80 443];
-
         security.acme = mkIf cfg.enableAcme {
           acceptTerms = true;
           defaults = {
@@ -437,106 +538,6 @@ flake: {
               if cfg.acmeProd
               then "https://acme-v02.api.letsencrypt.org/directory"
               else "https://acme-staging-v02.api.letsencrypt.org/directory";
-          };
-        };
-
-        services.nginx-vhost-exporter.enable = true;
-
-        services.nginx = {
-          enable = true;
-          eventsConfig = "worker_connections 8192;";
-          recommendedGzipSettings = true;
-          recommendedOptimisation = true;
-          recommendedProxySettings = true;
-
-          commonHttpConfig = ''
-            log_format x-fwd '$remote_addr - $remote_user $sent_http_x_cache [$time_local] '
-                             '"$scheme://$host" "$request" $status $body_bytes_sent '
-                             '"$http_referer" "$http_user_agent" "$http_x_forwarded_for"';
-
-            access_log syslog:server=unix:/dev/log x-fwd if=$loggable;
-
-            limit_req_zone $binary_remote_addr zone=metadataQueryPerIP:100m rate=10r/s;
-            limit_req_status 429;
-            server_names_hash_bucket_size 128;
-
-            map $sent_http_x_cache $loggable_varnish {
-              default 1;
-              "hit cached" 0;
-            }
-
-            map $request_uri $loggable {
-              /status/format/prometheus 0;
-              default $loggable_varnish;
-            }
-
-            map $request_method $upstream_location {
-              GET     127.0.0.1:6081;
-              default 127.0.0.1:${toString cfg.metadataServerPort};
-            }
-          '';
-
-          virtualHosts = {
-            metadata = {
-              inherit (cfg) serverAliases serverName;
-
-              default = true;
-              enableACME = cfg.enableAcme;
-              forceSSL = cfg.enableAcme;
-
-              locations = let
-                corsConfig = ''
-                  add_header 'Vary' 'Origin' always;
-                  add_header 'Access-Control-Allow-Methods' 'GET, PATCH, OPTIONS' always;
-                  add_header 'Access-Control-Allow-Headers' 'User-Agent,X-Requested-With,Content-Type' always;
-
-                  if ($request_method = OPTIONS) {
-                    add_header 'Access-Control-Max-Age' 86400;
-                    add_header 'Content-Type' 'text/plain; charset=utf-8';
-                    add_header 'Content-Length' 0;
-                    return 204;
-                  }
-                '';
-                serverEndpoints = [
-                  "/metadata/query"
-                  "/metadata"
-                ];
-                webhookEndpoints = [
-                  "/webhook"
-                ];
-              in
-                {
-                  "/".root = pkgs.runCommand "nginx-root-dir" {} ''mkdir $out; echo -n "Ready" > $out/index.html'';
-                }
-                // (recursiveUpdate (genAttrs serverEndpoints (_: {
-                    proxyPass = "http://$upstream_location";
-                    extraConfig = corsConfig;
-                  })) {
-                    # Uncomment to add varnish caching for all request on `/metadata/query` endpoint:
-                    # "/metadata/query".proxyPass = "http://127.0.0.1:6081";
-                    "/metadata/query".extraConfig = ''
-                      limit_req zone=metadataQueryPerIP burst=20 nodelay;
-                      ${corsConfig}
-                    '';
-                    "/metadata/healthcheck".extraConfig = ''
-                      add_header Content-Type text/plain;
-                      return 200 'OK';
-                    '';
-                  })
-                // (genAttrs webhookEndpoints (p: {
-                  proxyPass = "http://127.0.0.1:${toString cfg.metadataWebhookPort}${p}";
-                  extraConfig = corsConfig;
-                }));
-            };
-          };
-        };
-
-        services.prometheus.exporters = {
-          varnish = {
-            enable = true;
-            listenAddress = "127.0.0.1";
-            port = cfg.varnishExporterPort;
-            group = "varnish";
           };
         };
 

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -256,9 +256,13 @@
           }) {}
         iRange;
 
-      users.groups.cardano-node = {};
-      users.users.cardano-node.group = "cardano-node";
-      users.users.cardano-node.isSystemUser = true;
+      users = {
+        groups.cardano-node = {};
+        users.cardano-node = {
+          group = "cardano-node";
+          isSystemUser = true;
+        };
+      };
 
       assertions = [
         {

--- a/flake/nixosModules/profile-grafana-agent.nix
+++ b/flake/nixosModules/profile-grafana-agent.nix
@@ -93,9 +93,13 @@ flake: {
           };
         };
 
-        users.groups.grafana-agent = {};
-        users.users.grafana-agent.group = "grafana-agent";
-        users.users.grafana-agent.isSystemUser = true;
+        users = {
+          groups.grafana-agent = {};
+          users.grafana-agent = {
+            group = "grafana-agent";
+            isSystemUser = true;
+          };
+        };
 
         sops.secrets =
           mkSopsSecret (mkSopsSecretParams "grafana-agent-metrics-url")

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -171,8 +171,8 @@ in {
 
       envCfgs = cardanoLib: generateStaticHTMLConfigs pkgs cardanoLib cardanoLib.environments;
     in {
-      config = {
-        packages.job-gen-env-config = let
+      config.packages = {
+        job-gen-env-config = let
           configDir = runCommand "configDir" {} ''
             mkdir -p $out
             cp -r ${envCfgs cardanoLib} $out/environments
@@ -193,7 +193,7 @@ in {
             '';
           };
 
-        packages.job-gen-custom-node-config = writeShellApplication {
+        job-gen-custom-node-config = writeShellApplication {
           name = "job-gen-custom-node-config";
           runtimeInputs = stdPkgs;
           text = ''
@@ -293,7 +293,7 @@ in {
           '';
         };
 
-        packages.job-create-stake-pool-keys = writeShellApplication {
+        job-create-stake-pool-keys = writeShellApplication {
           name = "job-create-stake-pools";
           runtimeInputs = stdPkgs ++ [cardano-address];
           text = ''
@@ -424,7 +424,7 @@ in {
           '';
         };
 
-        packages.job-delegate-rewards-stake-key = writeShellApplication {
+        job-delegate-rewards-stake-key = writeShellApplication {
           name = "job-delegate-rewards-stake-key";
           runtimeInputs = stdPkgs;
           text = ''
@@ -521,7 +521,7 @@ in {
           '';
         };
 
-        packages.job-register-stake-pools = writeShellApplication {
+        job-register-stake-pools = writeShellApplication {
           name = "job-register-stake-pools";
           runtimeInputs = stdPkgs;
           text = ''
@@ -682,7 +682,7 @@ in {
           '';
         };
 
-        packages.job-rotate-kes-pools = writeShellApplication {
+        job-rotate-kes-pools = writeShellApplication {
           name = "job-rotate-kes-pools";
           runtimeInputs = stdPkgs;
           text = ''
@@ -755,7 +755,7 @@ in {
           '';
         };
 
-        packages.job-move-genesis-utxo = writeShellApplication {
+        job-move-genesis-utxo = writeShellApplication {
           name = "job-move-genesis-utxo";
           runtimeInputs = stdPkgs;
           text = ''
@@ -815,7 +815,7 @@ in {
           '';
         };
 
-        packages.job-update-proposal-generic = writeShellApplication {
+        job-update-proposal-generic = writeShellApplication {
           name = "job-update-proposal-generic";
           runtimeInputs = stdPkgs;
           text = ''
@@ -849,7 +849,7 @@ in {
           '';
         };
 
-        packages.job-update-proposal-d = writeShellApplication {
+        job-update-proposal-d = writeShellApplication {
           name = "job-update-proposal-d";
           runtimeInputs = stdPkgs;
           text = ''
@@ -879,7 +879,7 @@ in {
           '';
         };
 
-        packages.job-update-proposal-hard-fork = writeShellApplication {
+        job-update-proposal-hard-fork = writeShellApplication {
           name = "job-update-proposal-hard-fork";
           runtimeInputs = stdPkgs;
           text = ''
@@ -910,7 +910,7 @@ in {
           '';
         };
 
-        packages.job-update-proposal-cost-model = writeShellApplication {
+        job-update-proposal-cost-model = writeShellApplication {
           name = "job-update-proposal-cost-model";
           runtimeInputs = stdPkgs;
           text = ''
@@ -941,7 +941,7 @@ in {
           '';
         };
 
-        packages.job-update-proposal-mainnet-params = writeShellApplication {
+        job-update-proposal-mainnet-params = writeShellApplication {
           name = "job-update-proposal-mainnet-params";
           runtimeInputs = stdPkgs;
           text = ''
@@ -973,7 +973,7 @@ in {
           '';
         };
 
-        packages.job-submit-gov-action = writeShellApplication {
+        job-submit-gov-action = writeShellApplication {
           name = "job-submit-gov-action";
           runtimeInputs = stdPkgs;
           text = ''
@@ -1065,7 +1065,7 @@ in {
           '';
         };
 
-        packages.job-submit-vote = writeShellApplication {
+        job-submit-vote = writeShellApplication {
           name = "job-submit-vote";
           runtimeInputs = stdPkgs;
           text = ''
@@ -1158,7 +1158,7 @@ in {
           '';
         };
 
-        packages.job-register-drep = writeShellApplication {
+        job-register-drep = writeShellApplication {
           name = "job-register-drep";
           runtimeInputs = stdPkgs;
           text = ''
@@ -1262,7 +1262,7 @@ in {
           '';
         };
 
-        packages.job-register-cc = writeShellApplication {
+        job-register-cc = writeShellApplication {
           name = "job-register-cc";
           runtimeInputs = with pkgs; [coreutils jq];
           text = ''
@@ -1327,7 +1327,7 @@ in {
           '';
         };
 
-        packages.job-gen-keys-cc = writeShellApplication {
+        job-gen-keys-cc = writeShellApplication {
           name = "job-register-cc";
           runtimeInputs = with pkgs; [coreutils jq];
           text = ''
@@ -1357,7 +1357,7 @@ in {
           '';
         };
 
-        packages.job-delegate-drep = writeShellApplication {
+        job-delegate-drep = writeShellApplication {
           name = "job-delegate-drep";
           runtimeInputs = stdPkgs;
           text = ''

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -61,7 +61,6 @@ in
         withLocal = withSystem system;
         treefmtEval = localFlake.inputs.treefmt-nix.lib.evalModule pkgs cfgShell.global.defaultFormatterCfg;
         isPartsRepo = "${getExe pkgs.gnugrep} -qiE 'cardano[- ]parts' flake.nix &> /dev/null";
-        nushellPkg = pkgs.nushell.override {additionalFeatures = p: p ++ ["dataframe"];};
 
         globalDefault = isGlobal: default:
           if isGlobal
@@ -251,7 +250,7 @@ in
                     localFlake.inputs.nixpkgs-unstable.legacyPackages.${system}.jq
                     just
                     moreutils
-                    nushellPkg
+                    nushellFull
                     ripgrep
                     statix
                     xxd
@@ -371,7 +370,7 @@ in
             (pkgs.writeShellApplication
               {
                 name = "menu-${id}";
-                runtimeInputs = [nushellPkg];
+                runtimeInputs = [pkgs.nushellFull];
 
                 text = let
                   minWidth =

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -246,8 +246,7 @@ in
                     gawk
                     gnugrep
                     gnused
-                    # Need jq 1.7 for rc != 0 on empty file or stream key test
-                    localFlake.inputs.nixpkgs-unstable.legacyPackages.${system}.jq
+                    jq
                     just
                     moreutils
                     nushellFull
@@ -278,7 +277,8 @@ in
                     ++ (with pkgs;
                       with cfgPkgs; [
                         b2sum
-                        haskellPackages.cbor-tool
+                        # Currently marked as broken in nixpkgs-23.11 and nixpkgs-unstable
+                        # haskellPackages.cbor-tool
                         bech32
                         cardano-address
                         cardano-cli
@@ -315,11 +315,11 @@ in
                         mdbook
                         mdbook-kroki-preprocessor
                         localFlake.inputs.nixpkgs-unstable.legacyPackages.${system}.mimir
+                        opentofu
                         rain
                         sops
                         ssh-config-json
                         ssh-to-age
-                        terraform
                         wireguard-tools
                       ]);
                 };

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -246,10 +246,13 @@ in
                     gawk
                     gnugrep
                     gnused
-                    jq
+                    # Ensure we use jq 1.7 for rc != 0 on empty file or stream test
+                    # if the downstream repo is pinned to a nixpkgs <= 23.05
+                    localFlake.inputs.nixpkgs.legacyPackages.${system}.jq
                     just
                     moreutils
-                    nushellFull
+                    # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a non-existent pkg failure
+                    localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellFull
                     ripgrep
                     statix
                     xxd
@@ -370,7 +373,7 @@ in
             (pkgs.writeShellApplication
               {
                 name = "menu-${id}";
-                runtimeInputs = [pkgs.nushellFull];
+                runtimeInputs = [localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellFull];
 
                 text = let
                   minWidth =

--- a/perSystem/devShells/default.nix
+++ b/perSystem/devShells/default.nix
@@ -4,12 +4,17 @@
     config,
     ...
   }: {
-    cardano-parts.shell.global.defaultShell = "min";
-    cardano-parts.shell.global.enableVars = false;
-    cardano-parts.shell.min.extraPkgs = with pkgs; [
-      # For aws-ec2.json spec updates
-      awscli2
-      config.packages.inputs-check
-    ];
+    cardano-parts.shell = {
+      global = {
+        defaultShell = "min";
+        enableVars = false;
+      };
+
+      min.extraPkgs = with pkgs; [
+        # For aws-ec2.json spec updates
+        awscli2
+        config.packages.inputs-check
+      ];
+    };
   };
 }

--- a/perSystem/packages/terraform.nix
+++ b/perSystem/packages/terraform.nix
@@ -1,28 +1,73 @@
 {
-  perSystem = {
-    pkgs,
-    inputs',
-    ...
-  }: {
-    packages.terraform = let
-      inherit
-        (inputs'.terraform-providers.legacyPackages.providers)
-        fgouteroux
-        grafana
-        hashicorp
-        loafoe
-        ;
-    in
-      pkgs.terraform.withPlugins (_: [
-        fgouteroux.loki
-        fgouteroux.mimir
-        grafana.grafana
-        hashicorp.aws
-        hashicorp.external
-        hashicorp.local
-        hashicorp.null
-        hashicorp.tls
-        loafoe.ssh
-      ]);
-  };
+  inputs,
+  lib,
+  ...
+}: {
+  perSystem = {pkgs, ...}:
+    with builtins;
+    with lib;
+    with pkgs; {
+      packages.opentofu = let
+        mkTerraformProvider = {
+          owner,
+          repo,
+          version,
+          src,
+          registry ? "registry.opentofu.org",
+        }: let
+          inherit (go) GOARCH GOOS;
+          provider-source-address = "${registry}/${owner}/${repo}";
+        in
+          stdenv.mkDerivation {
+            pname = "terraform-provider-${repo}";
+            inherit version src;
+
+            unpackPhase = "unzip -o $src";
+
+            nativeBuildInputs = [unzip];
+
+            buildPhase = ":";
+
+            # The upstream terraform wrapper assumes the provider filename here.
+            installPhase = ''
+              dir=$out/libexec/terraform-providers/${provider-source-address}/${version}/${GOOS}_${GOARCH}
+              mkdir -p "$dir"
+              mv terraform-* "$dir/"
+            '';
+
+            passthru = {
+              inherit provider-source-address;
+            };
+          };
+
+        readJSON = f: fromJSON (readFile f);
+
+        # Fetch the latest version
+        providerFor = owner: repo: let
+          json = readJSON (inputs.opentofu-registry + "/providers/${substring 0 1 owner}/${owner}/${repo}.json");
+          latest = head json.versions;
+          matching = filter (e: e.os == "linux" && e.arch == "amd64") latest.targets;
+          target = head matching;
+        in
+          mkTerraformProvider {
+            inherit (latest) version;
+            inherit owner repo;
+            src = fetchurl {
+              url = target.download_url;
+              sha256 = target.shasum;
+            };
+          };
+      in
+        opentofu.withPlugins (_: [
+          (providerFor "fgouteroux" "loki")
+          (providerFor "fgouteroux" "mimir")
+          (providerFor "grafana" "grafana")
+          (providerFor "opentofu" "aws")
+          (providerFor "opentofu" "local")
+          (providerFor "opentofu" "external")
+          (providerFor "opentofu" "null")
+          (providerFor "opentofu" "tls")
+          (providerFor "loafoe" "ssh")
+        ]);
+    };
 }

--- a/templates/cardano-parts-project/flake.nix
+++ b/templates/cardano-parts-project/flake.nix
@@ -2,9 +2,9 @@
   description = "Cardano New Parts Project";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-23.05";
-    nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    flake-parts.url = "github:hercules-ci/flake-parts";
+    nixpkgs.follows = "cardano-parts/nixpkgs";
+    nixpkgs-unstable.follows = "cardano-parts/nixpkgs-unstable";
+    flake-parts.follows = "cardano-parts/flake-parts";
     cardano-parts.url = "github:input-output-hk/cardano-parts";
   };
 
@@ -35,6 +35,6 @@
   nixConfig = {
     extra-substituters = ["https://cache.iog.io"];
     extra-trusted-public-keys = ["hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ="];
-    allow-import-from-derivation = "true";
+    allow-import-from-derivation = true;
   };
 }

--- a/templates/cardano-parts-project/flake/terraform/cluster.nix
+++ b/templates/cardano-parts-project/flake/terraform/cluster.nix
@@ -89,10 +89,10 @@ in {
       {
         terraform = {
           required_providers = {
-            aws.source = "hashicorp/aws";
-            null.source = "hashicorp/null";
-            local.source = "hashicorp/local";
-            tls.source = "hashicorp/tls";
+            aws.source = "opentofu/aws";
+            null.source = "opentofu/null";
+            local.source = "opentofu/local";
+            tls.source = "opentofu/tls";
           };
 
           backend = {

--- a/templates/cardano-parts-project/flake/terraform/cluster.nix
+++ b/templates/cardano-parts-project/flake/terraform/cluster.nix
@@ -111,11 +111,11 @@ in {
         });
 
         # Common parameters:
-        #   data.aws_caller_identity.current.account_id
-        #   data.aws_region.current.name
-        data.aws_caller_identity.current = {};
-        data.aws_region.current = {};
-        data.aws_route53_zone.selected.name = "${cluster.domain}.";
+        data = {
+          aws_caller_identity.current = {};
+          aws_region.current = {};
+          aws_route53_zone.selected.name = "${cluster.domain}.";
+        };
 
         resource = {
           aws_instance = mapNodes (


### PR DESCRIPTION
# Overview
Bumps nixpkgs to 23.11 release and nix to 2.19.3, adding required module config changes, lint updates and tofu utilization.

# Details
* Bumps nixpkgs -> 23.11,
* Bumps nixpkgs-unstable -> HEAD
* Bumps nix -> 2.19.3
* Adds required nixpkgs 23.11 chronyd and postgres DB module option changes
* Adds localFlake pinning for jq and nushellFull pkgs for the case the downstream repo is using nixpkgs <= 23.05
* Adds a nixosConfiguration warning if cardano-parts nixpkgs version differs from downstream repo nixpkgs version
* Refactors nixosModule code for updated nixpkgs 23.11 nix linter pkg requirements
* Updates the template flake to default to following cardano-parts for nixpkgs, nixpkgs-unstable and flake-parts pins
* Migrates from terraform to opentofu to maintain open source license usage
  * The prior `just tf` and `just terraform` recipes remain as aliases to `just tofu`
  * The `terraform` binary no longer exists in the devShell and has been replaced by `tofu` binary