### PR TITLE
Mithril client

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -674,16 +674,15 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1706570118,
+        "lastModified": 1706839868,
         "narHash": "sha256-pCWqkQpdIHb6dy0/QJogLhR9U2UD0OWUabRHFnU4DsM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f644332bb7818a59eb4fc0210c066c31f1f0ef0f",
+        "rev": "7f7e3a456cdf8569e66f73c6a067678d51585992",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "mithril-client",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -696,16 +695,15 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1706570118,
+        "lastModified": 1706839868,
         "narHash": "sha256-pCWqkQpdIHb6dy0/QJogLhR9U2UD0OWUabRHFnU4DsM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f644332bb7818a59eb4fc0210c066c31f1f0ef0f",
+        "rev": "7f7e3a456cdf8569e66f73c6a067678d51585992",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "mithril-client",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -674,15 +674,16 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1702057058,
-        "narHash": "sha256-+0RP5JWOt56+rFgh5k1fggmDfm3i0L1LfUOf/mhrUz8=",
+        "lastModified": 1706570118,
+        "narHash": "sha256-pCWqkQpdIHb6dy0/QJogLhR9U2UD0OWUabRHFnU4DsM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "fbae4705ec10ed056146956f9ca94fac3a169c69",
+        "rev": "f644332bb7818a59eb4fc0210c066c31f1f0ef0f",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "mithril-client",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -695,15 +696,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1702057058,
-        "narHash": "sha256-+0RP5JWOt56+rFgh5k1fggmDfm3i0L1LfUOf/mhrUz8=",
+        "lastModified": 1706570118,
+        "narHash": "sha256-pCWqkQpdIHb6dy0/QJogLhR9U2UD0OWUabRHFnU4DsM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "fbae4705ec10ed056146956f9ca94fac3a169c69",
+        "rev": "f644332bb7818a59eb4fc0210c066c31f1f0ef0f",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "mithril-client",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,8 @@
     capkgs.url = "github:input-output-hk/capkgs";
     empty-flake.url = "github:input-output-hk/empty-flake";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
-    iohk-nix.url = "github:input-output-hk/iohk-nix/mithril-client";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/mithril-client";
+    iohk-nix.url = "github:input-output-hk/iohk-nix";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
 
     # Cardano related inputs required for service config
     # Services offered from the nixosModules of this repo are directly assigned to

--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,8 @@
     capkgs.url = "github:input-output-hk/capkgs";
     empty-flake.url = "github:input-output-hk/empty-flake";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
-    iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
+    iohk-nix.url = "github:input-output-hk/iohk-nix/mithril-client";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/mithril-client";
 
     # Cardano related inputs required for service config
     # Services offered from the nixosModules of this repo are directly assigned to

--- a/flake/nixosModules/module-cardano-parts.nix
+++ b/flake/nixosModules/module-cardano-parts.nix
@@ -29,6 +29,8 @@
 #   config.cardano-parts.perNode.pkgs.cardano-node-pkgs
 #   config.cardano-parts.perNode.pkgs.cardano-smash
 #   config.cardano-parts.perNode.pkgs.cardano-submit-api
