### PR TITLE
Process-compose dbsync and node stacks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /.direnv
 /.envrc.local
 result*
-/.run
+/.run/
 /treefmt.toml

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
-/.envrc.local
 /.direnv
-/treefmt.toml
+/.envrc.local
 result*
+/.run
+/treefmt.toml

--- a/flake.lock
+++ b/flake.lock
@@ -1208,16 +1208,15 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1705607892,
-        "narHash": "sha256-3kCswNKbiMVX6DGP2wogFvQSLiBlP240uEa4J28l57U=",
-        "owner": "johnalotoski",
+        "lastModified": 1705650762,
+        "narHash": "sha256-kSLMsz0tXc1N5Jx8ghEXhLmK4X3Bktt3S4ttXJXCzCo=",
+        "owner": "Platonic-systems",
         "repo": "process-compose-flake",
-        "rev": "2316693e8883e0e4400f5b47cefc8d9c88e30067",
+        "rev": "c8942208e7c7122aef4811a606f7c12ad0753a98",
         "type": "github"
       },
       "original": {
-        "owner": "johnalotoski",
-        "ref": "pre-and-post-hook",
+        "owner": "Platonic-systems",
         "repo": "process-compose-flake",
         "type": "github"
       }
@@ -1286,16 +1285,15 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1705619808,
-        "narHash": "sha256-THLPYlcSOLF43zTNA2fNw4zHXvVQyQfpQlUyPU7/dSc=",
-        "owner": "johnalotoski",
+        "lastModified": 1705690208,
+        "narHash": "sha256-BB2TgKi9ZwLWAfjeVIiYgUGciUcqTb9lsIaMNx6/oI4=",
+        "owner": "juspay",
         "repo": "services-flake",
-        "rev": "96790f8dab1bc24e115b46d75807740e166ea8bf",
+        "rev": "eb8361b9ab6d8f81a9dfb065cc68053839578753",
         "type": "github"
       },
       "original": {
-        "owner": "johnalotoski",
-        "ref": "pg-socket-path-creation",
+        "owner": "juspay",
         "repo": "services-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1208,11 +1208,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1701368682,
-        "narHash": "sha256-YkZbzfOkv68YOX4fK6VQvNHpysyZ/x3gePL3wbo8giA=",
+        "lastModified": 1705505543,
+        "narHash": "sha256-08T7pTpRsTTBx++DXntZBuTwnSaZa9cNdJBfeCDdmos=",
         "owner": "Platonic-Systems",
         "repo": "process-compose-flake",
-        "rev": "8edcd4de7c631eac2ce5f8e2a0782e0ca606da9b",
+        "rev": "5cc43941c05ae268d122bd7dc990b1416d3a2224",
         "type": "github"
       },
       "original": {
@@ -1243,6 +1243,7 @@
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
+        "services-flake": "services-flake",
         "sops-nix": "sops-nix",
         "terranix": "terranix",
         "treefmt-nix": "treefmt-nix_2"
@@ -1279,6 +1280,22 @@
         "owner": "bitcoin-core",
         "ref": "v0.3.2",
         "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "services-flake": {
+      "locked": {
+        "lastModified": 1705460134,
+        "narHash": "sha256-yvobSDZlZiGTAeKIRKY3vdrzMSbpPJho1jKbsVny/nQ=",
+        "owner": "johnalotoski",
+        "repo": "services-flake",
+        "rev": "cb0ae89c6c220b8a6098b587f4660b3ea94d5f32",
+        "type": "github"
+      },
+      "original": {
+        "owner": "johnalotoski",
+        "ref": "pgsocket",
+        "repo": "services-flake",
         "type": "github"
       }
     },

--- a/flake.lock
+++ b/flake.lock
@@ -1208,15 +1208,16 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1705505543,
-        "narHash": "sha256-08T7pTpRsTTBx++DXntZBuTwnSaZa9cNdJBfeCDdmos=",
-        "owner": "Platonic-Systems",
+        "lastModified": 1705607892,
+        "narHash": "sha256-3kCswNKbiMVX6DGP2wogFvQSLiBlP240uEa4J28l57U=",
+        "owner": "johnalotoski",
         "repo": "process-compose-flake",
