### PR TITLE
Blockperf

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,26 +71,6 @@
         "type": "github"
       }
     },
-    "blockperf": {
-      "inputs": {
-        "flake-parts": "flake-parts_2",
-        "nixpkgs": "nixpkgs_2"
-      },
-      "locked": {
-        "lastModified": 1706221215,
-        "narHash": "sha256-VRc2nGwfIFSU9a4oITrKZMyxVEY67k6hWAmeYnLfCS4=",
-        "owner": "johnalotoski",
-        "repo": "blockperf",
-        "rev": "9548fa338f3e2b1bfa5b7e86d9637951b680d0d7",
-        "type": "github"
-      },
-      "original": {
-        "owner": "johnalotoski",
-        "ref": "nix-flake",
-        "repo": "blockperf",
-        "type": "github"
-      }
-    },
     "blst": {
       "flake": false,
       "locked": {
@@ -178,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1705328573,
-        "narHash": "sha256-phIUmokqg/3fdhyIJqRee5INFgbwsgq/PZKZzGwQQC0=",
+        "lastModified": 1706813582,
+        "narHash": "sha256-syEg5q44eIYvvXNSC0pTGIFi+h9FbGIn/5o3rTA4+C0=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "6681de94bef5409203984fcf0d07fb882fc58988",
+        "rev": "a46db6ec6e338ff8beb660b06ba82185097e81ff",
         "type": "github"
       },
       "original": {
@@ -438,24 +418,6 @@
         "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1701473968,
-        "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "34fed993f1674c8d06d58b37ce1e0fe5eebcb9f5",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_4": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_4"
-      },
-      "locked": {
         "lastModified": 1690933134,
         "narHash": "sha256-ab989mN63fQZBFrkk4Q8bYxQCktuHmBIBqUG1jl6/FQ=",
         "owner": "hercules-ci",
@@ -687,8 +649,8 @@
     },
     "inputs-check": {
       "inputs": {
-        "flake-parts": "flake-parts_4",
-        "nixpkgs": "nixpkgs_4"
+        "flake-parts": "flake-parts_3",
+        "nixpkgs": "nixpkgs_3"
       },
       "locked": {
         "lastModified": 1692633913,
@@ -707,7 +669,7 @@
     "iohk-nix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -728,7 +690,7 @@
     "iohk-nix-ng": {
       "inputs": {
         "blst": "blst_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_5",
         "secp256k1": "secp256k1_2",
         "sodium": "sodium_2"
       },
@@ -798,7 +760,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -820,7 +782,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_6",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -989,24 +951,6 @@
     "nixpkgs-lib_3": {
       "locked": {
         "dir": "lib",
-        "lastModified": 1701253981,
-        "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e92039b55bcd58469325ded85d4f58dd5a4eaf58",
-        "type": "github"
-      },
-      "original": {
-        "dir": "lib",
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_4": {
-      "locked": {
-        "dir": "lib",
         "lastModified": 1690881714,
         "narHash": "sha256-h/nXluEqdiQHs1oSgkOOWF+j8gcJMWhwnZ9PFabN6q0=",
         "owner": "NixOS",
@@ -1102,38 +1046,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_10": {
-      "locked": {
-        "lastModified": 1636823747,
-        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "nixpkgs_2": {
-      "locked": {
-        "lastModified": 1705458851,
-        "narHash": "sha256-uQvEhiv33Zj/Pv364dTvnpPwFSptRZgVedDzoM+HqVg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "8bf65f17d8070a0a490daf5f1c784b87ee73982c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_3": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -1149,7 +1062,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1692339729,
         "narHash": "sha256-TUK76/Pqm9qIDjEGd27Lz9EiBIvn5F70JWDmEQ4Y5DQ=",
@@ -1161,6 +1074,22 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-23.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1183,22 +1112,6 @@
     },
     "nixpkgs_6": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_7": {
-      "locked": {
         "lastModified": 1700748986,
         "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
         "owner": "NixOS",
@@ -1213,7 +1126,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1701539137,
         "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
@@ -1229,7 +1142,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_9": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1702539185,
         "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
@@ -1241,6 +1154,21 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_9": {
+      "locked": {
+        "lastModified": 1636823747,
+        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1296,7 +1224,6 @@
     "root": {
       "inputs": {
         "auth-keys-hub": "auth-keys-hub",
-        "blockperf": "blockperf",
         "capkgs": "capkgs",
         "cardano-db-sync-schema": "cardano-db-sync-schema",
         "cardano-db-sync-schema-ng": "cardano-db-sync-schema-ng",
@@ -1306,13 +1233,13 @@
         "cardano-wallet-service": "cardano-wallet-service",
         "colmena": "colmena",
         "empty-flake": "empty-flake",
-        "flake-parts": "flake-parts_3",
+        "flake-parts": "flake-parts_2",
         "haskell-nix": "haskell-nix",
         "inputs-check": "inputs-check",
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix_2",
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
@@ -1407,7 +1334,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -1460,7 +1387,7 @@
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_10",
+        "nixpkgs": "nixpkgs_9",
         "terranix-examples": "terranix-examples"
       },
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -26,11 +26,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1703692836,
-        "narHash": "sha256-Vn/OBdQYKcHlKMToSlKkDCboSi06puC40ZskzxI5Usk=",
+        "lastModified": 1704983837,
+        "narHash": "sha256-J1oQdSqehbcslfHPjQbvRF7SgYpzk0Son6BJIiS6VjM=",
         "owner": "input-output-hk",
         "repo": "auth-keys-hub",
-        "rev": "a6b002e81fa401efa5ce182a34c7794c330920f6",
+        "rev": "246d8d3d0d3cd8f13dfededa125a4bdee669cb57",
         "type": "github"
       },
       "original": {
@@ -68,6 +68,26 @@
       "original": {
         "owner": "bats-core",
         "repo": "bats-support",
+        "type": "github"
+      }
+    },
+    "blockperf": {
+      "inputs": {
+        "flake-parts": "flake-parts_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1706114615,
+        "narHash": "sha256-g6aAJ27ngZ7zjzjaC75uHpCwQDKP7Z/xk7Nz8PsJm6c=",
+        "owner": "johnalotoski",
+        "repo": "blockperf",
+        "rev": "a0f8103d8b0f237d069934c28e50f61501805c26",
+        "type": "github"
+      },
+      "original": {
+        "owner": "johnalotoski",
+        "ref": "nix-flake",
+        "repo": "blockperf",
         "type": "github"
       }
     },
@@ -400,6 +420,24 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_3": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_3"
+      },
+      "locked": {
         "lastModified": 1701473968,
         "narHash": "sha256-YcVE5emp1qQ8ieHUnxt1wCZCC3ZfAS+SRRWZ2TMda7E=",
         "owner": "hercules-ci",
@@ -413,9 +451,9 @@
         "type": "github"
       }
     },
-    "flake-parts_3": {
+    "flake-parts_4": {
       "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_3"
+        "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
         "lastModified": 1690933134,
@@ -649,8 +687,8 @@
     },
     "inputs-check": {
       "inputs": {
-        "flake-parts": "flake-parts_3",
-        "nixpkgs": "nixpkgs_3"
+        "flake-parts": "flake-parts_4",
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1692633913,
@@ -669,7 +707,7 @@
     "iohk-nix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -690,7 +728,7 @@
     "iohk-nix-ng": {
       "inputs": {
         "blst": "blst_2",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_6",
         "secp256k1": "secp256k1_2",
         "sodium": "sodium_2"
       },
@@ -760,7 +798,7 @@
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
@@ -782,7 +820,7 @@
       "inputs": {
         "flake-compat": "flake-compat_3",
         "lowdown-src": "lowdown-src_2",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
@@ -933,6 +971,24 @@
     "nixpkgs-lib_2": {
       "locked": {
         "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "dir": "lib",
         "lastModified": 1701253981,
         "narHash": "sha256-ztaDIyZ7HrTAfEEUt9AtTDNoCYxUdSd6NrRHaYOIxtk=",
         "owner": "NixOS",
@@ -948,7 +1004,7 @@
         "type": "github"
       }
     },
-    "nixpkgs-lib_3": {
+    "nixpkgs-lib_4": {
       "locked": {
         "dir": "lib",
         "lastModified": 1690881714,
@@ -1046,7 +1102,38 @@
         "type": "github"
       }
     },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1636823747,
+        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1705458851,
+        "narHash": "sha256-uQvEhiv33Zj/Pv364dTvnpPwFSptRZgVedDzoM+HqVg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "8bf65f17d8070a0a490daf5f1c784b87ee73982c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_3": {
       "locked": {
         "lastModified": 1657693803,
         "narHash": "sha256-G++2CJ9u0E7NNTAi9n5G8TdDmGJXcIjkJ3NF8cetQB8=",
@@ -1062,7 +1149,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_3": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1692339729,
         "narHash": "sha256-TUK76/Pqm9qIDjEGd27Lz9EiBIvn5F70JWDmEQ4Y5DQ=",
@@ -1074,22 +1161,6 @@
       "original": {
         "owner": "nixos",
         "ref": "nixos-23.05",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1112,6 +1183,22 @@
     },
     "nixpkgs_6": {
       "locked": {
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_7": {
+      "locked": {
         "lastModified": 1700748986,
         "narHash": "sha256-/nqLrNU297h3PCw4QyDpZKZEUHmialJdZW2ceYFobds=",
         "owner": "NixOS",
@@ -1126,7 +1213,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1701539137,
         "narHash": "sha256-nVO/5QYpf1GwjvtpXhyxx5M3U/WN0MwBro4Lsk+9mL0=",
@@ -1142,7 +1229,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_8": {
+    "nixpkgs_9": {
       "locked": {
         "lastModified": 1702539185,
         "narHash": "sha256-KnIRG5NMdLIpEkZTnN5zovNYc0hhXjAgv6pfd5Z4c7U=",
@@ -1154,21 +1241,6 @@
       "original": {
         "owner": "NixOS",
         "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_9": {
-      "locked": {
-        "lastModified": 1636823747,
-        "narHash": "sha256-oWo1nElRAOZqEf90Yek2ixdHyjD+gqtS/pAgwaQ9UhQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "f6a2ed2082d9a51668c86ba27d0b5496f7a2ea93",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -1224,6 +1296,7 @@
     "root": {
       "inputs": {
         "auth-keys-hub": "auth-keys-hub",
+        "blockperf": "blockperf",
         "capkgs": "capkgs",
         "cardano-db-sync-schema": "cardano-db-sync-schema",
         "cardano-db-sync-schema-ng": "cardano-db-sync-schema-ng",
@@ -1233,13 +1306,13 @@
         "cardano-wallet-service": "cardano-wallet-service",
         "colmena": "colmena",
         "empty-flake": "empty-flake",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "haskell-nix": "haskell-nix",
         "inputs-check": "inputs-check",
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix_2",
-        "nixpkgs": "nixpkgs_7",
+        "nixpkgs": "nixpkgs_8",
         "nixpkgs-unstable": "nixpkgs-unstable_2",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
@@ -1334,7 +1407,7 @@
     },
     "sops-nix": {
       "inputs": {
-        "nixpkgs": "nixpkgs_8",
+        "nixpkgs": "nixpkgs_9",
         "nixpkgs-stable": "nixpkgs-stable"
       },
       "locked": {
@@ -1387,7 +1460,7 @@
         "bats-assert": "bats-assert",
         "bats-support": "bats-support",
         "flake-utils": "flake-utils_3",
-        "nixpkgs": "nixpkgs_9",
+        "nixpkgs": "nixpkgs_10",
         "terranix-examples": "terranix-examples"
       },
       "locked": {

--- a/flake.lock
+++ b/flake.lock
@@ -77,11 +77,11 @@
         "nixpkgs": "nixpkgs_2"
       },
       "locked": {
-        "lastModified": 1706114615,
-        "narHash": "sha256-g6aAJ27ngZ7zjzjaC75uHpCwQDKP7Z/xk7Nz8PsJm6c=",
+        "lastModified": 1706221215,
+        "narHash": "sha256-VRc2nGwfIFSU9a4oITrKZMyxVEY67k6hWAmeYnLfCS4=",
         "owner": "johnalotoski",
         "repo": "blockperf",
-        "rev": "a0f8103d8b0f237d069934c28e50f61501805c26",
+        "rev": "9548fa338f3e2b1bfa5b7e86d9637951b680d0d7",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -24,6 +24,10 @@
     process-compose-flake.url = "github:Platonic-systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
 
+    # Temp:
+    blockperf.url = "github:johnalotoski/blockperf/nix-flake";
+    # blockperf.url = "path:/home/jlotoski/work/johnalotoski/blockperf-wt/nix-flake";
+
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";
     empty-flake.url = "github:input-output-hk/empty-flake";

--- a/flake.nix
+++ b/flake.nix
@@ -24,10 +24,6 @@
     process-compose-flake.url = "github:Platonic-systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
 
-    # Move this to capkgs once the flake is stable and merged upstream:
-    blockperf.url = "github:johnalotoski/blockperf/nix-flake";
-    # blockperf.url = "path:/home/jlotoski/work/johnalotoski/blockperf-wt/nix-flake";
-
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";
     empty-flake.url = "github:input-output-hk/empty-flake";

--- a/flake.nix
+++ b/flake.nix
@@ -24,7 +24,7 @@
     process-compose-flake.url = "github:Platonic-systems/process-compose-flake";
     services-flake.url = "github:juspay/services-flake";
 
-    # Temp:
+    # Move this to capkgs once the flake is stable and merged upstream:
     blockperf.url = "github:johnalotoski/blockperf/nix-flake";
     # blockperf.url = "path:/home/jlotoski/work/johnalotoski/blockperf-wt/nix-flake";
 

--- a/flake/nixosModules/module-cardano-parts.nix
+++ b/flake/nixosModules/module-cardano-parts.nix
@@ -18,6 +18,7 @@
 #   config.cardano-parts.perNode.meta.cardano-smash-service
 #   config.cardano-parts.perNode.meta.hostAddr
 #   config.cardano-parts.perNode.meta.nodeId
+#   config.cardano-parts.perNode.pkgs.blockperf
 #   config.cardano-parts.perNode.pkgs.cardano-cli
 #   config.cardano-parts.perNode.pkgs.cardano-db-sync
 #   config.cardano-parts.perNode.pkgs.cardano-db-sync-pkgs
@@ -196,6 +197,7 @@ flake @ {moduleWithSystem, ...}: {
 
     pkgsSubmodule = submodule {
       options = foldl' recursiveUpdate {} [
+        (mkPkgOpt "blockperf" (cfg.group.pkgs.blockperf system))
         (mkPkgOpt "cardano-cli" (cfg.group.pkgs.cardano-cli system))
         (mkPkgOpt "cardano-db-sync" (cfg.group.pkgs.cardano-db-sync system))
         (mkPkgOpt "cardano-db-tool" (cfg.group.pkgs.cardano-db-tool system))

--- a/flake/nixosModules/profile-blockperf.nix
+++ b/flake/nixosModules/profile-blockperf.nix
@@ -1,0 +1,239 @@
+# nixosModule: profile-blockperf
+#
+# TODO: Move this to a docs generator
+#
+# Attributes available on nixos module import:
+#
+# Tips:
+#   * This is an add-on to the profile-cardano-node-group nixos service module
+#   * This module modifies runs blockperf and modifies the cardano-node service to do so
+#   * The profile-cardano-node-group nixos service module should still be imported separately
+flake: {
+  flake.nixosModules.profile-blockperf = {
+    config,
+    lib,
+    pkgs,
+    ...
+  }: let
+    inherit (lib) hasSuffix mkOption;
+    inherit (lib.types) int package str;
+    inherit (groupCfg) groupName groupFlake;
+    inherit (opsLib) mkSopsSecret;
+
+    groupCfg = config.cardano-parts.cluster.group;
+    groupOutPath = groupFlake.self.outPath;
+    opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
+
+    mkSopsSecretParams = secretName: keyName: {
+      inherit keyName groupOutPath groupName secretName;
+      fileOwner = "cardano-node";
+      fileGroup = "cardano-node";
+      pathPrefix =
+        if hasSuffix "/" cfg.secretsPathPrefix
+        then cfg.secretsPathPrefix
+        else cfg.secretsPathPrefix + "/";
+      restartUnits = ["blockPerf.service"];
+    };
+
+    sopsPath = name: config.sops.secrets.${name}.path;
+
+    cfg = config.services.blockperf;
+    cfgNode = config.services.cardano-node;
+  in {
+    options.services.blockperf = {
+      blockperfName = mkOption {
+        type = str;
+        default = null;
+        description = "The blockperf client identifier provided by Cardano Foundation.";
+      };
+
+      blockperfClientCert = mkOption {
+        type = str;
+        default = null;
+        description = "The filename of the local encrypted client certificate.";
+      };
+
+      blockperfClientKey = mkOption {
+        type = str;
+        default = null;
+        description = "The filename of the local encrypted client key.";
+      };
+
+      blockperfAmazonCA = mkOption {
+        type = str;
+        default = "blockperf-amazon-ca.pem.enc";
+        description = ''
+          The filename of the local encrypte amazon CA in PEM format
+
+          Path to the Amazon CA file in PEM format, sourced from:
+            https://www.amazontrust.com/repository/AmazonRootCA1.pem
+        '';
+      };
+
+      package = mkOption {
+        type = package;
+        default = config.cardano-parts.perNode.pkgs.blockperf;
+        description = "The default blockperf package";
+      };
+
+      nodeLogFile = mkOption {
+        type = str;
+        default = "${cfgNode.stateDir 0}/blockperf/node.json";
+        description = "The full path and file name of the node log file which blockperf consumes.";
+      };
+
+      nodeLogLimitBytes = mkOption {
+        type = int;
+        default = 5 * 1024 * 1024;
+        description = ''
+          The rpLogLimitBytes for the node log file legacy scribe rotation.
+          See: https://github.com/input-output-hk/iohk-monitoring-framework/wiki/Log-rotation
+        '';
+      };
+
+      nodeLogKeepFilesNum = mkOption {
+        type = int;
+        default = 10;
+        description = ''
+          The rpKeepFilesNum for the node log file legacy scribe rotation.
+          See: https://github.com/input-output-hk/iohk-monitoring-framework/wiki/Log-rotation
+        '';
+      };
+
+      nodeLogMaxAgeHours = mkOption {
+        type = int;
+        default = 24;
+        description = ''
+          The rpMaxAgeHours for the node log file legacy scribe rotation.
+          See: https://github.com/input-output-hk/iohk-monitoring-framework/wiki/Log-rotation
+        '';
+      };
+
+      secretsPathPrefix = mkOption {
+        type = str;
+        default = "${groupOutPath}/secrets/monitoring";
+        description = "The path where the local encrypted secrets files will be obtained from.";
+      };
+    };
+
+    config = {
+      environment.systemPackages = [cfg.package];
+
+      services.cardano-node = {
+        extraNodeInstanceConfig = _: {
+          TraceChainSyncClient = true;
+          TraceBlockFetchClient = true;
+
+          # We need to redeclare the standard setup in the list along
+          # with the new blockperf config because:
+          #   * cfgNode.extraNodeConfig won't merge or replace lists
+          #   * cfgNode.extraNodeInstanceConfig replaces lists
+          defaultScribes = [
+            # Standard scribe
+            ["JournalSK" "cardano"]
+
+            # Blockperf required
+            ["FileSK" cfg.nodeLogFile]
+          ];
+
+          setupScribes = [
+            # Standard scribe
+            {
+              scFormat = "ScText";
+              scKind = "JournalSK";
+              scName = "cardano";
+            }
+
+            # Blockperf required
+            {
+              scFormat = "ScJson";
+              scKind = "FileSK";
+              scName = cfg.nodeLogFile;
+              scRotation = {
+                rpLogLimitBytes = cfg.nodeLogLimitBytes;
+                rpKeepFilesNum = cfg.nodeLogKeepFilesNum;
+                rpMaxAgeHours = cfg.nodeLogMaxAgeHours;
+              };
+            }
+          ];
+        };
+      };
+
+      # The blockperf systemd service name cannot contain the string "blockperf"
+      # or the bin utility will think it is already running
+      systemd.services.blockPerf = {
+        after = ["cardano-node.service"];
+        wants = ["cardano-node.service"];
+        partOf = ["cardano-node.service"];
+        wantedBy = ["cardano-node.service"];
+
+        # Ensure service restarts are continuous
+        startLimitIntervalSec = 0;
+
+        path = with pkgs; [cfg.package dig gnugrep];
+
+        environment = {
+          # Path to the cardano-node blockperf log file
+          BLOCKPERF_NODE_LOGFILE = cfg.nodeLogFile;
+
+          # The client identifier; will be given to you with the certificates
+          BLOCKPERF_NAME = cfg.blockperfName;
+
+          # Path to the client certificate file
+          BLOCKPERF_CLIENT_CERT = sopsPath "blockperf-client-cert.pem";
+
+          # Path to the client key file
+          BLOCKPERF_CLIENT_KEY = sopsPath "blockperf-client.key";
+
+          # Path to the Amazon CA file in PEM format, find it here:
+          #   https://www.amazontrust.com/repository/AmazonRootCA1.pem
+          BLOCKPERF_AMAZON_CA = sopsPath "blockperf-amazon-ca.pem";
+        };
+
+        script = ''
+          set -euo pipefail
+
+          # Set the node config path
+          #
+          # The nixos service does not make the config file accessible,
+          # so we either need to regenerate it completely, or parse it
+          # out of the systemd unit
+          START_SCRIPT=$(grep -oP "ExecStart=\K.*" /etc/systemd/system/cardano-node.service)
+          NODE_CONFIG=$(grep -oP '   echo "--config \K(.*).json' $(echo "$START_SCRIPT"))
+          export BLOCKPERF_NODE_CONFIG="$NODE_CONFIG"
+
+          # Set our public IP using a generic resolver that is cloud/platform independent
+          PUBLIC_IP=$(dig +short @resolver1.opendns.com myip.opendns.com)
+          export BLOCKPERF_RELAY_PUBLIC_IP="$PUBLIC_IP";
+
+          echo "Blockperf machine Amazon CA: $BLOCKPERF_AMAZON_CA"
+          echo "Blockperf machine client cert: $BLOCKPERF_CLIENT_CERT"
+          echo "Blockperf machine client key: $BLOCKPERF_CLIENT_KEY"
+          echo "Starting blockperf..."
+          blockperf run
+        '';
+
+        serviceConfig = {
+          # Ensure quick restarts on any condition
+          Restart = "always";
+          RestartSec = 10;
+          KillSignal = "SIGINT";
+        };
+      };
+
+      users.users.cardano-node.extraGroups = ["keys"];
+
+      sops.secrets =
+        mkSopsSecret (mkSopsSecretParams "blockperf-client-cert.pem" cfg.blockperfClientCert)
+        // mkSopsSecret (mkSopsSecretParams "blockperf-client.key" cfg.blockperfClientKey)
+        // mkSopsSecret (mkSopsSecretParams "blockperf-amazon-ca.pem" cfg.blockperfAmazonCA);
+
+      assertions = [
+        {
+          assertion = cfgNode.instances == 1;
+          message = ''The nixos blockperf profile does not currently work with multiple cardano-node instances per machine.'';
+        }
+      ];
+    };
+  };
+}

--- a/flake/nixosModules/profile-blockperf.nix
+++ b/flake/nixosModules/profile-blockperf.nix
@@ -3,6 +3,18 @@
 # TODO: Move this to a docs generator
 #
 # Attributes available on nixos module import:
+#   config.services.blockperf.amazonCa
+#   config.services.blockperf.clientCert
+#   config.services.blockperf.clientKey
+#   config.services.blockperf.logFile
+#   config.services.blockperf.logKeepFilesNum
+#   config.services.blockperf.logLimitBytes
+#   config.services.blockperf.logMaxAgeHours
+#   config.services.blockperf.maskedDnsList
+#   config.services.blockperf.maskedIpList
+#   config.services.blockperf.name
+#   config.services.blockperf.package
+#   config.services.blockperf.secretsPathPrefix
 #
 # Tips:
 #   * This is an add-on to the profile-cardano-node-group nixos service module

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -205,7 +205,7 @@
 
             # Ensure quick restarts on any condition
             Restart = "always";
-            RestartSec = 1;
+            RestartSec = 10;
           };
         };
 
@@ -262,7 +262,7 @@
               });
 
               Restart = "always";
-              RestartSec = 1;
+              RestartSec = 10;
             };
           };
         }

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -3,9 +3,9 @@
 # TODO: Move this to a docs generator
 #
 # Attributes available on nixos module import:
-#   config.cardano-node.shareIpv6Address
-#   config.cardano-node.totalMaxHeapSizeMiB
-#   config.cardano-node.totalCpuCores
+#   config.services.cardano-node.shareIpv6Address
+#   config.services.cardano-node.totalMaxHeapSizeMiB
+#   config.services.cardano-node.totalCpuCores
 #
 # Tips:
 #   * This is a cardano-node add-on to the upstream cardano-node nixos service module

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -196,8 +196,10 @@
         };
 
         extraServiceConfig = _: {
-          # Ensure service restarts are continuous
-          startLimitIntervalSec = 0;
+          # Allow up to 10 failures with 30 second restarts in a 15 minute window
+          # before entering failure state and alerting
+          startLimitBurst = 10;
+          startLimitIntervalSec = 900;
 
           serviceConfig = {
             MemoryMax = "${toString (1.15 * cfg.totalMaxHeapSizeMiB / cfg.instances)}M";
@@ -205,7 +207,7 @@
 
             # Ensure quick restarts on any condition
             Restart = "always";
-            RestartSec = 10;
+            RestartSec = 30;
           };
         };
 
@@ -234,7 +236,10 @@
             partOf = ["cardano-node.service"];
             wantedBy = ["cardano-node.service"];
 
-            startLimitIntervalSec = 0;
+            # Allow up to 10 failures with 30 second restarts in a 15 minute window
+            # before entering failure state and alerting
+            startLimitBurst = 10;
+            startLimitIntervalSec = 900;
 
             serviceConfig = {
               ExecStart = getExe (pkgs.writeShellApplication {
@@ -262,7 +267,7 @@
               });
 
               Restart = "always";
-              RestartSec = 10;
+              RestartSec = 30;
             };
           };
         }

--- a/flake/nixosModules/service-cardano-faucet.nix
+++ b/flake/nixosModules/service-cardano-faucet.nix
@@ -145,7 +145,10 @@
           after = ["network-online.target"];
           wantedBy = ["multi-user.target"];
 
-          startLimitIntervalSec = 0;
+          # Allow up to 10 failures with 30 second restarts in a 15 minute window
+          # before entering failure state and alerting
+          startLimitBurst = 10;
+          startLimitIntervalSec = 900;
 
           environment = {
             CONFIG_FILE = cfg.configFile;

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -36,6 +36,7 @@
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-smash-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.domain
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.environmentName
+#   flake.cardano-parts.cluster.groups.<default|name>.pkgs.blockperf
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-cli
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-db-sync
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-db-sync-pkgs
@@ -411,6 +412,12 @@ flake @ {
 
   pkgsSubmodule = submodule {
     options = {
+      blockperf = mkOption {
+        type = functionTo package;
+        description = mdDoc "Cardano-parts cluster group default blockperf package.";
+        default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.blockperf);
+      };
+
       cardano-cli = mkOption {
         type = functionTo package;
         description = mdDoc "Cardano-parts cluster group default cardano-cli package.";

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -374,7 +374,7 @@ in
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
             (mkPkg "bech32" caPkgs.bech32-input-output-hk-cardano-node-8-7-3)
-            (mkPkg "blockperf" localFlake.inputs.blockperf.packages.${system}.blockperf)
+            (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2023-07-18)
             (mkPkg "cardano-cli" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-3 // {version = "8.17.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-3 // {version = "8.17.0.0";}))

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -19,6 +19,7 @@
 #   flake.cardano-parts.pkgs.special.cardano-smash-service
 #   perSystem.cardano-parts.pkgs.bech32
 #   perSystem.cardano-parts.pkgs.cardano-address
+#   perSystem.cardano-parts.pkgs.blockperf
 #   perSystem.cardano-parts.pkgs.cardano-cli
 #   perSystem.cardano-parts.pkgs.cardano-cli-ng
 #   perSystem.cardano-parts.pkgs.cardano-db-sync
@@ -373,6 +374,7 @@ in
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
             (mkPkg "bech32" caPkgs.bech32-input-output-hk-cardano-node-8-7-3)
+            (mkPkg "blockperf" localFlake.inputs.blockperf.packages.${system}.blockperf)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2023-07-18)
             (mkPkg "cardano-cli" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-3 // {version = "8.17.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs.cardano-cli-input-output-hk-cardano-node-8-7-3 // {version = "8.17.0.0";}))
@@ -422,6 +424,7 @@ in
             inherit
               (cfgPkgs)
               bech32
+              blockperf
               cardano-address
               cardano-cli
               cardano-db-sync


### PR DESCRIPTION
Overview:
* Adds a block performance module which utilizes cardano-foundation's [blockperf](https://github.com/cardano-foundation/blockperf) for aggregate block propagation reporting.

Details:
* Adds blockperf pkg and nixosModule (profile-blockperf)
* Adds a blockperf masked ip/dns option
* Tunes systemd services for retry interval, restart frequency and interval limit
* Update template just recipes with bash default error handling and fixes save-ssh-config