+#   config.cardano-parts.perNode.pkgs.mithril-client-cli
+#   config.cardano-parts.perNode.pkgs.mithril-signer
 #   config.cardano-parts.perNode.roles.isCardanoDensePool
 flake @ {moduleWithSystem, ...}: {
   flake.nixosModules.module-cardano-parts = moduleWithSystem ({system}: {
@@ -205,6 +207,8 @@ flake @ {moduleWithSystem, ...}: {
         (mkPkgOpt "cardano-node" (cfg.group.pkgs.cardano-node system))
         (mkPkgOpt "cardano-smash" (cfg.group.pkgs.cardano-smash system))
         (mkPkgOpt "cardano-submit-api" (cfg.group.pkgs.cardano-submit-api system))
+        (mkPkgOpt "mithril-client-cli" (cfg.group.pkgs.mithril-client-cli system))
+        (mkPkgOpt "mithril-signer" (cfg.group.pkgs.mithril-signer system))
         (mkSpecialOpt "cardano-db-sync-pkgs" lib.types.attrs (cfg.group.pkgs.cardano-db-sync-pkgs system))
         (mkSpecialOpt "cardano-metadata-pkgs" lib.types.attrs (cfg.group.pkgs.cardano-metadata-pkgs system))
         (mkSpecialOpt "cardano-node-pkgs" (attrsOf anything) (cfg.group.pkgs.cardano-node-pkgs system))

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -71,7 +71,7 @@
       services.cardano-node = {
         enableMithrilClient = mkOption {
           type = bool;
-          default = cfg.environments.${environmentName} ? mithrilAggregatorEndpointUrl;
+          default = cfg.environments.${environmentName} ? mithrilAggregatorEndpointUrl && environmentName != "mainnet";
           description = "Allow mithril-client to bootstrap cardano-node chain state.";
         };
 

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -3,9 +3,13 @@
 # TODO: Move this to a docs generator
 #
 # Attributes available on nixos module import:
+#   config.services.cardano-node.enableMithrilClient
+#   config.services.cardano-node.mithrilAggregatorEndpointUrl
+#   config.services.cardano-node.mithrilGenesisVerificationKey
+#   config.services.cardano-node.mithrilSnapshotDigest
 #   config.services.cardano-node.shareIpv6Address
-#   config.services.cardano-node.totalMaxHeapSizeMiB
 #   config.services.cardano-node.totalCpuCores
+#   config.services.cardano-node.totalMaxHeapSizeMiB
 #
 # Tips:
 #   * This is a cardano-node add-on to the upstream cardano-node nixos service module

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -24,14 +24,14 @@
     ...
   }: let
     inherit (builtins) fromJSON readFile;
-    inherit (lib) flatten foldl' getExe min mkDefault mkIf mkOption range recursiveUpdate types;
-    inherit (types) bool float ints oneOf;
+    inherit (lib) flatten foldl' getExe min mkDefault mkIf mkOption optionalString range recursiveUpdate types;
+    inherit (types) bool float ints oneOf str;
     inherit (nodeResources) cpuCount memMiB;
 
     inherit (nixos.config.cardano-parts.cluster.group.meta) environmentName;
     inherit (nixos.config.cardano-parts.perNode.lib) cardanoLib;
     inherit (nixos.config.cardano-parts.perNode.meta) cardanoNodePort cardanoNodePrometheusExporterPort hostAddr nodeId;
-    inherit (nixos.config.cardano-parts.perNode.pkgs) cardano-node cardano-node-pkgs;
+    inherit (nixos.config.cardano-parts.perNode.pkgs) cardano-node cardano-node-pkgs mithril-client-cli;
     inherit (cardanoLib) mkEdgeTopology mkEdgeTopologyP2P;
     inherit (cardanoLib.environments.${environmentName}.nodeConfig) ByronGenesisFile ShelleyGenesisFile;
     inherit ((fromJSON (readFile ByronGenesisFile)).protocolConsts) protocolMagic;
@@ -69,14 +69,28 @@
 
     options = {
       services.cardano-node = {
-        totalMaxHeapSizeMiB = mkOption {
-          type = oneOf [ints.positive float];
-          default = memMiB * 0.790;
+        enableMithrilClient = mkOption {
+          type = bool;
+          default = cfg.environments.${environmentName} ? mithrilAggregatorEndpointUrl;
+          description = "Allow mithril-client to bootstrap cardano-node chain state.";
         };
 
-        totalCpuCount = mkOption {
-          type = ints.positive;
-          default = min cpuCount (2 * cfg.instances);
+        mithrilAggregatorEndpointUrl = mkOption {
+          type = str;
+          default = cfg.environments.${environmentName}.mithrilAggregatorEndpointUrl or "";
+          description = "The mithril aggregator endpoint url.";
+        };
+
+        mithrilGenesisVerificationKey = mkOption {
+          type = str;
+          default = cfg.environments.${environmentName}.mithrilGenesisVerificationKey or "";
+          description = "The mithril genesis verification key.";
+        };
+
+        mithrilSnapshotDigest = mkOption {
+          type = str;
+          default = "latest";
+          description = "The mithril snapshot digest id or `latest` for the most recently taken snapshot.";
         };
 
         shareIpv6Address = mkOption {
@@ -97,6 +111,16 @@
             This is done using an inotifywait service to avoid long systemd job startups using postStart.
           '';
         };
+
+        totalCpuCount = mkOption {
+          type = ints.positive;
+          default = min cpuCount (2 * cfg.instances);
+        };
+
+        totalMaxHeapSizeMiB = mkOption {
+          type = oneOf [ints.positive float];
+          default = memMiB * 0.790;
+        };
       };
     };
 
@@ -110,6 +134,7 @@
         self'.packages.db-analyser-ng
         self'.packages.db-synthesizer-ng
         self'.packages.db-truncater-ng
+        mithril-client-cli
       ];
 
       environment = {
@@ -134,6 +159,8 @@
           CARDANO_NODE_SNAPSHOT_URL = mkIf (environmentName == "mainnet") "https://update-cardano-mainnet.iohk.io/cardano-node-state/db-mainnet.tar.gz";
           CARDANO_NODE_SNAPSHOT_SHA256_URL = mkIf (environmentName == "mainnet") "https://update-cardano-mainnet.iohk.io/cardano-node-state/db-mainnet.tar.gz.sha256sum";
           CARDANO_NODE_SOCKET_PATH = cfg.socketPath 0;
+          AGGREGATOR_ENDPOINT = mkIf cfg.enableMithrilClient cfg.mithrilAggregatorEndpointUrl;
+          GENESIS_VERIFICATION_KEY = mkIf cfg.enableMithrilClient cfg.mithrilGenesisVerificationKey;
           TESTNET_MAGIC = toString protocolMagic;
         };
       };
@@ -274,18 +301,51 @@
         // foldl' (acc: i:
           recursiveUpdate acc {
             "${serviceName i}" = {
-              path = with pkgs; [gnutar gzip];
-
-              preStart = ''
-                cd $STATE_DIRECTORY
-                if [ -f db-restore.tar.gz ]; then
-                  rm -rf db-${environmentName}*
-                  tar xzf db-restore.tar.gz
-                  rm db-restore.tar.gz
-                fi
-              '';
-
               serviceConfig = {
+                ExecStartPre = getExe (pkgs.writeShellApplication {
+                  name = "cardano-node-pre-start";
+                  runtimeInputs = with pkgs; [gnutar gzip];
+                  text = let
+                    mithril-client-bootstrap = optionalString cfg.enableMithrilClient ''
+                      TMPSTATE="''${DB_DIR}-mithril"
+                      rm -rf "$TMPSTATE"
+                      if ! [ -d "$DB_DIR" ]; then
+                        echo "Bootstrapping cardano-node-${toString i} state from mithril"
+                        ${getExe mithril-client-cli} \
+                          -vvv \
+                          --aggregator-endpoint "${cfg.mithrilAggregatorEndpointUrl}" \
+                          snapshot \
+                          download \
+                          "${cfg.mithrilSnapshotDigest}" \
+                          --download-dir "$TMPSTATE" \
+                          --genesis-verification-key "${cfg.mithrilGenesisVerificationKey}"
+                        mv "$TMPSTATE/db" "$DB_DIR"
+                        rm -rf "$TMPSTATE"
+                        echo "Mithril bootstrap complete for $DB_DIR"
+                      fi
+                    '';
+                  in ''
+                    INSTANCE="${toString i}"
+                    DB_DIR="${
+                      if i == 0
+                      then "db-${environmentName}"
+                      else "db-${environmentName}-${toString i}"
+                    }"
+                    cd "$STATE_DIRECTORY"
+
+                    # Legacy: if a db-restore.tar.gz file exists, use it to replace state of the first node instance
+                    if [ -f db-restore.tar.gz ] && [ "$INSTANCE" == "0" ]; then
+                      echo "Restoring database from db-restore.tar.gz to $DB_DIR"
+                      rm -rf "$DB_DIR"
+                      tar xzf db-restore.tar.gz
+                      rm db-restore.tar.gz
+                    fi
+
+                    # Mithril-client bootstrap code will follow if nixos option service.cardano-node.enableMithrilClient is true
+                    ${mithril-client-bootstrap}
+                  '';
+                });
+
                 # Allow long ledger replays and/or db-restore gunzip, including on slow systems
                 TimeoutStartSec = "infinity";
               };

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -47,6 +47,8 @@
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-node-pkgs
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-smash
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-submit-api
+#   flake.cardano-parts.cluster.groups.<default|name>.pkgs.mithril-client-cli
+#   flake.cardano-parts.cluster.groups.<default|name>.pkgs.signer
 #
 # Tips:
 #   * flake level attrs are accessed from flake level at [config.]flake.cardano-parts.cluster.<...>
@@ -488,6 +490,18 @@ flake @ {
         type = functionTo package;
         description = mdDoc "Cardano-parts cluster group default cardano-submit-api package.";
         default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-submit-api);
+      };
+
+      mithril-client-cli = mkOption {
+        type = functionTo package;
+        description = mdDoc "Cardano-parts cluster group default mithril-client-cli package.";
+        default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.mithril-client-cli);
+      };
+
+      mithril-signer = mkOption {
+        type = functionTo package;
+        description = mdDoc "Cardano-parts cluster group default mithril-signer package.";
+        default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.mithril-signer);
       };
     };
   };

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -1,187 +1,156 @@
-flake @ {
-  flake-parts-lib,
-  lib,
-  ...
-}: let
+flake @ {flake-parts-lib, ...}: let
   inherit (flake-parts-lib) mkPerSystemOption;
