### PR TITLE
Improve ssh key handling

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,40 +16,21 @@
         "type": "github"
       }
     },
-    "ameba-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1679041484,
-        "narHash": "sha256-pc9mtVR/PBhM5l1PnDkm+y+McxbrfAmQzxmLi761VF4=",
-        "owner": "crystal-ameba",
-        "repo": "ameba",
-        "rev": "7c74d196d6d9a496a81a0c7b79ef44f39faf41b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crystal-ameba",
-        "ref": "v1.4.3",
-        "repo": "ameba",
-        "type": "github"
-      }
-    },
     "auth-keys-hub": {
       "inputs": {
-        "crystal": "crystal",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts",
         "inclusive": "inclusive",
         "nixpkgs": [
           "nixpkgs"
         ],
-        "statix": "statix",
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1691483346,
-        "narHash": "sha256-wvn84eGcc+PMbq/qSCWcZ/kV7/bjwuGOVSn/9rGaaKw=",
+        "lastModified": 1702655420,
+        "narHash": "sha256-w1gxNRrzMsHIAb73ofjrYlVv/4sR+SF3Q/NA+nXCDOc=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "ab7c79f49886b8f24cfae4b967a59ea62af9156e",
+        "rev": "8a7cb195490f0a0219fafdcbe5bb9fb828be166a",
         "type": "github"
       },
       "original": {
@@ -87,23 +68,6 @@
       "original": {
         "owner": "bats-core",
         "repo": "bats-support",
-        "type": "github"
-      }
-    },
-    "bdwgc-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1661523039,
-        "narHash": "sha256-UYJQGeSykmfydGAmTlNJNyAPBasBkddOSoopBHiY7TI=",
-        "owner": "ivmai",
-        "repo": "bdwgc",
-        "rev": "cd1fbc1dbfd2cc888436944dd2784f39820698d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "ivmai",
-        "ref": "v8.2.2",
-        "repo": "bdwgc",
         "type": "github"
       }
     },
@@ -349,102 +313,6 @@
         "type": "github"
       }
     },
-    "crystal": {
-      "inputs": {
-        "ameba-src": "ameba-src",
-        "bdwgc-src": "bdwgc-src",
-        "crystal-aarch64-darwin": "crystal-aarch64-darwin",
-        "crystal-src": "crystal-src",
-        "crystal-x86_64-darwin": "crystal-x86_64-darwin",
-        "crystal-x86_64-linux": "crystal-x86_64-linux",
-        "crystalline-src": "crystalline-src",
-        "flake-parts": "flake-parts",
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1683429373,
-        "narHash": "sha256-Mx5lwMyk2T40wFqOoYcJLs4srwO2UrsepTZhlHNuTrI=",
-        "owner": "manveru",
-        "repo": "crystal-flake",
-        "rev": "e7a443c20e2be6e5dd870586705dd27c91aa9c5c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "manveru",
-        "repo": "crystal-flake",
-        "type": "github"
-      }
-    },
-    "crystal-aarch64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-NqYaZHM3kHAgYbO0RDJtA8eHqp4vVe4MBpisTOGrRVw=",
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      }
-    },
-    "crystal-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681995387,
-        "narHash": "sha256-t+1vM1m62UftCvfa90Dg6nqt6Zseh/GP/Gc1VfOa4+c=",
-        "owner": "crystal-lang",
-        "repo": "crystal",
-        "rev": "a59a3dbd738269d5aad6051c3834fc70f482f469",
-        "type": "github"
-      },
-      "original": {
-        "owner": "crystal-lang",
-        "ref": "1.8.1",
-        "repo": "crystal",
-        "type": "github"
-      }
-    },
-    "crystal-x86_64-darwin": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-NqYaZHM3kHAgYbO0RDJtA8eHqp4vVe4MBpisTOGrRVw=",
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-darwin-universal.tar.gz"
-      }
-    },
-    "crystal-x86_64-linux": {
-      "flake": false,
-      "locked": {
-        "narHash": "sha256-/Jk3uiglM/hzjygxmMUgVTvz+tuFFjBv8+uUIL05rXo=",
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-linux-x86_64.tar.gz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/crystal-lang/crystal/releases/download/1.8.1/crystal-1.8.1-1-linux-x86_64.tar.gz"
-      }
-    },
-    "crystalline-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1681549124,
-        "narHash": "sha256-kx3rdGqIbrOaHY7V3uXLqIFEYzzsMKzNwZ6Neq8zM3c=",
-        "owner": "elbywan",
-        "repo": "crystalline",
-        "rev": "4ac0ae282c5f4172230fea1e93df51c2b380f475",
-        "type": "github"
-      },
-      "original": {
-        "owner": "elbywan",
-        "ref": "v0.9.0",
-        "repo": "crystalline",
-        "type": "github"
-      }
-    },
     "empty-flake": {
       "locked": {
         "lastModified": 1630400035,
@@ -457,29 +325,6 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "empty-flake",
-        "type": "github"
-      }
-    },
-    "fenix": {
-      "inputs": {
-        "nixpkgs": [
-          "auth-keys-hub",
-          "statix",
-          "nixpkgs"
-        ],
-        "rust-analyzer-src": "rust-analyzer-src"
-      },
-      "locked": {
-        "lastModified": 1645251813,
-        "narHash": "sha256-cQ66tGjnZclBCS3nD26mZ5fUH+3/HnysGffBiWXUSHk=",
-        "owner": "nix-community",
-        "repo": "fenix",
-        "rev": "9892337b588c38ec59466a1c89befce464aae7f8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "fenix",
         "type": "github"
       }
     },
@@ -537,24 +382,6 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
-        "lastModified": 1672152762,
-        "narHash": "sha256-U8iWWHgabN07zfbgedogMVWrEP1Zywyf3Yx3OYHSSgE=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "19e0f88324d90509141e192664ded98bb88ef9b2",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_2": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_2"
-      },
-      "locked": {
         "lastModified": 1682984683,
         "narHash": "sha256-fSMthG+tp60AHhNmaHc4StT3ltfHkQsJtN8GhfLWmtI=",
         "owner": "hercules-ci",
@@ -568,9 +395,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_2": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
         "lastModified": 1701473968,
@@ -586,9 +413,9 @@
         "type": "github"
       }
     },