-        "rev": "5cc43941c05ae268d122bd7dc990b1416d3a2224",
+        "rev": "2316693e8883e0e4400f5b47cefc8d9c88e30067",
         "type": "github"
       },
       "original": {
-        "owner": "Platonic-Systems",
+        "owner": "johnalotoski",
+        "ref": "pre-and-post-hook",
         "repo": "process-compose-flake",
         "type": "github"
       }
@@ -1285,16 +1286,15 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1705460134,
-        "narHash": "sha256-yvobSDZlZiGTAeKIRKY3vdrzMSbpPJho1jKbsVny/nQ=",
-        "owner": "johnalotoski",
+        "lastModified": 1705599616,
+        "narHash": "sha256-VmXMc00fn3FF5Ak+Ai64UHylJSq3hT/wBIIrb3pGANo=",
+        "owner": "juspay",
         "repo": "services-flake",
-        "rev": "cb0ae89c6c220b8a6098b587f4660b3ea94d5f32",
+        "rev": "1a3f2d1936ee3c96e8d30bcf9c99d2507c9bc624",
         "type": "github"
       },
       "original": {
-        "owner": "johnalotoski",
-        "ref": "pgsocket",
+        "owner": "juspay",
         "repo": "services-flake",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1703702592,
-        "narHash": "sha256-fIEncfDhs+00keB7nfntt8A5DDcG2lIg/zD+mJZv/fE=",
+        "lastModified": 1704896812,
+        "narHash": "sha256-RqU75BEtDZ7fEmQi9o9tAo7xuRcWf06AusvNNl2hoL8=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "8b229173763074bf6d5acdbb6ae3768883af7970",
+        "rev": "11f5152084797dd1bd363b20ed81bb10e61a0b47",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1704896812,
-        "narHash": "sha256-RqU75BEtDZ7fEmQi9o9tAo7xuRcWf06AusvNNl2hoL8=",
+        "lastModified": 1705328573,
+        "narHash": "sha256-phIUmokqg/3fdhyIJqRee5INFgbwsgq/PZKZzGwQQC0=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "11f5152084797dd1bd363b20ed81bb10e61a0b47",
+        "rev": "6681de94bef5409203984fcf0d07fb882fc58988",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1286,15 +1286,16 @@
     },
     "services-flake": {
       "locked": {
-        "lastModified": 1705599616,
-        "narHash": "sha256-VmXMc00fn3FF5Ak+Ai64UHylJSq3hT/wBIIrb3pGANo=",
-        "owner": "juspay",
+        "lastModified": 1705619808,
+        "narHash": "sha256-THLPYlcSOLF43zTNA2fNw4zHXvVQyQfpQlUyPU7/dSc=",
+        "owner": "johnalotoski",
         "repo": "services-flake",
-        "rev": "1a3f2d1936ee3c96e8d30bcf9c99d2507c9bc624",
+        "rev": "96790f8dab1bc24e115b46d75807740e166ea8bf",
         "type": "github"
       },
       "original": {
-        "owner": "juspay",
+        "owner": "johnalotoski",
+        "ref": "pg-socket-path-creation",
         "repo": "services-flake",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,8 @@
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
     # Process compose related
-    process-compose-flake.url = "github:johnalotoski/process-compose-flake/pre-and-post-hook";
-    services-flake.url = "github:johnalotoski/services-flake/pg-socket-path-creation";
+    process-compose-flake.url = "github:Platonic-systems/process-compose-flake";
+    services-flake.url = "github:juspay/services-flake";
 
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,14 @@
       url = "github:opentofu/registry";
       flake = false;
     };
-    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
     sops-nix.url = "github:Mic92/sops-nix";
     terranix.url = "github:terranix/terranix";
     treefmt-nix.url = "github:numtide/treefmt-nix";
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+    # Process compose related
+    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
+    services-flake.url = "github:johnalotoski/services-flake/pgsocket";
 
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -22,7 +22,7 @@
 
     # Process compose related
     process-compose-flake.url = "github:johnalotoski/process-compose-flake/pre-and-post-hook";
-    services-flake.url = "github:juspay/services-flake";
+    services-flake.url = "github:johnalotoski/services-flake/pg-socket-path-creation";
 
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -21,8 +21,8 @@
     treefmt-nix.inputs.nixpkgs.follows = "nixpkgs";
 
     # Process compose related
-    process-compose-flake.url = "github:Platonic-Systems/process-compose-flake";
-    services-flake.url = "github:johnalotoski/services-flake/pgsocket";
+    process-compose-flake.url = "github:johnalotoski/process-compose-flake/pre-and-post-hook";
+    services-flake.url = "github:juspay/services-flake";
 
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -72,7 +72,7 @@ in
               if [ -n "''${ENVIRONMENT:-}" ]; then
                 echo "Using the preset environment $ENVIRONMENT ..." >&2
 
-                # Subst hypgen for underscore as iohk-nix envs historically use the former while cardano-world uses the later
+                # Subst hyphen for underscore as iohk-nix envs historically use the former while cardano-world uses the later
                 NODE_CONFIG="$DATA_DIR/config/''${ENVIRONMENT/-/_}/config.json"
                 NODE_TOPOLOGY="''${NODE_TOPOLOGY:-$DATA_DIR/config/''${ENVIRONMENT/-/_}/topology.json}"
               else

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -400,7 +400,7 @@ in
             (mkPkg "db-synthesizer-ng" caPkgs.db-synthesizer-input-output-hk-cardano-node-8-7-2)
             (mkPkg "db-truncater" caPkgs.db-truncater-input-output-hk-cardano-node-8-7-2)
             (mkPkg "db-truncater-ng" caPkgs.db-truncater-input-output-hk-cardano-node-8-7-2)
-            (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-77-8)
+            (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-80-0)
             (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0)
             (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0)
             (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0)

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -372,23 +372,23 @@ in
         pkgsSubmodule = submodule {
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
-            (mkPkg "bech32" caPkgs.bech32-input-output-hk-cardano-node-8-7-2)
+            (mkPkg "bech32" caPkgs.bech32-input-output-hk-cardano-node-8-7-3)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2023-07-18)
-            (mkPkg "cardano-cli" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-2 // {version = "8.17.0.0";}))
-            (mkPkg "cardano-cli-ng" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-2 // {version = "8.17.0.0";}))
+            (mkPkg "cardano-cli" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-3 // {version = "8.17.0.0";}))
+            (mkPkg "cardano-cli-ng" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-3 // {version = "8.17.0.0";}))
             (mkPkg "cardano-db-sync" (caPkgs.cardano-db-sync-input-output-hk-cardano-db-sync-13-1-1-3 // {exeName = "cardano-db-sync";}))
             (mkPkg "cardano-db-sync-ng" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-sancho-3-0-0" // {exeName = "cardano-db-sync";}))
             (mkPkg "cardano-db-tool" caPkgs.cardano-db-tool-input-output-hk-cardano-db-sync-13-1-1-3)
             (mkPkg "cardano-db-tool-ng" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-input-output-hk-cardano-db-sync-sancho-3-0-0")
             (mkPkg "cardano-faucet" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-master")
             (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-master")
-            (mkPkg "cardano-node" (caPkgs.cardano-node-input-output-hk-cardano-node-8-7-2 // {version = "8.7.2";}))
-            (mkPkg "cardano-node-ng" (caPkgs.cardano-node-input-output-hk-cardano-node-8-7-2 // {version = "8.7.2";}))
+            (mkPkg "cardano-node" (caPkgs.cardano-node-input-output-hk-cardano-node-8-7-3 // {version = "8.7.3";}))
+            (mkPkg "cardano-node-ng" (caPkgs.cardano-node-input-output-hk-cardano-node-8-7-3 // {version = "8.7.3";}))
             (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-1-1-3)
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-sancho-3-0-0)
-            (mkPkg "cardano-submit-api" caPkgs.cardano-submit-api-input-output-hk-cardano-node-8-7-2)
-            (mkPkg "cardano-submit-api-ng" caPkgs.cardano-submit-api-input-output-hk-cardano-node-8-7-2)
-            (mkPkg "cardano-tracer" caPkgs.cardano-tracer-input-output-hk-cardano-node-8-7-2)
+            (mkPkg "cardano-submit-api" caPkgs.cardano-submit-api-input-output-hk-cardano-node-8-7-3)
+            (mkPkg "cardano-submit-api-ng" caPkgs.cardano-submit-api-input-output-hk-cardano-node-8-7-3)
+            (mkPkg "cardano-tracer" caPkgs.cardano-tracer-input-output-hk-cardano-node-8-7-3)
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2023-12-18
               // {
                 pname = "cardano-wallet";
@@ -400,7 +400,7 @@ in
             (mkPkg "db-synthesizer-ng" caPkgs.db-synthesizer-input-output-hk-cardano-node-8-7-2)
             (mkPkg "db-truncater" caPkgs.db-truncater-input-output-hk-cardano-node-8-7-2)
             (mkPkg "db-truncater-ng" caPkgs.db-truncater-input-output-hk-cardano-node-8-7-2)
-            (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-77-4)
+            (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-77-8)
             (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0)
             (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0)
             (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0)

--- a/flakeModules/process-compose.nix
+++ b/flakeModules/process-compose.nix
@@ -16,6 +16,7 @@ in {
           run-process-compose-dbsync-private
           run-process-compose-dbsync-sanchonet
           run-process-compose-dbsync-shelley-qa
+          run-process-compose-node-stack
           ;
       };
     });

--- a/flakeModules/process-compose.nix
+++ b/flakeModules/process-compose.nix
@@ -8,7 +8,15 @@ in {
       ...
     }: {
       config.packages = {
-        inherit (localFlake.packages.${system}) demo;
+        inherit
+          (localFlake.packages.${system})
+          run-process-compose-dbsync-mainnet
+          run-process-compose-dbsync-preprod
+          run-process-compose-dbsync-preview
+          run-process-compose-dbsync-private
+          run-process-compose-dbsync-sanchonet
+          run-process-compose-dbsync-shelley-qa
+          ;
       };
     });
   };

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -320,6 +320,7 @@ in
                         mdbook-kroki-preprocessor
                         localFlake.inputs.nixpkgs-unstable.legacyPackages.${system}.mimir
                         opentofu
+                        postgresql
                         rain
                         sops
                         ssh-config-json

--- a/perSystem/process-compose/default.nix
+++ b/perSystem/process-compose/default.nix
@@ -13,7 +13,7 @@ flake @ {
     ...
   }: let
     inherit (builtins) attrNames fromJSON readFile;
-    inherit (lib) foldl' mkForce recursiveUpdate replaceStrings;
+    inherit (lib) concatMapStringsSep foldl' mkForce recursiveUpdate replaceStrings;
     inherit (cardanoLib) environments;
     inherit (opsLib) generateStaticHTMLConfigs;
 
@@ -31,26 +31,32 @@ flake @ {
       mainnet = {
         isNodeNg = false;
         isDbsyncNg = true;
+        magic = getMagic "mainnet";
       };
       preprod = {
         isNodeNg = false;
         isDbsyncNg = true;
+        magic = getMagic "preprod";
       };
       preview = {
         isNodeNg = false;
         isDbsyncNg = true;
+        magic = getMagic "preview";
       };
       private = {
         isNodeNg = true;
         isDbsyncNg = true;
+        magic = getMagic "private";
       };
       sanchonet = {
         isNodeNg = true;
         isDbsyncNg = true;
+        magic = getMagic "sanchonet";
       };
       shelley-qa = {
         isNodeNg = true;
         isDbsyncNg = true;
+        magic = getMagic "shelley-qa";
       };
     };
 
@@ -62,6 +68,8 @@ flake @ {
     toHyphen = s: replaceStrings ["_"] ["-"] s;
     toUnderscore = s: replaceStrings ["-"] ["_"] s;
 
+    getMagic = env: toString (fromJSON (readFile environments.${toUnderscore env}.nodeConfig.ByronGenesisFile)).protocolConsts.protocolMagic;
+
     # The common state dir will be generic and relative since
     # we may run this from any consuming repository stored at
     # any path.
@@ -70,7 +78,24 @@ flake @ {
     # of node state at ${XDG_DATA_HOME:=$HOME/.local/share}/$REPO
     # in the future
     stateDir = "./.run";
-    commonLogDir = "/tmp/process-compose/";
+    commonLogDir = "$TMPDIR/process-compose/";
+
+    preHook = ''
+      [ -n "''${DEBUG:-}" ] && set -x
+      export TMPDIR="''${TMPDIR:=/tmp}"
+
+      if ! [ -d "$TMPDIR" ]; then
+        if ! mkdir -p "$TMPDIR" &> /dev/null; then
+          echo "This process-compose stack requires that \$TMPDIR exists"
+          echo "This environment currently has \$TMPDIR set to $TMPDIR which cannot be created by the current user"
+          exit 1
+        fi
+      elif ! [ -w "$TMPDIR" ]; then
+        echo "This process-compose stack requires that \$TMPDIR is writable by the current user"
+        echo "This environment currently has \$TMPDIR set to $TMPDIR which is not writable by the current user"
+        exit 1
+      fi
+    '';
 
     mkNodeProcess = env: namespace: {
       inherit namespace;
@@ -84,13 +109,11 @@ flake @ {
       '';
     };
 
-    mkCliProcess = env: namespace: let
-      testnetMagic = toString (fromJSON (readFile environments.${toUnderscore env}.nodeConfig.ByronGenesisFile)).protocolConsts.protocolMagic;
-    in {
+    mkCliProcess = env: namespace: {
       inherit namespace;
       log_location = "${stateDir}/${env}/cardano-node/cli.log";
       command = pkgs.writeShellApplication {
-        name = "cardano-cli-${env}${envVer env "isNodeNg"}";
+        name = "cardano-node-${env}${envVer env "isNodeNg"}-query";
         text = ''
           CLI="${config.cardano-parts.pkgs."cardano-cli${envVer env "isNodeNg"}"}/bin/cardano-cli"
           SOCKET="${stateDir}/${env}/cardano-node/node.socket"
@@ -100,7 +123,7 @@ flake @ {
             sleep 5
           done
 
-          while ! "$CLI" ping -c 1 -u "$SOCKET" -m "${testnetMagic}" &> /dev/null; do
+          while ! "$CLI" ping -c 1 -u "$SOCKET" -m "${envBinCfgs.${env}.magic}" &> /dev/null; do
             echo "$(date -u --rfc-3339=seconds): Waiting 5 seconds for the socket to become active at $SOCKET"
             sleep 5
           done
@@ -114,7 +137,7 @@ flake @ {
         '';
       };
       environment = {
-        CARDANO_NODE_NETWORK_ID = testnetMagic;
+        CARDANO_NODE_NETWORK_ID = envBinCfgs.${env}.magic;
         CARDANO_NODE_SOCKET_PATH = "${stateDir}/${env}/cardano-node/node.socket";
       };
     };
@@ -123,6 +146,8 @@ flake @ {
       imports = [
         inputs.services-flake.processComposeModules.default
       ];
+
+      inherit preHook;
 
       apiServer = false;
       package = self'.packages.process-compose;
@@ -135,9 +160,44 @@ flake @ {
             recursiveUpdate acc
             {
               "cardano-node-${env}${envVer env "isNodeNg"}" = mkNodeProcess env env // {disabled = true;};
-              "cardano-cli-${env}${envVer env "isNodeNg"}" = mkCliProcess env env // {disabled = true;};
+              "cardano-node-${env}${envVer env "isNodeNg"}-query" = mkCliProcess env env // {disabled = true;};
             }) {} (attrNames envBinCfgs)
-          // {tui-keepalive.command = "while true; do sleep 60; done";};
+          // {
+            access-instructions = {
+              command = pkgs.writeShellApplication {
+                name = "access-instructions";
+                text = ''
+                  echo "This process-compose stack presents cardano-node jobs for each testnet chain and mainnet."
+                  echo "Any or all of these jobs may be started (and stopped) with the control keys shown at the bottom of the TUI."
+                  echo "The \".*-query\" jobs provide an ongoing sync status for each respective environment."
+                  echo
+                  echo "The cardano-cli or cardano-cli-ng commands from the cardano-parts \"ops\" devShell can be"
+                  echo "can be used to connect to each environment."
+                  echo
+                  echo "If you don't have an \"ops\" devShell handy, you can enter one with:"
+                  echo
+                  echo "  nix develop github:input-output-hk/cardano-parts#devShells.x86_64-linux.ops"
+                  echo
+                  echo "Connection parameters for each environment are:"
+                  echo
+                  ${concatMapStringsSep "\n"
+                    (env: ''
+                      echo "${env}:"
+                      echo "  export CARDANO_NODE_SOCKET_PATH=${stateDir}/${env}/cardano-node/node.socket"
+                      echo "  export CARDANO_NODE_NETWORK_ID=${envBinCfgs.${env}.magic}"
+                      echo
+                    '') (attrNames envBinCfgs)}
+                  echo
+                  echo "^^^ Scroll to the top of this window to read all the instructions"
+
+                  # Keep the TUI alive
+                  while true; do
+                    sleep 60;
+                  done
+                '';
+              };
+            };
+          };
       };
     };
 
@@ -145,25 +205,19 @@ flake @ {
       # To accomodate legacy shelley_qa env naming in iohk-nix
       env' = toHyphen env;
 
-      # It would be nice to set this to "${TMPDIR:=/tmp}/..."
-      # but the process-compose bin doesn't currently allow for
-      # shell interpolation in the probe commands
-      socketDir = "/tmp/process-compose/${env'}";
+      # $TMPDIR needs to be exported in the preHook, otherwise the
+      # dbsync readiness check won't evaluate properly
+      socketDir = "$TMPDIR/process-compose/${env'}";
     in {
       imports = [
         inputs.services-flake.processComposeModules.default
       ];
 
+      inherit preHook;
+
       apiServer = false;
       package = self'.packages.process-compose;
       tui = true;
-
-      preHook = ''
-        if ! [ -d /tmp ] || ! [ -w /tmp ]; then
-          echo "This process-compose stack requires that /tmp exists and is writable by the current user"
-          exit 1
-        fi
-      '';
 
       services.postgres."postgres-${env'}" = {
         inherit socketDir;
@@ -179,6 +233,22 @@ flake @ {
       settings = {
         log_location = "${commonLogDir}/${env'}/dbsync-${env'}.log";
         processes = {
+          access-instructions = {
+            command = pkgs.writeShellApplication {
+              name = "access-instructions-${env'}${envVer env' "isDbsyncNg"}";
+              text = ''
+                echo "The dbsync cexplorer database for ${env'} environment may be accessed with:"
+                echo
+                echo "  ${pkgs.postgresql}/bin/psql -h ${socketDir} -U cexplorer -d cexplorer"
+                echo
+                echo "...or, if psql is already in your devShell path, then simply:"
+                echo
+                echo "  psql -h ${socketDir} -U cexplorer -d cexplorer"
+              '';
+            };
+            depends_on."postgres-${env'}".condition = "process_healthy";
+          };
+
           "postgres-${env'}" = {
             namespace = mkForce "postgresql";
             log_location = "${stateDir}/${env'}/cardano-db-sync/postgres.log";
@@ -191,7 +261,7 @@ flake @ {
 
           "cardano-node-${env'}${envVer env' "isNodeNg"}" = mkNodeProcess env' "cardano-node";
 
-          "cardano-cli-${env'}${envVer env' "isNodeNg"}" = mkCliProcess env' "cardano-node";
+          "cardano-node-${env'}${envVer env' "isNodeNg"}-query" = mkCliProcess env' "cardano-node";
 
           "cardano-db-sync-${env'}${envVer env' "isDbsyncNg"}" = {
             namespace = "cardano-db-sync";
@@ -200,6 +270,12 @@ flake @ {
               name = "cardano-db-sync-${env'}${envVer env' "isDbsyncNg"}";
               runtimeInputs = [pkgs.postgresql];
               text = ''
+                # Export PGPASSFILE here rather than set a process-compose environment var
+                # so that we can substitute runtime env vars which socketDir may use, ex: $TMPDIR
+                export PGPASSFILE="${stateDir}/${env'}/cardano-db-sync/pgpass"
+                echo "${socketDir}:5432:cexplorer:cexplorer:*" > "$PGPASSFILE"
+                chmod 0600 "$PGPASSFILE"
+
                 ${config.cardano-parts.pkgs."cardano-db-sync${envVer env' "isDbsyncNg"}"}/bin/cardano-db-sync \
                   --config ${envCfgs}/config/${env}/db-sync-config.json \
                   --socket-path ${stateDir}/${env'}/cardano-node/node.socket \
@@ -207,7 +283,6 @@ flake @ {
                   --schema-dir ${flake.config.flake.cardano-parts.pkgs.special."cardano-db-sync-schema${envVer env' "isDbsyncNg"}"}
               '';
             };
-            environment.PGPASSFILE = "${pkgs.writeText "pgpass-${env'}" "${socketDir}:5432:cexplorer:cexplorer:*"}";
             depends_on."postgres-${env'}".condition = "process_healthy";
           };
         };

--- a/perSystem/process-compose/default.nix
+++ b/perSystem/process-compose/default.nix
@@ -1,11 +1,6 @@
-flake @ {
-  # self,
-  inputs,
-  ...
-}: {
+flake @ {inputs, ...}: {
   perSystem = {
     config,
-    # inputs',
     self',
     lib,
     pkgs,

--- a/perSystem/process-compose/default.nix
+++ b/perSystem/process-compose/default.nix
@@ -1,17 +1,152 @@
-{
-  perSystem = {self', ...}: {
-    process-compose.demo = {
+flake @ {
+  # self,
+  inputs,
+  ...
+}: {
+  perSystem = {
+    config,
+    # inputs',
+    self',
+    lib,
+    pkgs,
+    system,
+    ...
+  }: let
+    inherit (lib) mkForce replaceStrings;
+    inherit (opsLib) generateStaticHTMLConfigs;
+
+    cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLib system;
+    opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
+
+    envCfgs = generateStaticHTMLConfigs pkgs cardanoLib cardanoLib.environments;
+
+    # Node and dbsync versioning for local development testing
+    #
+    # Note that mainnet, preprod, preview have dbsync set as `-ng` versioning
+    # until the next release after 13.1.1.3 which will no longer require
+    # the deprecated `ApplicationName` key to be set in the environment config
+    envBinCfgs = {
+      mainnet = {
+        isNodeNg = false;
+        isDbsyncNg = true;
+      };
+      preprod = {
+        isNodeNg = false;
+        isDbsyncNg = true;
+      };
+      preview = {
+        isNodeNg = false;
+        isDbsyncNg = true;
+      };
+      private = {
+        isNodeNg = true;
+        isDbsyncNg = true;
+      };
+      sanchonet = {
+        isNodeNg = true;
+        isDbsyncNg = true;
+      };
+      shelley-qa = {
+        isNodeNg = true;
+        isDbsyncNg = true;
+      };
+    };
+
+    envVer = env: binCfg:
+      if envBinCfgs.${env}.${binCfg}
+      then "-ng"
+      else "";
+
+    mkDbsyncStack = env: let
+      # To accomodate legacy shelley_qa env naming in iohk-nix
+      env' = replaceStrings ["_"] ["-"] env;
+
+      # The common state dir will be generic and relative since
+      # we may run this from any consuming repository stored at
+      # any path.
+      #
+      # We may wish to align this better with Justfile's handling
+      # of node state at ${XDG_DATA_HOME:=$HOME/.local/share}/$REPO
+      # in the future
+      stateDir = "./.run";
+
+      # It would be nice to set this to "${TMPDIR:=/tmp}/..."
+      # but the process-compose bin doesn't currently allow for
+      # shell interpolation in the probe commands
+      socketDir = "/tmp/process-compose/${env'}";
+      commonLogDir = "/tmp/process-compose/${env'}";
+    in {
+      imports = [
+        inputs.services-flake.processComposeModules.default
+      ];
+
+      apiServer = false;
       package = self'.packages.process-compose;
+      tui = true;
+
+      services.postgres."postgres-${env'}" = {
+        inherit socketDir;
+        enable = true;
+        dataDir = "${stateDir}/${env'}/cardano-db-sync/database";
+        initialDatabases = [{name = "cexplorer";}];
+        initialScript.after = ''
+          CREATE USER cexplorer;
+          ALTER DATABASE cexplorer OWNER TO cexplorer;
+        '';
+      };
+
       settings = {
+        log_location = "${commonLogDir}/${env'}.log";
         processes = {
-          demosay.command = ''
-            while true; do
-              echo "Enjoy the big demo!"
-              sleep 2
-            done
-          '';
+          "postgres-${env'}" = {
+            namespace = mkForce "postgresql";
+            log_location = "${stateDir}/${env'}/cardano-db-sync/postgres.log";
+          };
+
+          "postgres-${env'}-init" = {
+            namespace = mkForce "postgresql";
+            log_location = "${stateDir}/${env'}/cardano-db-sync/postgres-init.log";
+          };
+
+          "cardano-node-${env'}${envVer env' "isNodeNg"}" = {
+            namespace = "cardano-node";
+            log_location = "${stateDir}/${env'}/cardano-node/node.log";
+            command = ''
+              ${config.cardano-parts.pkgs."cardano-node${envVer env' "isNodeNg"}"}/bin/cardano-node run +RTS -N -RTS \
+              --topology ${envCfgs}/config/${env}/topology.json \
+              --database-path ${stateDir}/${env'}/cardano-node/db \
+              --socket-path ${stateDir}/${env'}/cardano-node/node.socket \
+              --config ${envCfgs}/config/${env}/config.json
+            '';
+          };
+
+          "cardano-db-sync-${env'}${envVer env' "isDbsyncNg"}" = {
+            namespace = "cardano-db-sync";
+            log_location = "${stateDir}/${env'}/cardano-db-sync/dbsync.log";
+            command = pkgs.writeShellApplication {
+              name = "cardano-db-sync-${env'}";
+              text = ''
+                ${config.cardano-parts.pkgs."cardano-db-sync${envVer env' "isDbsyncNg"}"}/bin/cardano-db-sync \
+                  --config ${envCfgs}/config/${env}/db-sync-config.json \
+                  --socket-path ${stateDir}/${env'}/cardano-node/node.socket \
+                  --state-dir ${stateDir}/${env'}/cardano-db-sync/ledger-state \
+                  --schema-dir ${flake.config.flake.cardano-parts.pkgs.special."cardano-db-sync-schema${envVer env' "isDbsyncNg"}"}
+              '';
+            };
+            environment.PGPASSFILE = "${pkgs.writeText "pgpass-${env'}" "${socketDir}:5432:cexplorer:cexplorer:*"}";
+            depends_on."postgres-${env'}".condition = "process_healthy";
+          };
         };
       };
+    };
+  in {
+    process-compose = {
+      run-process-compose-dbsync-mainnet = mkDbsyncStack "mainnet";
+      run-process-compose-dbsync-preprod = mkDbsyncStack "preprod";
+      run-process-compose-dbsync-preview = mkDbsyncStack "preview";
+      run-process-compose-dbsync-private = mkDbsyncStack "private";
+      run-process-compose-dbsync-sanchonet = mkDbsyncStack "sanchonet";
+      run-process-compose-dbsync-shelley-qa = mkDbsyncStack "shelley_qa";
     };
   };
 }

--- a/templates/cardano-parts-project/.gitignore
+++ b/templates/cardano-parts-project/.gitignore
@@ -7,6 +7,7 @@
 /*.pid
 __pycache__
 /result*
+/.run/
 /*.skey
 /*.socket
 /.ssh_config

--- a/templates/cardano-parts-project/flake.nix
+++ b/templates/cardano-parts-project/flake.nix
@@ -25,6 +25,7 @@
           inputs.cardano-parts.flakeModules.jobs
           inputs.cardano-parts.flakeModules.lib
           inputs.cardano-parts.flakeModules.pkgs
+          inputs.cardano-parts.flakeModules.process-compose
           inputs.cardano-parts.flakeModules.shell
           {options.flake.opentofu = mkOption {type = types.attrs;};}
         ];


### PR DESCRIPTION
# Overview:

Adds some useful process compose stacks for running cardano-node or a full dbsync stack for testnets and mainnet

Example process compose node stack running:
![image](https://github.com/input-output-hk/cardano-parts/assets/39752197/4b9fae04-ea04-417d-8b8e-237e5b5a039c)

Example process compose dbsync stack running for sanchonet:
![image](https://github.com/input-output-hk/cardano-parts/assets/39752197/ce1a16ed-39bf-459c-afbf-61a85532bb82)

# Details:
* Bump node to 8.7.3 from capkgs
* Bump process-compose to v0.80.0
* Add process-compose-flake and services-flake for support of process-compose run jobs
* To run, `nix >= 2.17.0` is required as well as `experimental-features = nix-command flakes fetch-closure` in addition to flakes support
* Add process-compose stacks of:
  * Dbsync stack for each testnet plus mainnet as `nix run .#run-process-compose-dbsync-$NETWORK`
  * Node stack for testnets plus mainnet as `nix run .#run-process-compose-node-stack`

# Caveats:
* State directories prefixes default to `$CWD/.run` and in the case of postgresql sockets `$TMPDIR/process-compose`
* Multiple dbsync process-compose stacks can be run concurrently without interfering with each other
* To avoid doubling node storage, node jobs and dbsync jobs for a given network use the same node state path
* In this case, only 1 of a node job from the node stack or a dbsync stack for the same network can be run at a time