-in
-  with lib; {
-    options = {
-      perSystem = mkPerSystemOption ({
-        config,
-        pkgs,
-        system,
-        ...
-      }: let
-        cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLib system;
-        cardanoLibNg = flake.config.flake.cardano-parts.pkgs.special.cardanoLibNg system;
-        opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
+in {
+  options = {
+    perSystem = mkPerSystemOption ({
+      config,
+      lib,
+      pkgs,
+      system,
+      ...
+    }: let
+      inherit (builtins) attrNames;
+      inherit (lib) boolToString concatStringsSep escapeShellArgs getExe;
+      inherit (opsLib) generateStaticHTMLConfigs;
 
-        inherit (opsLib) generateStaticHTMLConfigs;
+      cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLib system;
+      cardanoLibNg = flake.config.flake.cardano-parts.pkgs.special.cardanoLibNg system;
+      opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
 
-        cfgPkgs = config.cardano-parts.pkgs;
+      cfgPkgs = config.cardano-parts.pkgs;
 
-        # Copy the environment configs from iohk-nix into our jobs at runtime
-        copyEnvsTemplate = environments: let
-          envCfgs = generateStaticHTMLConfigs pkgs cardanoLib environments;
-        in ''
-          # DATA_DIR is a runtime entrypoint env var which will contain the cp target
-          mkdir -p "$DATA_DIR/config"
+      # Copy the environment configs from iohk-nix into our jobs at runtime
+      copyEnvsTemplate = environments: let
+        envCfgs = generateStaticHTMLConfigs pkgs cardanoLib environments;
+      in ''
+        # Prepare standard env configs
+        ENVS=(${escapeShellArgs (attrNames environments)})
+        for ENV in "''${ENVS[@]}"; do
+          cp -r "${envCfgs}/config/$ENV" "$DATA_DIR/config/"
+        done
 
-          ENVS=(${pkgs.lib.escapeShellArgs (builtins.attrNames environments)})
-          for ENV in "''${ENVS[@]}"; do
-            cp -r "${envCfgs}/config/$ENV" "$DATA_DIR/config/"
-          done
-        '';
+        # Prepare mithril client env configs
+        ${
+          concatStringsSep "\n"
+          (
+            map (
+              env:
+                "declare -A MITHRIL_CFG_${env}\n"
+                + "MITHRIL_CFG_${env}[MITHRIL_ENV]=\"${boolToString (environments.${env} ? mithrilAggregatorEndpointUrl && env != "mainnet")}\"\n"
+                + "MITHRIL_CFG_${env}[AGG_ENDPOINT]=\"${environments.${env}.mithrilAggregatorEndpointUrl or ""}\"\n"
+                + "MITHRIL_CFG_${env}[GENESIS_VKEY]=\"${environments.${env}.mithrilGenesisVerificationKey or ""}\"\n"
+            )
+            (attrNames environments)
+          )
+        }
+      '';
+    in {
+      # perSystem level option definition
+      # options.cardano-parts = mkOption {
+      #   type = mainSubmodule;
+      # };
 
-        node-snapshots = {
-          # https://update-cardano-mainnet.iohk.io/cardano-node-state/index.html#
-          mainnet = {
-            base_url = "https://update-cardano-mainnet.iohk.io/cardano-node-state";
-            file_name = "db-mainnet.tar.gz";
-          };
-        };
-      in {
-        # perSystem level option definition
-        # options.cardano-parts = mkOption {
-        #   type = mainSubmodule;
-        # };
+      config = {
+        # Make entrypoints
+        packages.run-cardano-node = pkgs.writeShellApplication {
+          name = "run-cardano-node";
+          runtimeInputs = [pkgs.jq];
+          excludeShellChecks = ["SC2034"];
+          text = ''
+            [ -z "''${DATA_DIR:-}" ] && echo "DATA_DIR env var must be set -- aborting" && exit 1
 
-        config = {
-          # Make entrypoints
-          packages.run-cardano-node = pkgs.writeShellApplication {
-            name = "run-cardano-node";
-            runtimeInputs = [pkgs.jq];
-            text = ''
-              [ -z "''${DATA_DIR:-}" ] && echo "DATA_DIR env var must be set -- aborting" && exit 1
+            mkdir -p "$DATA_DIR/config/custom"
+            chmod -R +w "$DATA_DIR/config" "$DATA_DIR/config/custom"
 
-              mkdir -p "$DATA_DIR"
-              mkdir -p "$DATA_DIR/config"
-              chmod -R +w "$DATA_DIR/config"
-              mkdir -p "$DATA_DIR/config/custom"
-              chmod -R +w "$DATA_DIR/config/custom"
+            # The menu of environments that we ship as built-in envs
+            if [ "''${UNSTABLE_LIB:-}" = "true" ]; then
+              echo "Preparing environments using cardanoLibNg"
+              ${copyEnvsTemplate cardanoLibNg.environments}
+            else
+              echo "Preparing environments using cardanoLib"
+              ${copyEnvsTemplate cardanoLib.environments}
+            fi
 
-              # The menu of environments that we ship as built-in envs
-              if [ "''${UNSTABLE_LIB:-}" = "true" ]; then
-                ${copyEnvsTemplate cardanoLibNg.environments}
-              else
-                ${copyEnvsTemplate cardanoLib.environments}
-              fi
+            if [ -n "''${ENVIRONMENT:-}" ]; then
+              echo "Using the preset environment $ENVIRONMENT ..." >&2
 
-              # CASE: built-in environment
-              if [ -n "''${ENVIRONMENT:-}" ]; then
-                echo "Using the preset environment $ENVIRONMENT ..." >&2
+              # Subst hyphen for underscore as iohk-nix envs historically use the former
+              NODE_CONFIG="$DATA_DIR/config/''${ENVIRONMENT/-/_}/config.json"
+              NODE_TOPOLOGY="''${NODE_TOPOLOGY:-$DATA_DIR/config/''${ENVIRONMENT/-/_}/topology.json}"
+            else
+              [ -z "''${NODE_CONFIG:-}" ] && echo "NODE_CONFIG env var must be set for custom config -- aborting" && exit 1
+              echo "Using custom config: $NODE_CONFIG ..." >&2
+            fi
 
-                # Subst hyphen for underscore as iohk-nix envs historically use the former while cardano-world uses the later
-                NODE_CONFIG="$DATA_DIR/config/''${ENVIRONMENT/-/_}/config.json"
-                NODE_TOPOLOGY="''${NODE_TOPOLOGY:-$DATA_DIR/config/''${ENVIRONMENT/-/_}/topology.json}"
-              else
-                echo "Using custom config: $NODE_CONFIG ..." >&2
+            DB_DIR="$DATA_DIR/db-''${ENVIRONMENT:-custom}"
+            if [ -z "''${MITHRIL_DISABLE:-}" ] && [ "''${ENVIRONMENT:-custom}" != "custom" ]; then
 
-                [ -z "''${NODE_CONFIG:-}" ] && echo "NODE_CONFIG env var must be set -- aborting" && exit 1
-              fi
-
-              DB_DIR="$DATA_DIR/db-''${ENVIRONMENT:-custom}"
-              function pull_snapshot {
-                [ -z "''${SNAPSHOT_BASE_URL:-}" ] && echo "SNAPSHOT_BASE_URL env var must be set -- aborting" && exit 1
-                [ -z "''${SNAPSHOT_FILE_NAME:-}" ] && echo "SNAPSHOT_FILE_NAME env var must be set -- aborting" && exit 1
-                [ -z "''${DATA_DIR:-}" ] && echo "DATA_DIR env var must be set -- aborting" && exit 1
-
-                SNAPSHOT_DIR="$DATA_DIR/initial-snapshot"
-                mkdir -p "$SNAPSHOT_DIR"
-
-                # We are already initialized
-                [ -s "$SNAPSHOT_DIR/$SNAPSHOT_FILE_NAME.sha256sum" ] && INITIALIZED="true" && return
-
-                # shellcheck source=/dev/null
-                source ${pkgs.cacert}/nix-support/setup-hook
-                echo "Downloading $SNAPSHOT_BASE_URL/$SNAPSHOT_FILE_NAME into $SNAPSHOT_DIR ..." >&2
-                if curl -fL "$SNAPSHOT_BASE_URL/$SNAPSHOT_FILE_NAME" --output "$SNAPSHOT_DIR/$SNAPSHOT_FILE_NAME"; then
-                  echo "Downloading $SNAPSHOT_BASE_URL/$SNAPSHOT_FILE_NAME.sha256sum into $SNAPSHOT_DIR ..." >&2
-                  if curl -fL "$SNAPSHOT_BASE_URL/$SNAPSHOT_FILE_NAME.sha256sum" --output "$SNAPSHOT_DIR/$SNAPSHOT_FILE_NAME.sha256sum"; then
-                    echo -n "pushd: " >&2
-                    pushd "$SNAPSHOT_DIR" >&2
-                    echo "Validating sha256sum for ./$SNAPSHOT_FILE_NAME." >&2
-                    if sha256sum -c "$SNAPSHOT_FILE_NAME.sha256sum" >&2; then
-                      echo "Downloading $SNAPSHOT_BASE_URL/$SNAPSHOT_FILE_NAME{,.sha256sum} into $SNAPSHOT_DIR complete." >&2
-                    else
-                      echo "Could retrieve snapshot, but could not validate its checksum -- aborting" && exit 1
-                    fi
-                    echo -n "popd: " >&2
-                    popd >&2
-                  else
-                    echo "Could retrieve snapshot, but not its sha256 file -- aborting" && exit 1
-                  fi
-                else
-                  echo "No snapshot pulled -- aborting" && exit 1
-                fi
+              # Use an indirect reference to access the runtime environment associative mithril config array
+              mithrilAttr() {
+                declare -n POINTER="MITHRIL_CFG_''${1/-/_}"
+                echo "''${POINTER[$2]}"
               }
 
-              function extract_snapshot_tgz_to {
-                local TARGETDIR="$1"
-                local STRIP="''${2:-0}"
-                mkdir -p "$TARGETDIR"
-
-                [ -n "''${INITIALIZED:-}" ] && return
-
-                echo "Extracting snapshot to $TARGETDIR ..." >&2
-                if tar --strip-components="$STRIP" -C "$TARGETDIR" -zxf "$SNAPSHOT_DIR/$SNAPSHOT_FILE_NAME"; then
-                  echo "Extracting snapshot to $TARGETDIR complete." >&2
-                else
-                  echo "Extracting snapshot to $TARGETDIR failed -- aborting" && exit 1
+              if [ "$(mithrilAttr "$ENVIRONMENT" "MITHRIL_ENV")" == "true" ]; then
+                MITHRIL_CLIENT="${cfgPkgs.mithril-client-cli}/bin/mithril-client"
+                TMPSTATE="''${DB_DIR}/node-mithril"
+                rm -rf "$TMPSTATE"
+                if ! [ -d "$DB_DIR/node" ]; then
+                  echo "Bootstrapping cardano-node state from mithril"
+                  echo "To disable mithril syncing, set MITHRIL_DISABLE env var"
+                  "$MITHRIL_CLIENT" \
+                    -vvv \
+                    --aggregator-endpoint "$(mithrilAttr "$ENVIRONMENT" "AGG_ENDPOINT")" \
+                    snapshot \
+                    download \
+                    "latest" \
+                    --download-dir "$TMPSTATE" \
+                    --genesis-verification-key "$(mithrilAttr "$ENVIRONMENT" "GENESIS_VKEY")"
+                  mv "$TMPSTATE/db" "$DB_DIR/node"
+                  rm -rf "$TMPSTATE"
+                  echo "Mithril bootstrap complete for $DB_DIR/node"
                 fi
-              }
-
-              if [ -n "''${ENVIRONMENT:-}" ] && [ -n "''${USE_SNAPSHOT:-}" ]; then
-                # We are using a standard environment that already has known snapshots
-                SNAPSHOTS="${builtins.toFile "snapshots.json" (builtins.toJSON node-snapshots)}"
-                SNAPSHOT_BASE_URL="$(jq -e -r --arg CARDENV "$ENVIRONMENT" '.[$CARDENV].base_url' < "$SNAPSHOTS")"
-                SNAPSHOT_FILE_NAME="$(jq -e -r --arg CARDENV "$ENVIRONMENT" '.[$CARDENV].file_name' < "$SNAPSHOTS")"
               fi
+            fi
 
-              if [ -n "''${SNAPSHOT_BASE_URL:-}" ]; then
-                pull_snapshot
-                extract_snapshot_tgz_to "$DB_DIR/node" 1
-              fi
+            # Build args array
+            args+=("--config" "$NODE_CONFIG")
+            args+=("--database-path" "$DB_DIR/node")
+            [ -n "''${HOST_ADDR:-}" ] && args+=("--host-addr" "$HOST_ADDR")
+            [ -n "''${HOST_IPV6_ADDR:-}" ] && args+=("--host-ipv6-addr" "$HOST_IPV6_ADDR")
+            [ -n "''${PORT:-}" ] && args+=("--port" "$PORT")
+            [ -n "''${SOCKET_PATH:-}" ] && args+=("--socket-path" "$SOCKET_PATH")
 
-              # Build args array
-              args+=("--config" "$NODE_CONFIG")
-              args+=("--database-path" "$DB_DIR/node")
-              [ -n "''${HOST_ADDR:-}" ] && args+=("--host-addr" "$HOST_ADDR")
-              [ -n "''${HOST_IPV6_ADDR:-}" ] && args+=("--host-ipv6-addr" "$HOST_IPV6_ADDR")
-              [ -n "''${PORT:-}" ] && args+=("--port" "$PORT")
-              [ -n "''${SOCKET_PATH:-}" ] && args+=("--socket-path" "$SOCKET_PATH")
+            # If RTS flags are present, eval the RTS flag string for runtime dependency calcs,
+            # and convert the output to an arg array for inclusion in node args if non-empty.
+            if [ -n "''${RTS_FLAGS:-}" ]; then
+              RTS_FLAGS=$(eval echo -n "$RTS_FLAGS")
+              read -r -a RTS_FLAGS <<< "$RTS_FLAGS"
+            fi
 
-              # If RTS flags are present, eval the RTS flag string for runtime dependency calcs,
-              # and convert the output to an arg array for inclusion in node args if non-empty.
-              if [ -n "''${RTS_FLAGS:-}" ]; then
-                RTS_FLAGS=$(eval echo -n "$RTS_FLAGS")
-                read -r -a RTS_FLAGS <<< "$RTS_FLAGS"
-              fi
+            [ -n "''${BYRON_DELEG_CERT:-}" ] && args+=("--byron-delegation-certificate" "$BYRON_DELEG_CERT")
+            [ -n "''${BYRON_SIGNING_KEY:-}" ] && args+=("--byron-signing-key" "$BYRON_SIGNING_KEY")
+            [ -n "''${SHELLEY_KES_KEY:-}" ] && args+=("--shelley-kes-key" "$SHELLEY_KES_KEY")
+            [ -n "''${SHELLEY_VRF_KEY:-}" ] && args+=("--shelley-vrf-key" "$SHELLEY_VRF_KEY")
+            [ -n "''${SHELLEY_OPCERT:-}" ] && args+=("--shelley-operational-certificate" "$SHELLEY_OPCERT")
+            [ -n "''${BULK_CREDS:-}" ] && args+=("--bulk-credentials-file" "$BULK_CREDS")
 
-              [ -n "''${BYRON_DELEG_CERT:-}" ] && args+=("--byron-delegation-certificate" "$BYRON_DELEG_CERT")
-              [ -n "''${BYRON_SIGNING_KEY:-}" ] && args+=("--byron-signing-key" "$BYRON_SIGNING_KEY")
-              [ -n "''${SHELLEY_KES_KEY:-}" ] && args+=("--shelley-kes-key" "$SHELLEY_KES_KEY")
-              [ -n "''${SHELLEY_VRF_KEY:-}" ] && args+=("--shelley-vrf-key" "$SHELLEY_VRF_KEY")
-              [ -n "''${SHELLEY_OPCERT:-}" ] && args+=("--shelley-operational-certificate" "$SHELLEY_OPCERT")
-              [ -n "''${BULK_CREDS:-}" ] && args+=("--bulk-credentials-file" "$BULK_CREDS")
-
-              [ -z "''${NODE_TOPOLOGY:-}" ] && echo "NODE_TOPOLOGY env var must be set -- aborting" && exit 1
-              args+=("--topology" "$NODE_TOPOLOGY")
-              echo "Running node as:"
-              if [ "''${USE_SHELL_BINS:-}" = "true" ]; then
-                echo "cardano-node run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
-                exec cardano-node run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
-              elif [ "''${UNSTABLE:-}" = "true" ]; then
-                echo "${lib.getExe cfgPkgs.cardano-node-ng} run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
-                exec ${lib.getExe cfgPkgs.cardano-node-ng} run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
-              else
-                echo "${lib.getExe cfgPkgs.cardano-node} run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
-                exec ${lib.getExe cfgPkgs.cardano-node} run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
-              fi
-            '';
-          };
+            [ -z "''${NODE_TOPOLOGY:-}" ] && echo "NODE_TOPOLOGY env var must be set -- aborting" && exit 1
+            args+=("--topology" "$NODE_TOPOLOGY")
+            echo "Running node as:"
+            if [ "''${USE_SHELL_BINS:-}" = "true" ]; then
+              echo "cardano-node run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
+              exec cardano-node run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
+            elif [ "''${UNSTABLE:-}" = "true" ]; then
+              echo "${getExe cfgPkgs.cardano-node-ng} run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
+              exec ${getExe cfgPkgs.cardano-node-ng} run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
+            else
+              echo "${getExe cfgPkgs.cardano-node} run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
+              exec ${getExe cfgPkgs.cardano-node} run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
+            fi
+          '';
         };
-      });
-    };
-  }
+      };
+    });
+  };
+}

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -42,6 +42,8 @@
 #   perSystem.cardano-parts.pkgs.metadata-sync
 #   perSystem.cardano-parts.pkgs.metadata-validator-github
 #   perSystem.cardano-parts.pkgs.metadata-webhook
+#   perSystem.cardano-parts.pkgs.mithril-client-cli
+#   perSystem.cardano-parts.pkgs.mithril-signer
 #   perSystem.cardano-parts.pkgs.token-metadata-creator
 #
 # Tips:
@@ -407,6 +409,8 @@ in
             (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0)
             (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0)
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0)
+            (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2403-1-pre {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2403-1-pre {meta.mainProgram = "mithril-signer";}))
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0 {meta.mainProgram = "token-metadata-creator";}))
           ];
         };