-    "flake-parts_4": {
+    "flake-parts_3": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
         "lastModified": 1690933134,
@@ -822,8 +649,8 @@
     },
     "inputs-check": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_5"
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1692633913,
@@ -842,7 +669,7 @@
     "iohk-nix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_4",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -863,7 +690,7 @@
     "iohk-nix-ng": {
       "inputs": {
         "blst": "blst_2",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_5",
         "secp256k1": "secp256k1_2",
         "sodium": "sodium_2"
       },
@@ -933,7 +760,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -955,7 +782,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -975,16 +802,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1677543769,
-        "narHash": "sha256-LwbqS8vGisXl2WHpK9r5+kodr0zoIT8F2YB0R4y1TsA=",
-        "owner": "NixOS",
+        "lastModified": 1680945546,
+        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b26d52c9feb6476580016e78935cbf96eb3e2115",
+        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "owner": "nixos",
+        "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1088,24 +915,6 @@
     "nixpkgs-lib": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1671359686,
-        "narHash": "sha256-3MpC6yZo+Xn9cPordGz2/ii6IJpP2n8LE8e/ebUXLrs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "04f574a1c0fde90b51bf68198e2297ca4e7cccf4",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_2": {
-      "locked": {
-        "dir": "lib",
         "lastModified": 1682879489,
         "narHash": "sha256-sASwo8gBt7JDnOOstnps90K1wxmVfyhsTPPNTGBPjjg=",
         "owner": "NixOS",
@@ -1121,7 +930,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
         "lastModified": 1701253981,
@@ -1139,7 +948,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_4": {
+    "nixpkgs-lib_3": {
       "locked": {
         "dir": "lib",
         "lastModified": 1690881714,
@@ -1237,70 +1046,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1690026219,
-        "narHash": "sha256-oOduRk/kzQxOBknZXTLSEYd7tk+GoKvr8wV6Ab+t4AU=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f465da166263bc0d4b39dfd4ca28b777c92d4b73",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_11": {
-      "locked": {
-        "lastModified": 1636823747,
-        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1645013224,
-        "narHash": "sha256-b7OEC8vwzJv3rsz9pwnTX2LQDkeOWz2DbKypkVvNHXc=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "b66b39216b1fef2d8c33cc7a5c72d8da80b79970",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
-      "locked": {
-        "lastModified": 1680945546,
-        "narHash": "sha256-8FuaH5t/aVi/pR1XxnF0qi4WwMYC+YxlfdsA0V+TEuQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "d9f759f2ea8d265d974a6e1259bd510ac5844c5d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -1316,7 +1062,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1692339729,
         "narHash": "sha256-TUK76/Pqm9qIDjEGd27Lz9EiBIvn5F70JWDmEQ4Y5DQ=",
@@ -1332,39 +1078,39 @@
         "type": "github"
       }
     },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_5": {
+      "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_6": {
-      "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_8": {
       "locked": {
         "lastModified": 1700748986,
         "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
@@ -1380,7 +1126,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1701539137,
         "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
@@ -1392,6 +1138,37 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_8": {
+      "locked": {
+        "lastModified": 1690026219,
+        "narHash": "sha256-oOduRk/kzQxOBknZXTLSEYd7tk+GoKvr8wV6Ab+t4AU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f465da166263bc0d4b39dfd4ca28b777c92d4b73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1636823747,
+        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1456,36 +1233,19 @@
         "cardano-wallet-service": "cardano-wallet-service",
         "colmena": "colmena",
         "empty-flake": "empty-flake",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_2",
         "haskell-nix": "haskell-nix",
         "inputs-check": "inputs-check",
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix_2",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
         "sops-nix": "sops-nix",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix_2"
-      }
-    },
-    "rust-analyzer-src": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645205556,
-        "narHash": "sha256-e4lZW3qRyOEJ+vLKFQP7m2Dxh5P44NrnekZYLxlucww=",
-        "owner": "rust-analyzer",
-        "repo": "rust-analyzer",
-        "rev": "acf5874b39f3dc5262317a6074d9fc7285081161",
-        "type": "github"
-      },
-      "original": {
-        "owner": "rust-analyzer",
-        "ref": "nightly",
-        "repo": "rust-analyzer",
-        "type": "github"
       }
     },
     "secp256k1": {
@@ -1558,7 +1318,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -1591,25 +1351,6 @@
         "type": "github"
       }
     },
-    "statix": {
-      "inputs": {
-        "fenix": "fenix",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1676888642,
-        "narHash": "sha256-C73LOMVVCkeL0jA5xN7klLEDEB4NkuiATEJY4A/tIyM=",
-        "owner": "nerdypepper",
-        "repo": "statix",
-        "rev": "3c7136a23f444db252a556928c1489869ca3ab4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nerdypepper",
-        "repo": "statix",
-        "type": "github"
-      }
-    },
     "stdlib": {
       "locked": {
         "lastModified": 1590026685,
@@ -1630,7 +1371,7 @@
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_11",
+        "nixpkgs": "nixpkgs_9",
         "terranix-examples": "terranix-examples"
       },
       "locked": {
@@ -1664,7 +1405,7 @@
     },
     "treefmt-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs"
       },
       "locked": {
         "lastModified": 1683117219,

--- a/flake.lock
+++ b/flake.lock
@@ -1000,11 +1000,11 @@
     },
     "nixpkgs-stable": {
       "locked": {
-        "lastModified": 1690066826,
-        "narHash": "sha256-6L2qb+Zc0BFkh72OS9uuX637gniOjzU6qCDBpjB2LGY=",
+        "lastModified": 1702777222,
+        "narHash": "sha256-/SYmqgxTYzqZnQEfbOCHCN4GzqB9uAIsR9IWLzo0/8I=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ce45b591975d070044ca24e3003c830d26fea1c8",
+        "rev": "a19a71d1ee93226fd71984359552affbc1cd3dc3",
         "type": "github"
       },
       "original": {
@@ -1144,11 +1144,11 @@
     },
     "nixpkgs_8": {
       "locked": {
-        "lastModified": 1690026219,
-        "narHash": "sha256-oOduRk/kzQxOBknZXTLSEYd7tk+GoKvr8wV6Ab+t4AU=",
+        "lastModified": 1702539185,
+        "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "f465da166263bc0d4b39dfd4ca28b777c92d4b73",
+        "rev": "aa9d4729cbc99dabacb50e3994dcefb3ea0f7447",
         "type": "github"
       },
       "original": {
@@ -1322,11 +1322,11 @@
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
-        "lastModified": 1690199016,
-        "narHash": "sha256-yTLL72q6aqGmzHq+C3rDp3rIjno7EJZkFLof6Ika7cE=",
+        "lastModified": 1702812162,
+        "narHash": "sha256-18cKptpAAfkatdQgjO5SZXZsbc1IVPRoYx2AxaiooL4=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c36df4fe4bf4bb87759b1891cab21e7a05219500",
+        "rev": "21f2b8f123a1601fef3cf6bbbdf5171257290a77",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -176,13 +176,13 @@
       "locked": {
         "lastModified": 1688568916,
         "narHash": "sha256-XTGTi3PzCcbLL+63JSXTe7mQmGKB0YgEoW1VpqdX2d0=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "6e69a80797f2d68423b25ca7787e81533b367e42",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "13.1.1.3",
         "repo": "cardano-db-sync",
         "type": "github"
@@ -193,13 +193,13 @@
       "locked": {
         "lastModified": 1701131841,
         "narHash": "sha256-mDKE/HqNvDxQ/mQU9j/jthw0NMcTiKHmgswzp0ZHdzM=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "0edff13a734a0ae02a6d7a99d0f77d27413f3421",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "sancho-2-3-0",
         "repo": "cardano-db-sync",
         "type": "github"
@@ -210,13 +210,13 @@
       "locked": {
         "lastModified": 1688568916,
         "narHash": "sha256-XTGTi3PzCcbLL+63JSXTe7mQmGKB0YgEoW1VpqdX2d0=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
         "rev": "6e69a80797f2d68423b25ca7787e81533b367e42",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "13.1.1.3",
         "repo": "cardano-db-sync",
         "type": "github"
@@ -244,13 +244,13 @@
       "locked": {
         "lastModified": 1700615474,
         "narHash": "sha256-pVUWfzVnM4RvpFlJNH2ZmWPZzmkGT1Ty8B1p7NFh69M=",
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
         "rev": "34d89af65439db92293b88967c299c20692abc1c",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
         "ref": "8.7.0-pre",
         "repo": "cardano-node",
         "type": "github"

--- a/flake.lock
+++ b/flake.lock
@@ -26,15 +26,16 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1702655420,
-        "narHash": "sha256-w1gxNRrzMsHIAb73ofjrYlVv/4sR+SF3Q/NA+nXCDOc=",
+        "lastModified": 1702939833,
+        "narHash": "sha256-1ay7Lo2tKRyV/DV8lsSraZvyCurr19FJtqaAkwGZ5zc=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "8a7cb195490f0a0219fafdcbe5bb9fb828be166a",
+        "rev": "2bc614b16d3bfd782563cb05c0e8331d0ebcb1a9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "more-assertions",
         "repo": "auth-keys-hub",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -26,16 +26,15 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1702939833,
-        "narHash": "sha256-1ay7Lo2tKRyV/DV8lsSraZvyCurr19FJtqaAkwGZ5zc=",
+        "lastModified": 1703018934,
+        "narHash": "sha256-7h6XsWczUzsxID0H5QX0+bJks22pijAxnSJ2RYTyswQ=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "2bc614b16d3bfd782563cb05c0e8331d0ebcb1a9",
+        "rev": "31f8d4e404bf64d559516abfd6610bb7f4cabee2",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "more-assertions",
         "repo": "auth-keys-hub",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Cardano Parts: nix flake parts for cardano clusters";
 
   inputs = {
-    auth-keys-hub.url = "github:input-output-hk/auth-keys-hub";
+    auth-keys-hub.url = "github:input-output-hk/auth-keys-hub/more-assertions";
     auth-keys-hub.inputs.nixpkgs.follows = "nixpkgs";
     colmena.inputs.nixpkgs.follows = "nixpkgs";
     colmena.url = "github:zhaofengli/colmena/v0.4.0";

--- a/flake.nix
+++ b/flake.nix
@@ -32,22 +32,22 @@
     # Services offered from the nixosModules of this repo are directly assigned to
     # the flake.cardano-parts.pkgs.special.*-service flakeModule options.
     cardano-db-sync-service = {
-      url = "github:input-output-hk/cardano-db-sync/13.1.1.3";
+      url = "github:IntersectMBO/cardano-db-sync/13.1.1.3";
       flake = false;
     };
 
     cardano-db-sync-schema = {
-      url = "github:input-output-hk/cardano-db-sync/13.1.1.3";
+      url = "github:IntersectMBO/cardano-db-sync/13.1.1.3";
       flake = false;
     };
 
     cardano-db-sync-schema-ng = {
-      url = "github:input-output-hk/cardano-db-sync/sancho-2-3-0";
+      url = "github:IntersectMBO/cardano-db-sync/sancho-2-3-0";
       flake = false;
     };
 
     cardano-node-service = {
-      url = "github:input-output-hk/cardano-node/8.7.0-pre";
+      url = "github:IntersectMBO/cardano-node/8.7.0-pre";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Cardano Parts: nix flake parts for cardano clusters";
 
   inputs = {
-    auth-keys-hub.url = "github:input-output-hk/auth-keys-hub/more-assertions";
+    auth-keys-hub.url = "github:input-output-hk/auth-keys-hub";
     auth-keys-hub.inputs.nixpkgs.follows = "nixpkgs";
     colmena.inputs.nixpkgs.follows = "nixpkgs";
     colmena.url = "github:zhaofengli/colmena/v0.4.0";

--- a/flake/nixosModules/profile-cardano-db-sync.nix
+++ b/flake/nixosModules/profile-cardano-db-sync.nix
@@ -33,7 +33,7 @@
       perNodeCfg = nixos.config.cardano-parts.perNode;
 
       # Required since db-sync still requires legacy byron application parameters as of 13.1.1.3.
-      # Issue: https://github.com/input-output-hk/cardano-db-sync/issues/1473
+      # Issue: https://github.com/IntersectMBO/cardano-db-sync/issues/1473
       #
       # environmentConfig = environments.${environmentName}.nodeConfig;
       environmentConfig = let

--- a/flake/nixosModules/profile-cardano-faucet.nix
+++ b/flake/nixosModules/profile-cardano-faucet.nix
@@ -37,18 +37,13 @@ flake: {
       nginx-vhost-exporter.enable = true;
     };
 
-    systemd.services.cardano-faucet = {
-      after = ["sops-secrets.service"];
-      wants = ["sops-secrets.service"];
-      partOf = ["sops-secrets.service"];
-    };
-
     sops.secrets = mkSopsSecret {
       secretName = "cardano-faucet.json";
       keyName = "${name}-faucet.json";
       inherit groupOutPath groupName;
       fileOwner = "cardano-faucet";
       fileGroup = "cardano-faucet";
+      restartUnits = ["cardano-faucet.service"];
     };
   };
 }

--- a/flake/nixosModules/profile-cardano-metadata.nix
+++ b/flake/nixosModules/profile-cardano-metadata.nix
@@ -241,12 +241,6 @@ flake: {
             LimitNOFILE = 65535;
             LogNamespace = "nginx";
           };
-
-          metadata-webhook = {
-            after = ["sops-secrets.service"];
-            wants = ["sops-secrets.service"];
-            partOf = ["sops-secrets.service"];
-          };
         };
 
         services = {
@@ -547,6 +541,7 @@ flake: {
           inherit groupOutPath groupName;
           fileOwner = "metadata-webhook";
           fileGroup = "metadata-webhook";
+          restartUnits = ["metadata-webhook.service"];
         };
       };
     };

--- a/flake/nixosModules/profile-cardano-postgres.nix
+++ b/flake/nixosModules/profile-cardano-postgres.nix
@@ -79,7 +79,7 @@
 
         -- Prepared statements should only be executed if the schema has already migrated
         -- This can be verified by checking stage_three of schema_version is non-zero
-        -- Ref: https://github.com/input-output-hk/cardano-db-sync/blob/master/doc/schema.md#schema_version
+        -- Ref: https://github.com/IntersectMBO/cardano-db-sync/blob/master/doc/schema.md#schema_version
         DO $$
         BEGIN
           IF (select true from pg_tables where tablename = 'schema_version') THEN

--- a/flake/nixosModules/profile-common.nix
+++ b/flake/nixosModules/profile-common.nix
@@ -59,8 +59,17 @@
 
       programs = {
         auth-keys-hub = {
-          enable = lib.mkDefault true;
+          enable = mkDefault true;
           package = inputs.auth-keys-hub.packages.${system}.auth-keys-hub;
+
+          # Avoid loss of access edge cases associated with use of ephemeral authorized_keys storage
+          # Edge case example:
+          #   * Both auth-keys-hub state and github token default to the /run ephemeral state dir or subdirs for default secrets storage
+          #   * Only a github team is declared for auth-keys-hub access
+          #   * The machine is rebooted
+          #   * Auth keys hub state is now gone and a github token is required to pull new authorized key state, but that's gone too
+          #   * Machine lockout occurs
+          dataDir = "/var/lib/auth-keys-hub";
         };
       };
 

--- a/flake/nixosModules/profile-common.nix
+++ b/flake/nixosModules/profile-common.nix
@@ -101,8 +101,18 @@
             };
           };
 
-          # Sops-secrets service provides a systemd hook for other services
-          # needing to be restarted after new secrets are pushed.
+          # On boot SOPS runs in stage 2 without networking.
+          # For repositories using KMS sops secrets, this prevent KMS from working,
+          # so we repeat the activation script until decryption succeeds.
+          #
+          # Sops-nix module does provide a systemd restart and reload hook for
+          # associated secrets changes with the option:
+          #
+          #   sops.secrets.<name>.<restartUnits|reloadUnits>
+          #
+          # Although the sops-nix restart or reload options are preferred,
+          # sops-secrets service can also act as a generic systemd hook
+          # for services needing to be restarted after new sops secrets are pushed.
           #
           # Example usage:
           #   systemd.services.<name> = {
@@ -111,9 +121,6 @@
           #     partOf = ["sops-secrets.service"];
           #   };
           #
-          # Also, on boot SOPS runs in stage 2 without networking.
-          # For repositories using KMS sops secrets, this prevent KMS from working,
-          # so we repeat the activation script until decryption succeeds.
           sops-secrets = {
             wantedBy = ["multi-user.target"];
             after = ["network-online.target"];

--- a/flake/nixosModules/profile-common.nix
+++ b/flake/nixosModules/profile-common.nix
@@ -30,33 +30,6 @@
         inputs.auth-keys-hub.nixosModules.auth-keys-hub
       ];
 
-      # Sops-secrets service provides a systemd hook for other services
-      # needing to be restarted after new secrets are pushed.
-      #
-      # Example usage:
-      #   systemd.services.<name> = {
-      #     after = ["sops-secrets.service"];
-      #     wants = ["sops-secrets.service"];
-      #     partOf = ["sops-secrets.service"];
-      #   };
-      #
-      # Also, on boot SOPS runs in stage 2 without networking.
-      # For repositories using KMS sops secrets, this prevent KMS from working,
-      # so we repeat the activation script until decryption succeeds.
-      systemd.services.sops-secrets = {
-        wantedBy = ["multi-user.target"];
-        after = ["network-online.target"];
-
-        script = config.system.activationScripts.setupSecrets.text or "true";
-
-        serviceConfig = {
-          Type = "oneshot";
-          RemainAfterExit = true;
-          Restart = "on-failure";
-          RestartSec = "2s";
-        };
-      };
-
       programs = {
         auth-keys-hub = {
           enable = mkDefault true;
@@ -73,48 +46,91 @@
         };
       };
 
-      # Remove the bootstrap key after 1 week in favor of auth-keys-hub use
-      systemd.services = {
-        remove-ssh-bootstrap-key = {
-          wantedBy = ["multi-user.target"];
-          after = ["network-online.target"];
+      # Collect some system metrics locally at higher resolution than the default exported metrics which is typically a rate of 1 sample/min
+      services.sysstat = {
+        enable = true;
 
-          serviceConfig = {
-            Type = "oneshot";
+        # Also include disk statistics by partition and filesystem not collected by default
+        collect-args = "1 1 -S XDISK";
 
-            ExecStart = getExe (writeShellApplication {
-              name = "remove-ssh-bootstrap-key";
-              runtimeInputs = [fd gnugrep gnused];
-              text = ''
-                if ! [ -f /root/.ssh/.bootstrap-key-removed ]; then
-                  # Verify auth keys is properly hooked into sshd
-                  if ! grep -q 'AuthorizedKeysCommand /etc/ssh/auth-keys-hub --user %u' /etc/ssh/sshd_config; then
-                    echo "SSH daemon authorized keys command does not appear to have auth-keys-hub installed"
-                    exit
+        # Collect every 10 seconds, with accuracy enforced in the systemd timer
+        collect-frequency = "*:*:00/10";
+      };
+
+      systemd = {
+        services = {
+          # Remove the bootstrap key after 1 week in favor of auth-keys-hub use
+          remove-ssh-bootstrap-key = {
+            wantedBy = ["multi-user.target"];
+            after = ["network-online.target"];
+
+            serviceConfig = {
+              Type = "oneshot";
+
+              ExecStart = getExe (writeShellApplication {
+                name = "remove-ssh-bootstrap-key";
+                runtimeInputs = [fd gnugrep gnused];
+                text = ''
+                  if ! [ -f /root/.ssh/.bootstrap-key-removed ]; then
+                    # Verify auth keys is properly hooked into sshd
+                    if ! grep -q 'AuthorizedKeysCommand /etc/ssh/auth-keys-hub --user %u' /etc/ssh/sshd_config; then
+                      echo "SSH daemon authorized keys command does not appear to have auth-keys-hub installed"
+                      exit
+                    fi
+
+                    if ! grep -q 'AuthorizedKeysCommandUser ${config.programs.auth-keys-hub.user}' /etc/ssh/sshd_config; then
+                      echo "SSH daemon authorized keys command user does not appear to be using the ${config.programs.auth-keys-hub.user} user"
+                      exit
+                    fi
+
+                    # Allow 1 week of bootstrap key use before removing it
+                    if fd --quiet --changed-within 7d authorized_keys /root/.ssh; then
+                      echo "The root authorized_keys file has been changed within the past week; waiting a little longer before removing the bootstrap key"
+                      exit
+                    fi
+
+                    # Remove the bootstrap key and set a marker
+                    echo "Removing the bootstrap key from /root/.ssh/authorized_keys"
+                    sed -i '/bootstrap/d' /root/.ssh/authorized_keys
+                    touch /root/.ssh/.bootstrap-key-removed
                   fi
+                '';
+              });
 
-                  if ! grep -q 'AuthorizedKeysCommandUser ${config.programs.auth-keys-hub.user}' /etc/ssh/sshd_config; then
-                    echo "SSH daemon authorized keys command user does not appear to be using the ${config.programs.auth-keys-hub.user} user"
-                    exit
-                  fi
+              RemainAfterExit = true;
+            };
+          };
 
-                  # Allow 1 week of bootstrap key use before removing it
-                  if fd --quiet --changed-within 7d authorized_keys /root/.ssh; then
-                    echo "The root authorized_keys file has been changed within the past week; waiting a little longer before removing the bootstrap key"
-                    exit
-                  fi
+          # Sops-secrets service provides a systemd hook for other services
+          # needing to be restarted after new secrets are pushed.
+          #
+          # Example usage:
+          #   systemd.services.<name> = {
+          #     after = ["sops-secrets.service"];
+          #     wants = ["sops-secrets.service"];
+          #     partOf = ["sops-secrets.service"];
+          #   };
+          #
+          # Also, on boot SOPS runs in stage 2 without networking.
+          # For repositories using KMS sops secrets, this prevent KMS from working,
+          # so we repeat the activation script until decryption succeeds.
+          sops-secrets = {
+            wantedBy = ["multi-user.target"];
+            after = ["network-online.target"];
 
-                  # Remove the bootstrap key and set a marker
-                  echo "Removing the bootstrap key from /root/.ssh/authorized_keys"
-                  sed -i '/bootstrap/d' /root/.ssh/authorized_keys
-                  touch /root/.ssh/.bootstrap-key-removed
-                fi
-              '';
-            });
+            script = config.system.activationScripts.setupSecrets.text or "true";
 
-            RemainAfterExit = true;
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              Restart = "on-failure";
+              RestartSec = "2s";
+            };
           };
         };
+
+        # Enforce accurate 10 second sysstat sampling intervals
+        timers.sysstat-collect.timerConfig.AccuracySec = "1us";
       };
 
       sops.defaultSopsFormat = "binary";

--- a/flake/nixosModules/profile-grafana-agent.nix
+++ b/flake/nixosModules/profile-grafana-agent.nix
@@ -33,6 +33,7 @@ flake: {
         fileOwner = "grafana-agent";
         fileGroup = "grafana-agent";
         pathPrefix = "${groupOutPath}/secrets/monitoring/";
+        restartUnits = ["grafana-agent.service"];
       };
 
       cfgSvc = config.services;
@@ -80,10 +81,6 @@ flake: {
 
       config = {
         systemd.services.grafana-agent = {
-          after = ["sops-secrets.service"];
-          wants = ["sops-secrets.service"];
-          partOf = ["sops-secrets.service"];
-
           # A non-dynamic user is required for collecting systemd metrics, else the collector errors with:
           # "/run/dbus/system_bus_socket: recvmsg: connection reset by peer"
           serviceConfig = {

--- a/flakeModules/lib/ops.nix
+++ b/flakeModules/lib/ops.nix
@@ -49,15 +49,20 @@ with lib; rec {
     fileOwner,
     fileGroup,
     pathPrefix ? "${groupOutPath}/secrets/groups/${groupName}/deploy/",
+    restartUnits ? [],
+    reloadUnits ? [],
+    extraCfg ? {},
   }: let
     trimStorePrefix = path: last (split "/nix/store/[^/]+/" path);
     verboseTrace = keyName: traceVerbose ("${name}: using " + (trimStorePrefix keyName));
   in {
-    ${secretName} = verboseTrace (pathPrefix + keyName) {
-      owner = fileOwner;
-      group = fileGroup;
-      sopsFile = pathPrefix + keyName;
-    };
+    ${secretName} = verboseTrace (pathPrefix + keyName) ({
+        inherit restartUnits reloadUnits;
+        owner = fileOwner;
+        group = fileGroup;
+        sopsFile = pathPrefix + keyName;
+      }
+      // extraCfg);
   };
 
   removeByPath = pathList:

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -610,6 +610,6 @@ tofu *ARGS:
   rm --force terraform.tf.json
   nix build ".#terraform.$WORKSPACE" --out-link terraform.tf.json
 
-  tofu workspace select -or-create "$WORKSPACE"
   tofu init -reconfigure
+  tofu workspace select -or-create "$WORKSPACE"
   tofu ${ARGS[@]} ${VAR_FILE:+-var-file=<("${SOPS[@]}" "$VAR_FILE")}

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -5,134 +5,139 @@
   ...
 }: let
   inherit (config.flake) nixosModules nixosConfigurations;
-in {
-  flake.colmena = let
-    # Region defs:
-    eu-central-1.aws.region = "eu-central-1";
-    eu-west-1.aws.region = "eu-west-1";
-    us-east-2.aws.region = "us-east-2";
+in
+  with builtins;
+  with lib; {
+    flake.colmena = let
+      # Region defs:
+      eu-central-1.aws.region = "eu-central-1";
+      eu-west-1.aws.region = "eu-west-1";
+      us-east-2.aws.region = "us-east-2";
 
-    # Instance defs:
-    t3a-small.aws.instance.instance_type = "t3a.small";
-    t3a-medium.aws.instance.instance_type = "t3a.medium";
-    m5a-large.aws.instance.instance_type = "m5a.large";
+      # Instance defs:
+      t3a-small.aws.instance.instance_type = "t3a.small";
+      t3a-medium.aws.instance.instance_type = "t3a.medium";
+      m5a-large.aws.instance.instance_type = "m5a.large";
 
-    # Helper fns:
-    ebs = size: {aws.instance.root_block_device.volume_size = lib.mkDefault size;};
+      # Helper fns:
+      ebs = size: {aws.instance.root_block_device.volume_size = mkDefault size;};
+      # ebsIops = iops: {aws.instance.root_block_device.iops = mkDefault iops;};
+      # ebsTp = tp: {aws.instance.root_block_device.throughput = mkDefault tp;};
+      # ebsHighPerf = recursiveUpdate (ebsIops 10000) (ebsTp 1000);
 
-    # Helper defs:
-    # delete.aws.instance.count = 0;
+      # Helper defs:
+      # delete.aws.instance.count = 0;
 
-    # Cardano group assignments:
-    group = name: {
-      cardano-parts.cluster.group = config.flake.cardano-parts.cluster.groups.${name};
+      # Cardano group assignments:
+      group = name: {
+        cardano-parts.cluster.group = config.flake.cardano-parts.cluster.groups.${name};
 
-      # Since all machines are assigned a group, this is a good place to include default aws instance tags
-      aws.instance.tags = {
-        inherit (config.flake.cardano-parts.cluster.infra.generic) organization tribe function repo;
-        environment = config.flake.cardano-parts.cluster.groups.${name}.meta.environmentName;
-        group = name;
-      };
-    };
-
-    # Cardano-node modules for group deployment
-    node = {
-      imports = [
-        # Base cardano-node service
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
-
-        # Config for cardano-node group deployments
-        inputs.cardano-parts.nixosModules.profile-cardano-node-group
-      ];
-    };
-
-    # Profiles
-    pre = {imports = [inputs.cardano-parts.nixosModules.profile-pre-release];};
-
-    smash = {
-      imports = [
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-smash-service
-        inputs.cardano-parts.nixosModules.profile-cardano-smash
-        {services.cardano-smash.acmeEmail = "devops@iohk.io";}
-      ];
-    };
-
-    # Snapshots Profile: add this to a dbsync machine defn and deploy; remove once the snapshot is restored.
-    # Snapshots for mainnet can be found at: https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.1/
-    # snapshot = {services.cardano-db-sync.restoreSnapshot = "$SNAPSHOT_URL";};
-
-    # Topology profiles
-    # Note: not including a topology profile will default to edge topology if module profile-cardano-node-group is imported
-    topoBp = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-topology = {role = "bp";};}];};
-    topoRel = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-topology = {role = "relay";};}];};
-
-    # Roles
-    bp = {imports = [inputs.cardano-parts.nixosModules.role-block-producer topoBp];};
-    rel = {imports = [inputs.cardano-parts.nixosModules.role-relay topoRel];};
-
-    dbsync = {
-      imports = [
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
-        config.flake.cardano-parts.cluster.groups.default.meta.cardano-db-sync-service
-        inputs.cardano-parts.nixosModules.profile-cardano-db-sync
-        inputs.cardano-parts.nixosModules.profile-cardano-node-group
-        inputs.cardano-parts.nixosModules.profile-cardano-postgres
-      ];
-    };
-
-    faucet = {
-      imports = [
-        # TODO: Module import fixup for local services
-        # config.flake.cardano-parts.cluster.groups.default.meta.cardano-faucet-service
-        inputs.cardano-parts.nixosModules.service-cardano-faucet
-
-        inputs.cardano-parts.nixosModules.profile-cardano-faucet
-        {services.cardano-faucet.acmeEmail = "devops@iohk.io";}
-      ];
-    };
-  in {
-    meta = {
-      nixpkgs = import inputs.nixpkgs {
-        system = "x86_64-linux";
+        # Since all machines are assigned a group, this is a good place to include default aws instance tags
+        aws.instance.tags = {
+          inherit (config.flake.cardano-parts.cluster.infra.generic) organization tribe function repo;
+          environment = config.flake.cardano-parts.cluster.groups.${name}.meta.environmentName;
+          group = name;
+        };
       };
 
-      nodeSpecialArgs =
-        lib.foldl'
-        (acc: node: let
-          instanceType = node: nixosConfigurations.${node}.config.aws.instance.instance_type;
-        in
-          lib.recursiveUpdate acc {
-            ${node} = {
-              nodeResources = {
-                inherit
-                  (config.flake.cardano-parts.aws.ec2.spec.${instanceType node})
-                  provider
-                  coreCount
-                  cpuCount
-                  memMiB
-                  nodeType
-                  threadsPerCore
-                  ;
+      # Cardano-node modules for group deployment
+      node = {
+        imports = [
+          # Base cardano-node service
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
+
+          # Config for cardano-node group deployments
+          inputs.cardano-parts.nixosModules.profile-cardano-node-group
+        ];
+      };
+
+      # Profiles
+      pre = {imports = [inputs.cardano-parts.nixosModules.profile-pre-release];};
+
+      smash = {
+        imports = [
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-smash-service
+          inputs.cardano-parts.nixosModules.profile-cardano-smash
+          {services.cardano-smash.acmeEmail = "devops@iohk.io";}
+        ];
+      };
+
+      # Snapshots Profile: add this to a dbsync machine defn and deploy; remove once the snapshot is restored.
+      # Snapshots for mainnet can be found at: https://update-cardano-mainnet.iohk.io/cardano-db-sync/index.html#13.1/
+      # snapshot = {services.cardano-db-sync.restoreSnapshot = "$SNAPSHOT_URL";};
+
+      # Topology profiles
+      # Note: not including a topology profile will default to edge topology if module profile-cardano-node-group is imported
+      topoBp = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-topology = {role = "bp";};}];};
+      topoRel = {imports = [inputs.cardano-parts.nixosModules.profile-cardano-node-topology {services.cardano-topology = {role = "relay";};}];};
+
+      # Roles
+      bp = {imports = [inputs.cardano-parts.nixosModules.role-block-producer topoBp];};
+      rel = {imports = [inputs.cardano-parts.nixosModules.role-relay topoRel];};
+
+      dbsync = {
+        imports = [
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-node-service
+          config.flake.cardano-parts.cluster.groups.default.meta.cardano-db-sync-service
+          inputs.cardano-parts.nixosModules.profile-cardano-db-sync
+          inputs.cardano-parts.nixosModules.profile-cardano-node-group
+          inputs.cardano-parts.nixosModules.profile-cardano-postgres
+        ];
+      };
+
+      faucet = {
+        imports = [
+          # TODO: Module import fixup for local services
+          # config.flake.cardano-parts.cluster.groups.default.meta.cardano-faucet-service
+          inputs.cardano-parts.nixosModules.service-cardano-faucet
+
+          inputs.cardano-parts.nixosModules.profile-cardano-faucet
+          {services.cardano-faucet.acmeEmail = "devops@iohk.io";}
+        ];
+      };
+    in {
+      meta = {
+        nixpkgs = import inputs.nixpkgs {
+          system = "x86_64-linux";
+        };
+
+        nodeSpecialArgs =
+          foldl'
+          (acc: node: let
+            instanceType = node: nixosConfigurations.${node}.config.aws.instance.instance_type;
+          in
+            recursiveUpdate acc {
+              ${node} = {
+                nodeResources = {
+                  inherit
+                    (config.flake.cardano-parts.aws.ec2.spec.${instanceType node})
+                    provider
+                    coreCount
+                    cpuCount
+                    memMiB
+                    nodeType
+                    threadsPerCore
+                    ;
+                };
               };
-            };
-          })
-        {} (builtins.attrNames nixosConfigurations);
+            })
+          {} (attrNames nixosConfigurations);
+      };
+
+      defaults.imports = [
+        inputs.cardano-parts.nixosModules.module-aws-ec2
+        inputs.cardano-parts.nixosModules.module-cardano-parts
+        inputs.cardano-parts.nixosModules.profile-basic
+        inputs.cardano-parts.nixosModules.profile-common
+        inputs.cardano-parts.nixosModules.profile-grafana-agent
+        nixosModules.common
+      ];
+
+      preview1-bp-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "preview1") node bp];};
+      preview1-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "preview1") node rel];};
+      preview1-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "preview1") node rel];};
+      preview1-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "preview1") node rel];};
+      preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preview1") dbsync smash];};
+      preview1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node faucet pre];};
     };