@@ -443,6 +447,8 @@ in
               metadata-sync
               metadata-validator-github
               metadata-webhook
+              mithril-client-cli
+              mithril-signer
               token-metadata-creator
               ;
 

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -290,6 +290,7 @@ in
                         db-analyser
                         db-synthesizer
                         db-truncater
+                        mithril-client-cli
 
                         # The packages derivations of the `-ng` pkgs provide
                         # the wrapped binary to avoid cli name collision.

--- a/perSystem/process-compose/default.nix
+++ b/perSystem/process-compose/default.nix
@@ -323,7 +323,7 @@ flake @ {inputs, ...}: {
                 chmod 0600 "$PGPASSFILE"
 
                 ${config.cardano-parts.pkgs."cardano-db-sync${envVer env' "isDbsyncNg"}"}/bin/cardano-db-sync \
-                  --config ${envCfgs' env}/config/${env}/db-sync-config.json \
+                  --config ${envCfgs' env'}/config/${env}/db-sync-config.json \
                   --socket-path ${stateDir}/${env'}/cardano-node/node.socket \
                   --state-dir ${stateDir}/${env'}/cardano-db-sync/ledger-state \
                   --schema-dir ${flake.config.flake.cardano-parts.pkgs.special."cardano-db-sync-schema${envVer env' "isDbsyncNg"}"}


### PR DESCRIPTION
# Overview:
* Adds a [mithril](https://github.com/input-output-hk/mithril) client for nixosConfigurations, process-compose cardano-node processes and cardano-node entrypoint

# Details:
* Adds a mithril client and signer packages, iohk-nix mithril input
* Adds a cardano-node mithril client for nixosConfigurations using `profile-cardano-node-group` nixosModule
* Adds a process-compose cardano-node mithril client
* Adds a cardano-node entrypoint mithril client, replacing the prior snapshot entrypoint functionality

# Default Mithril Behavior:
* Mithril client will bootstrap automatically on preview and preprod environments
* Mithril client for mainnet is expected to be enabled in the near future
* nixosConfigurations can disable mithril bootstrapping with the `config.services.cardano-node.enableMithrilClient` option
* process-compose can disable mithril bootstrapping with the `MITHRIL_DISABLE` or `MITHRIL_DISABLE_$ENV` env vars
* cardano-node entrypoint can disable mithril bootstrapping with the `MITHRIL_DISABLE` env var