-
-    defaults.imports = [
-      inputs.cardano-parts.nixosModules.module-aws-ec2
-      inputs.cardano-parts.nixosModules.module-cardano-parts
-      inputs.cardano-parts.nixosModules.profile-basic
-      inputs.cardano-parts.nixosModules.profile-common
-      inputs.cardano-parts.nixosModules.profile-grafana-agent
-      nixosModules.common
-    ];
-
-    preview1-bp-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "preview1") node bp];};
-    preview1-rel-a-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "preview1") node rel];};
-    preview1-rel-b-1 = {imports = [eu-west-1 t3a-small (ebs 40) (group "preview1") node rel];};
-    preview1-rel-c-1 = {imports = [us-east-2 t3a-small (ebs 40) (group "preview1") node rel];};
-    preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preview1") dbsync smash];};
-    preview1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node faucet pre];};
-  };
-}
+  }

--- a/templates/cardano-parts-project/flake/nixosModules/common.nix
+++ b/templates/cardano-parts-project/flake/nixosModules/common.nix
@@ -1,16 +1,40 @@
-# {self, ... }:
+# {self, ...}:
 {
   flake.nixosModules.common =
     # {config, ...}:
     {
       # Update auth-keys-hub config for your project's access requirements
       programs.auth-keys-hub.github = {
-        # teams = [
-        #   "input-output-hk/UPDATE_ME"
-        # ];
+        # teams = ["input-output-hk/UPDATE_ME"];
+
+        # Avoid loss of access edge cases when only github teams used for authorized key access
+        # Edge case example:
+        #   * Auth-keys-hub state defaults to the /run ephemeral state dir or subdirs
+        #   * Only a github team is declared for auth-keys-hub access, and assume the github token secret is non-ephemeral
+        #   * Another user deletes deletes the github token from github
+        #   * The machine is rebooted
+        #   * Auth keys hub state is now gone and the github token is required to pull new authorized key state, but it's no longer valid
+        #   * Machine lockout occurs
+        #
+        # NOTE: auth-keys-hub update is required to support individual users when team fetch fails due to invalid or missing github token
+        # users = ["UPDATE_ME"];
 
         # tokenFile = config.sops.secrets.github-token.path;
       };
+
+      # Protect against remaining loss of access edge cases and black swan events
+      # Edge case examples:
+      #   a) Auth keys hub is deployed as the sole source of authorized keys
+      #      * Auth keys hub is updated and a bug is introduced which expresses later on, causing machine lockout
+      #   b) Auth keys hub is deployed as the sole source of authorized keys
+      #      * Later, auth-keys-hub is removed from the deployment, but adding additional authorized_keys was forgotten
+      #      * Machine lockout occurs
+      #   c) Solar flare EMP knocking out a large number of machines over a large geographic area for some period of time
+      #      * Github api is not available to pull fresh authorized key state and the ephermal storage was lost during reboot
+      #      * Machine lockout occurs
+      # users.users.root.openssh.authorizedKeys.keys = [
+      #   "UPDATE_ME"
+      # ];
 
       # For auth-keys-hub team access, create an encrypted github token
       # with org:read access at: ./secrets/github-token.enc,

--- a/templates/cardano-parts-project/flake/terraform/cluster.nix
+++ b/templates/cardano-parts-project/flake/terraform/cluster.nix
@@ -141,7 +141,8 @@ in {
                 root_block_device = {
                   inherit (node.aws.instance.root_block_device) volume_size;
                   volume_type = "gp3";
-                  iops = 3000;
+                  iops = node.aws.instance.root_block_device.iops or 3000;
+                  throughput = node.aws.instance.root_block_device.throughput or 125;
                   delete_on_termination = true;
                   tags = {Name = name;} // node.aws.instance.tags or {};
                 };

--- a/templates/cardano-parts-project/flake/terraform/cluster.nix
+++ b/templates/cardano-parts-project/flake/terraform/cluster.nix
@@ -326,7 +326,6 @@ in {
                 User root
                 UserKnownHostsFile /dev/null
                 StrictHostKeyChecking no
-                IdentityFile .ssh_key
                 ServerAliveCountMax 2
                 ServerAliveInterval 60
 

--- a/templates/cardano-parts-project/flake/terraform/grafana/alerts/varnish.nix-import
+++ b/templates/cardano-parts-project/flake/terraform/grafana/alerts/varnish.nix-import
@@ -9,7 +9,8 @@
         description = "The Cache hit rate is {{ printf \"%.0f\" $value }} percent over the last 5 minutes on {{$labels.instance}}, which is below the threshold of 80 percent.";
         summary = "Cache is not answering a sufficient percentage of read requests.";
       };
-      expr = "increase(varnish_main_cache_hit[10m]) / (clamp_min((increase(varnish_main_cache_hit[10m]) + increase(varnish_main_cache_miss[10m])), 1)) * 100 < 80 and (increase(varnish_main_cache_hit[10m]) + increase(varnish_main_cache_miss[10m]) > 0)  and ((increase(varnish_main_cache_hit[10m]) + increase(varnish_main_cache_miss[10m])) > 100)\n";
+      # The webservers pipe all traffic through varnish and are subject to large amounts of spam requests making the cache rate intermittently low
+      expr = "increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) / (clamp_min((increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) + increase(varnish_main_cache_miss{instance!~\".*webserver.*\"}[10m])), 1)) * 100 < 80 and (increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) + increase(varnish_main_cache_miss{instance!~\".*webserver.*\"}[10m]) > 0)  and ((increase(varnish_main_cache_hit{instance!~\".*webserver.*\"}[10m]) + increase(varnish_main_cache_miss{instance!~\".*webserver.*\"}[10m])) > 100)\n";
       for = "10m";
       labels = {severity = "warning";};
     }

--- a/templates/cardano-parts-project/flake/terraform/grafana/dashboards/cardano-node-p2p.json
+++ b/templates/cardano-parts-project/flake/terraform/grafana/dashboards/cardano-node-p2p.json
@@ -108,7 +108,6 @@
           "expr": "cardano_node_metrics_connectionManager_duplexConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -199,7 +198,6 @@
           "expr": "cardano_node_metrics_peerSelection_hot{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -290,7 +288,6 @@
           "expr": "cardano_node_metrics_inboundGovernor_hot{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -381,7 +378,6 @@
           "expr": "cardano_node_metrics_connectionManager_unidirectionalConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -472,7 +468,6 @@
           "expr": "cardano_node_metrics_peerSelection_warm{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -563,7 +558,6 @@
           "expr": "cardano_node_metrics_inboundGovernor_warm{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -654,7 +648,6 @@
           "expr": "cardano_node_metrics_connectionManager_incomingConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -745,7 +738,6 @@
           "expr": "cardano_node_metrics_peerSelection_cold{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -836,7 +828,6 @@
           "expr": "rate(cardano_node_metrics_served_block_latest_count_int{environment=\"$environment\"}[1h])/rate(cardano_node_metrics_blockNum_int{environment=\"$environment\"}[1h])",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -927,7 +918,6 @@
           "expr": "cardano_node_metrics_connectionManager_outgoingConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1018,7 +1008,6 @@
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfOne{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1111,7 +1100,6 @@
           "expr": "avg(quantile_over_time(0.5,cardano_node_metrics_blockfetchclient_blockdelay_s{environment=\"$environment\"}[15m]))",
           "interval": "",
           "legendFormat": "P50",
-          "queryType": "randomWalk",
           "refId": "A"
         },
         {
@@ -1120,7 +1108,6 @@
           "hide": false,
           "interval": "",
           "legendFormat": "P95",
-          "queryType": "randomWalk",
           "refId": "B"
         }
       ],
@@ -1211,7 +1198,6 @@
           "expr": "cardano_node_metrics_connectionManager_prunableConns{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1302,7 +1288,6 @@
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfThree{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1393,7 +1378,6 @@
           "expr": "rate(cardano_node_metrics_blockfetchclient_lateblocks{environment=\"$environment\"}[1h])/rate(cardano_node_metrics_blockNum_int{environment=\"$environment\"}[1h])",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],
@@ -1484,7 +1468,6 @@
           "expr": "cardano_node_metrics_blockfetchclient_blockdelay_cdfFive{environment=\"$environment\"}",
           "interval": "",
           "legendFormat": "{{instance}}",
-          "queryType": "randomWalk",
           "refId": "A"
         }
       ],

--- a/templates/cardano-parts-project/flake/terraform/grafana/dashboards/cardano-node.json
+++ b/templates/cardano-parts-project/flake/terraform/grafana/dashboards/cardano-node.json
@@ -842,8 +842,7 @@
           "exemplar": true,
           "expr": "rate(cardano_node_metrics_slotsMissedNum_int{environment=\"$environment\"}[1h]) * 3600",
           "interval": "",
-          "legendFormat": "{{environment}}",
-          "queryType": "randomWalk",
+          "legendFormat": "{{instance}}",
           "range": true,
           "refId": "A"
         }
@@ -1183,7 +1182,6 @@
           "hide": false,
           "interval": "",
           "legendFormat": "15 min average",
-          "queryType": "randomWalk",
           "range": true,
           "refId": "A"
         },


### PR DESCRIPTION
# Overview:
Improve ssh key handling and edge cases, resolve misc issues, add IOPS and throughput gp3 openTofu support

# Details:
* Update auth-keys-hub for more assertions and warns on edge case configuration
* Update inputs for the IntersectMBO migration
* Enable local sysstat metrics collection at high resolution in the common nixos profile
* Switch to sops-nix systemd restart/reload secrets hook which is now preferred over the custom sops-secrets hook
* Fix dashboard panels and adjust alerts
* Fix bootstrap key use in the default ssh config for those not using an SSH/GPG agent
* Fix tofu create-all prompt on pre-existing resources
* Add EBS gp3 IOPS and throughput tofu support
* Add a machine bootstrap key auto-expiration service to transition to auth-keys-hub use gracefully