### PR TITLE
Grafana alloy migration and misc updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1154,11 +1154,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1727266098,
-        "narHash": "sha256-AHTKbJ9ffR7Nx+XcR2XP0AYLI4OlUh2IGh4SAkdG5Ig=",
+        "lastModified": 1728538411,
+        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4f31540079322e6013930b5b2563fd10f96917f0",
+        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -241,16 +241,16 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1721843629,
-        "narHash": "sha256-F5wgRA820x16f+8c/LlEEBG0rMJIA1XWw6X0ZwX5UWs=",
+        "lastModified": 1728686091,
+        "narHash": "sha256-gc4P+THcnnOEP34az+NncS97ETVlSTbZ/58bAYd2oec=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "176f99e51155cb3eaa0711db1c3c969d67438958",
+        "rev": "6cfedc9ada83f614b86833b6f3530d87f545e95c",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.1.0",
+        "ref": "jl/mn-relays-new",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -258,16 +258,16 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1721843629,
-        "narHash": "sha256-F5wgRA820x16f+8c/LlEEBG0rMJIA1XWw6X0ZwX5UWs=",
+        "lastModified": 1728686091,
+        "narHash": "sha256-gc4P+THcnnOEP34az+NncS97ETVlSTbZ/58bAYd2oec=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "176f99e51155cb3eaa0711db1c3c969d67438958",
+        "rev": "6cfedc9ada83f614b86833b6f3530d87f545e95c",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "9.1.0",
+        "ref": "jl/mn-relays-new",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -776,11 +776,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1721825987,
-        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
+        "lastModified": 1728687575,
+        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
+        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
         "type": "github"
       },
       "original": {
@@ -797,11 +797,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1721825987,
-        "narHash": "sha256-PPcma4tjozwXJAWf+YtHUQUulmxwulVlwSQzKItx/n8=",
+        "lastModified": 1728687575,
+        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "eb61f2c14e1f610ec59117ad40f8690cddbf80cb",
+        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1727968530,
-        "narHash": "sha256-40vaqMh09VmQo4hBOVjId82U7ASUOmMNR7aGGZbVwdQ=",
+        "lastModified": 1728397354,
+        "narHash": "sha256-5AB7mRXKMGDgrR0mbSnQsdBdR6ZwhpMDqYHInxuWC/U=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "cc9373555eb2dd13791adc7128b6869241d33c36",
+        "rev": "427ccc70c7adcb3dec72bb9f8fd55898e13b931a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -58,12 +58,12 @@
     };
 
     cardano-node-service = {
-      url = "github:IntersectMBO/cardano-node/9.1.0";
+      url = "github:IntersectMBO/cardano-node/jl/mn-relays-new";
       flake = false;
     };
 
     cardano-node-service-ng = {
-      url = "github:IntersectMBO/cardano-node/9.1.0";
+      url = "github:IntersectMBO/cardano-node/jl/mn-relays-new";
       flake = false;
     };
 

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -316,12 +316,7 @@
           if
             (cfg.producers == [])
             && cfg.publicProducers == []
-            # The if can be dropped once a GA release is >= node 8.9.0 for `&& cfg.bootstrapPeers == null`
-            && (
-              if cfg ? bootstrapPeers
-              then cfg.bootstrapPeers == null
-              else true
-            )
+            && cfg.bootstrapPeers == null
             && (flatten (map cfg.instanceProducers iRange)) == []
             && (flatten (map cfg.instancePublicProducers iRange)) == []
           then mkTopology cardanoLib.environments.${environmentName}

--- a/flake/nixosModules/profile-cardano-node-topology.nix
+++ b/flake/nixosModules/profile-cardano-node-topology.nix
@@ -43,8 +43,7 @@
 
       topologyFns = with topologyLib; {
         edge =
-          # This can be simplified upon all machines deployed >= node 8.9.0
-          if cfgNode ? bootstrapPeers && cfgNode.bootstrapPeers != null
+          if cfgNode.bootstrapPeers != null
           then []
           else p2pEdgeNodes cfg.edgeNodes;
 
@@ -359,31 +358,26 @@
       };
 
       config = {
-        services.cardano-node =
-          {
-            extraNodeConfig = mkIf (cfg.role == "bp") roles.${cfg.role}.extraNodeConfig;
+        services.cardano-node = {
+          extraNodeConfig = mkIf (cfg.role == "bp") roles.${cfg.role}.extraNodeConfig;
 
-            producers = mkIf (cfg.role != null || cfg.enableProducers) (
-              if cfg.role != null
-              then verboseTrace "producers" (roles.${cfg.role}.producers ++ extraNodeListProducers ++ extraProducers)
-              else verboseTrace "producers" (topologyFns.${cfg.producerTopologyFn} ++ extraNodeListProducers ++ extraProducers)
-            );
+          bootstrapPeers = mkIf (cfg.role == "bp") null;
 
-            publicProducers = mkIf (cfg.role != null || cfg.enablePublicProducers) (
-              # Extra node list public producers and public producers for roles are included in the role defns due to selective mkForce use
-              if cfg.role != null
-              then verboseTrace "publicProducers" roles.${cfg.role}.publicProducers
-              else verboseTrace "publicProducers" (topologyFns.${cfg.publicProducerTopologyFn} ++ extraNodeListPublicProducers ++ extraPublicProducers)
-            );
+          producers = mkIf (cfg.role != null || cfg.enableProducers) (
+            if cfg.role != null
+            then verboseTrace "producers" (roles.${cfg.role}.producers ++ extraNodeListProducers ++ extraProducers)
+            else verboseTrace "producers" (topologyFns.${cfg.producerTopologyFn} ++ extraNodeListProducers ++ extraProducers)
+          );
 
-            usePeersFromLedgerAfterSlot = mkIf (cfg.role == "bp") roles.${cfg.role}.usePeersFromLedgerAfterSlot;
-          }
-          # This can be simplified upon all machines deployed >= node 8.9.0
-          // optionalAttrs (cfgNode ? bootstrapPeers) {
-            bootstrapPeers =
-              mkIf (cfg.role == "bp")
-              null;
-          };
+          publicProducers = mkIf (cfg.role != null || cfg.enablePublicProducers) (
+            # Extra node list public producers and public producers for roles are included in the role defns due to selective mkForce use
+            if cfg.role != null
+            then verboseTrace "publicProducers" roles.${cfg.role}.publicProducers
+            else verboseTrace "publicProducers" (topologyFns.${cfg.publicProducerTopologyFn} ++ extraNodeListPublicProducers ++ extraPublicProducers)
+          );
+
+          usePeersFromLedgerAfterSlot = mkIf (cfg.role == "bp") roles.${cfg.role}.usePeersFromLedgerAfterSlot;
+        };
       };
     };
 }

--- a/flake/nixosModules/profile-common.nix
+++ b/flake/nixosModules/profile-common.nix
@@ -28,6 +28,7 @@
       imports = [
         inputs.sops-nix.nixosModules.default
         inputs.auth-keys-hub.nixosModules.auth-keys-hub
+        (inputs.nixpkgs-unstable.outPath + "/nixos/modules/services/monitoring/alloy.nix")
       ];
 
       programs = {

--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -220,7 +220,7 @@ flake @ {moduleWithSystem, ...}: {
       };
 
       cardanoPartsComponentCfg = {
-        blockperf = concatStringsSep "\n" (optional (cfgSvc ? blockperf) ''
+        blockperf = optional (cfgSvc ? blockperf) ''
           // Blockperf integration component
           prometheus.scrape "integrations_blockperf" {
             targets = [{
@@ -229,14 +229,6 @@ flake @ {moduleWithSystem, ...}: {
             }]
             forward_to = [prometheus.relabel.integrations_blockperf.receiver]
             job_name = "integrations/blockperf"
-            params = {
-              format = ["prometheus"],
-              // Filtering here won't work as grafana-alloy encodes the
-              // pattern match. Filtering can be configured from the
-              // profile-cardano-custom-metrics nixosModule with the
-              // `enableFilter` and `filter` options.
-              // filter = ["statsd_cardano*"];
-            }
             metrics_path = "/"
 
             // Normally we prefer 1 minute default; however, we need
@@ -254,9 +246,9 @@ flake @ {moduleWithSystem, ...}: {
             }
           }
 
-        '');
+        '';
 
-        cardanoCustomMetrics = concatStringsSep "\n" (optional (cfgSvc ? cardano-custom-metrics && cfgSvc.netdata.enable) ''
+        cardanoCustomMetrics = optional (cfgSvc ? cardano-custom-metrics && cfgSvc.netdata.enable) ''
           // Cardano custom metrics integration component
           prometheus.scrape "integrations_cardano_custom_metrics" {
             targets = [{
@@ -276,9 +268,9 @@ flake @ {moduleWithSystem, ...}: {
             metrics_path = "/api/v1/allmetrics"
           }
 
-        '');
+        '';
 
-        cardanoDbSync = concatStringsSep "\n" (optional (cfgSvc ? cardano-db-sync && cfgSvc.cardano-db-sync.enable) ''
+        cardanoDbSync = optional (cfgSvc ? cardano-db-sync && cfgSvc.cardano-db-sync.enable) ''
           // Cardano-db-sync integration component
           prometheus.scrape "integrations_cardano_db_sync" {
             targets = [{
@@ -290,9 +282,9 @@ flake @ {moduleWithSystem, ...}: {
             metrics_path = "/"
           }
 
-        '');
+        '';
 
-        cardanoFaucet = concatStringsSep "\n" (optional (cfgSvc ? cardano-faucet && cfgSvc.cardano-faucet.enable) ''
+        cardanoFaucet = optional (cfgSvc ? cardano-faucet && cfgSvc.cardano-faucet.enable) ''
           // Cardano-faucet integration component
           prometheus.scrape "integrations_cardano_faucet" {
             targets = [{
@@ -304,9 +296,9 @@ flake @ {moduleWithSystem, ...}: {
             metrics_path = "/metrics"
           }
 
-        '');
+        '';
 
-        cardanoNode = concatStringsSep "\n" (optionals (cfgSvc ? cardano-node && cfgSvc.cardano-node.enable) (map (
+        cardanoNode = optionals (cfgSvc ? cardano-node && cfgSvc.cardano-node.enable) (map (
           i: let
             metricsPath =
               if cfgSvc.cardano-node.useLegacyTracing
@@ -339,9 +331,9 @@ flake @ {moduleWithSystem, ...}: {
             }
 
           ''
-        ) (range 0 (cfgSvc.cardano-node.instances - 1))));
+        ) (range 0 (cfgSvc.cardano-node.instances - 1)));
 
-        cardanoSmash = concatStringsSep "\n" (optional (cfgSvc ? cardano-smash) ''
+        cardanoSmash = optional (cfgSvc ? cardano-smash) ''
           // Cardano-smash integration component
           prometheus.scrape "integrations_cardano_smash" {
             targets = [{
@@ -353,9 +345,9 @@ flake @ {moduleWithSystem, ...}: {
             metrics_path = "/"
           }
 
-        '');
+        '';
 
-        mithrilSigner = concatStringsSep "\n" (optional (cfgSvc ? mithril-signer && cfgSvc.mithril-signer.enable && cfgSvc.mithril-signer.enableMetrics) ''
+        mithrilSigner = optional (cfgSvc ? mithril-signer && cfgSvc.mithril-signer.enable && cfgSvc.mithril-signer.enableMetrics) ''
           // Mithril-signer integration component
           prometheus.scrape "integrations_mithril_signer" {
             targets = [{
@@ -367,9 +359,9 @@ flake @ {moduleWithSystem, ...}: {
             metrics_path = "/metrics"
           }
 
-        '');
+        '';
 
-        nginxVts = concatStringsSep "\n" (optional (cfgSvc ? nginx-vhost-exporter && cfgSvc.nginx-vhost-exporter.enable) ''
+        nginxVts = optional (cfgSvc ? nginx-vhost-exporter && cfgSvc.nginx-vhost-exporter.enable) ''
           // Nginx-vts integration component
           prometheus.scrape "integrations_nginx_vts" {
             targets = [{
@@ -381,9 +373,9 @@ flake @ {moduleWithSystem, ...}: {
             metrics_path = "/status/format/prometheus"
           }
 
-        '');
+        '';
 
-        varnishCache = concatStringsSep "\n" (optional (cfgSvc.prometheus.exporters ? varnish && cfgSvc.prometheus.exporters.varnish.enable) ''
+        varnishCache = optional (cfgSvc.prometheus.exporters ? varnish && cfgSvc.prometheus.exporters.varnish.enable) ''
           // Varnish cache integration components
           prometheus.scrape "integrations_varnish_cache" {
             targets = [{
@@ -422,7 +414,7 @@ flake @ {moduleWithSystem, ...}: {
             }
           }
 
-        '');
+        '';
       };
 
       cfgSvc = config.services;
@@ -612,15 +604,17 @@ flake @ {moduleWithSystem, ...}: {
               #
               # Cardano-parts optional component configuration snippets
               #
-              + cardanoPartsComponentCfg.blockperf
-              + cardanoPartsComponentCfg.cardanoCustomMetrics
-              + cardanoPartsComponentCfg.cardanoDbSync
-              + cardanoPartsComponentCfg.cardanoFaucet
-              + cardanoPartsComponentCfg.cardanoNode
-              + cardanoPartsComponentCfg.cardanoSmash
-              + cardanoPartsComponentCfg.mithrilSigner
-              + cardanoPartsComponentCfg.nginxVts
-              + cardanoPartsComponentCfg.varnishCache
+              + concatStringsSep "\n" (
+                cardanoPartsComponentCfg.blockperf
+                ++ cardanoPartsComponentCfg.cardanoCustomMetrics
+                ++ cardanoPartsComponentCfg.cardanoDbSync
+                ++ cardanoPartsComponentCfg.cardanoFaucet
+                ++ cardanoPartsComponentCfg.cardanoNode
+                ++ cardanoPartsComponentCfg.cardanoSmash
+                ++ cardanoPartsComponentCfg.mithrilSigner
+                ++ cardanoPartsComponentCfg.nginxVts
+                ++ cardanoPartsComponentCfg.varnishCache
+              )
             );
         in
           (pkgs.runCommandNoCCLocal "alloy.config" {} ''

--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -231,10 +231,10 @@ flake @ {moduleWithSystem, ...}: {
             job_name = "integrations/blockperf"
             metrics_path = "/"
 
-            // Normally we prefer 1 minute default; however, we need
+            // Normally we prefer 1 minute default however we need
             // higher frequency with blockperf to catch large block
             // header delays.
-            scrape_interval = "10s";
+            scrape_interval = "10s"
           }
 
           prometheus.relabel "integrations_blockperf" {
@@ -263,7 +263,7 @@ flake @ {moduleWithSystem, ...}: {
               // pattern match. Filtering can be configured from the
               // profile-cardano-custom-metrics nixosModule with the
               // `enableFilter` and `filter` options.
-              // filter = ["statsd_cardano*"];
+              // filter = ["statsd_cardano*"]
             }
             metrics_path = "/api/v1/allmetrics"
           }

--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -1,0 +1,667 @@
+# nixosModule: profile-grafana-alloy
+#
+# TODO: Move this to a docs generator
+#
+# Attributes available on nixos module import:
+#   config.services.alloy.enableLiveDebugging
+#   config.services.alloy.labels
+#   config.services.alloy.logLevel
+#   config.services.alloy.prometheusExporterUnixNodeSetCollectors
+#   config.services.alloy.prometheusRelabelNodeKeepRegex
+#   config.services.alloy.systemdEnableRestartMetrics
+#   config.services.alloy.systemdEnableStartTimeMetrics
+#   config.services.alloy.systemdEnableTaskMetrics
+#   config.services.alloy.systemdUnitExclude
+#   config.services.alloy.systemdUnitInclude
+#   config.services.alloy.useSopsSecrets
+#
+# Tips:
+#   * This module provides a grafana-alloy service and configures common application metrics hooks
+flake @ {moduleWithSystem, ...}: {
+  flake.nixosModules.profile-grafana-alloy = moduleWithSystem ({inputs'}: {
+    config,
+    lib,
+    name,
+    pkgs,
+    self,
+    ...
+  }:
+    with builtins;
+    with lib; let
+      inherit (lib.types) attrsOf bool enum listOf str;
+      inherit (config.cardano-parts.perNode.meta) cardanoDbSyncPrometheusExporterPort cardanoNodePrometheusExporterPort hostAddr;
+      inherit (groupCfg) groupName groupFlake;
+      inherit (groupCfg.meta) environmentName;
+      inherit (opsLib) mkSopsSecret;
+
+      groupCfg = config.cardano-parts.cluster.group;
+      groupOutPath = groupFlake.self.outPath;
+      opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
+
+      mkSopsSecretParams = secretName: {
+        inherit groupOutPath groupName name secretName;
+        keyName = secretName + ".enc";
+        # Setting grafana-alloy service to a non-dynamic user allows constraining the secrets file to non-root ownership
+        fileOwner = "grafana-alloy";
+        fileGroup = "grafana-alloy";
+        pathPrefix = "${groupOutPath}/secrets/monitoring/";
+        restartUnits = ["alloy.service"];
+      };
+
+      alloyComponentCfg = {
+        logging = ''
+          // Log setup
+          logging {
+            level = "${toString cfg.logLevel}"
+            format = "logfmt"
+          }
+
+        '';
+
+        livedebugging = ''
+          // Live debug setup: experimental, but useful for relabel component investigation
+          livedebugging {
+            enabled = ${boolToString cfg.enableLiveDebugging}
+          }
+
+        '';
+
+        secrets = ''
+          // Secrets
+          local.file "remote_write_url" {
+            filename = "/run/secrets/grafana-alloy-metrics-url"
+          }
+
+          local.file "remote_write_username" {
+            filename = "/run/secrets/grafana-alloy-metrics-username"
+          }
+
+          local.file "remote_write_password" {
+            filename = "/run/secrets/grafana-alloy-metrics-password"
+            is_secret = true
+          }
+
+        '';
+
+        remoteWrite = ''
+          // Default prometheus remote write target
+          prometheus.remote_write "integrations" {
+            endpoint {
+              url = local.file.remote_write_url.content
+
+              basic_auth {
+                username = local.file.remote_write_username.content
+                password = local.file.remote_write_password.content
+              }
+            }
+          }
+
+        '';
+
+        alloy = ''
+          // Default grafana alloy integration components, in lowest to highest dependency order
+          prometheus.exporter.self "integrations_alloy" {}
+
+          discovery.relabel "integrations_alloy" {
+            targets = prometheus.exporter.self.integrations_alloy.targets
+
+            rule {
+              source_labels = ["alloy_hostname"]
+              target_label = "instance"
+            }
+
+            rule {
+              regex = "^alloy_hostname$"
+              action = "labeldrop"
+            }
+
+            rule {
+              target_label = "instance"
+              replacement = "${name}"
+            }
+
+            rule {
+              target_label = "job"
+              replacement = "integrations/alloy-check"
+            }
+          }
+
+          prometheus.scrape "integrations_alloy" {
+            targets = discovery.relabel.integrations_alloy.output
+            forward_to = [prometheus.relabel.integrations_alloy.receiver]
+            job_name = "integrations/alloy"
+          }
+
+          prometheus.relabel "integrations_alloy" {
+            forward_to = [prometheus.remote_write.integrations.receiver]
+
+            rule {
+              source_labels = ["__name__"]
+              regex = "${cfg.prometheusRelabelAlloyKeepRegex}"
+              action = "keep"
+            }
+          }
+
+        '';
+
+        exporter = ''
+          // Default grafana alloy node exporter integration components, in lowest to highest dependency order
+          prometheus.exporter.unix "integrations_node_exporter" {
+            set_collectors = [${concatMapStringsSep ", " (s: "\"${s}\"") cfg.prometheusExporterUnixNodeSetCollectors}]
+
+            systemd {
+              enable_restarts = ${boolToString cfg.systemdEnableRestartMetrics}
+              start_time = ${boolToString cfg.systemdEnableStartTimeMetrics}
+              task_metrics = ${boolToString cfg.systemdEnableTaskMetrics}
+              unit_exclude = "${cfg.systemdUnitExclude}"
+              unit_include = "${cfg.systemdUnitInclude}"
+            }
+          }
+
+          discovery.relabel "integrations_node_exporter" {
+            targets = prometheus.exporter.unix.integrations_node_exporter.targets
+
+            rule {
+              source_labels = ["alloy_hostname"]
+              target_label = "instance"
+            }
+
+            rule {
+              regex = "^alloy_hostname$"
+              action = "labeldrop"
+            }
+
+            rule {
+              target_label = "instance"
+              replacement = "${name}"
+            }
+
+            rule {
+              target_label = "job"
+              replacement = "integrations/node_exporter"
+            }
+          }
+
+          prometheus.scrape "integrations_node_exporter" {
+            targets = discovery.relabel.integrations_node_exporter.output
+            forward_to = [prometheus.relabel.integrations_node_exporter.receiver]
+            job_name = "integrations/node_exporter"
+          }
+
+          prometheus.relabel "integrations_node_exporter" {
+            forward_to = [prometheus.remote_write.integrations.receiver]
+
+            rule {
+              source_labels = ["__name__"]
+              regex = "${cfg.prometheusRelabelNodeKeepRegex}"
+              action = "keep"
+            }
+
+            rule {
+              source_labels = ["__name__"]
+              regex = "^node_filesystem_readonly$"
+              action = "drop"
+            }
+
+            rule {
+              source_labels = ["mountpoint"]
+              regex = "^|/|/boot|/state|/home|/nix$"
+              action = "keep"
+            }
+
+            rule {
+              source_labels = ["mode"]
+              regex = "^|system|user|iowait|steal|idle$"
+              action = "keep"
+            }
+          }
+
+        '';
+      };
+
+      cardanoPartsComponentCfg = {
+        blockperf = concatStringsSep "\n" (optional (cfgSvc ? blockperf) ''
+          // Blockperf integration component
+          prometheus.scrape "integrations_blockperf" {
+            targets = [{
+              __address__ = "127.0.0.1:${toString config.services.blockperf.port}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.relabel.integrations_blockperf.receiver]
+            job_name = "integrations/blockperf"
+            params = {
+              format = ["prometheus"],
+              // Filtering here won't work as grafana-alloy encodes the
+              // pattern match. Filtering can be configured from the
+              // profile-cardano-custom-metrics nixosModule with the
+              // `enableFilter` and `filter` options.
+              // filter = ["statsd_cardano*"];
+            }
+            metrics_path = "/"
+
+            // Normally we prefer 1 minute default; however, we need
+            // higher frequency with blockperf to catch large block
+            // header delays.
+            scrape_interval = "10s";
+          }
+
+          prometheus.relabel "integrations_blockperf" {
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            rule {
+              source_labels = ["__name__"]
+              regex = "^blockperf_.*$"
+              action = "keep"
+            }
+          }
+
+        '');
+
+        cardanoCustomMetrics = concatStringsSep "\n" (optional (cfgSvc ? cardano-custom-metrics && cfgSvc.netdata.enable) ''
+          // Cardano custom metrics integration component
+          prometheus.scrape "integrations_cardano_custom_metrics" {
+            targets = [{
+              __address__ = "${cfgSvc.cardano-custom-metrics.address}:${toString cfgSvc.cardano-custom-metrics.port}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            job_name = "integrations/cardano-custom-metrics"
+            params = {
+              format = ["prometheus"],
+              // Filtering here won't work as grafana-alloy encodes the
+              // pattern match. Filtering can be configured from the
+              // profile-cardano-custom-metrics nixosModule with the
+              // `enableFilter` and `filter` options.
+              // filter = ["statsd_cardano*"];
+            }
+            metrics_path = "/api/v1/allmetrics"
+          }
+
+        '');
+
+        cardanoDbSync = concatStringsSep "\n" (optional (cfgSvc ? cardano-db-sync && cfgSvc.cardano-db-sync.enable) ''
+          // Cardano-db-sync integration component
+          prometheus.scrape "integrations_cardano_db_sync" {
+            targets = [{
+              __address__ = "${hostAddr}:${toString cardanoDbSyncPrometheusExporterPort}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            job_name = "integrations/cardano-db-sync"
+            metrics_path = "/"
+          }
+
+        '');
+
+        cardanoFaucet = concatStringsSep "\n" (optional (cfgSvc ? cardano-faucet && cfgSvc.cardano-faucet.enable) ''
+          // Cardano-faucet integration component
+          prometheus.scrape "integrations_cardano_faucet" {
+            targets = [{
+              __address__ = "127.0.0.1:${toString cfgSvc.cardano-faucet.faucetPort}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            job_name = "integrations/cardano-faucet"
+            metrics_path = "/metrics"
+          }
+
+        '');
+
+        cardanoNode = concatStringsSep "\n" (optionals (cfgSvc ? cardano-node && cfgSvc.cardano-node.enable) (map (
+          i: let
+            metricsPath =
+              if cfgSvc.cardano-node.useLegacyTracing
+              then "/metrics"
+              else "/${(cfgSvc.cardano-node.extraNodeInstanceConfig i).TraceOptionNodeName}";
+
+            serviceName = i:
+              if i == 0
+              then "cardano-node"
+              else "cardano-node-${toString i}";
+
+            target =
+              if cfgSvc.cardano-node.useLegacyTracing
+              then "${hostAddr}:${toString (cardanoNodePrometheusExporterPort + i)}"
+              else "${hostAddr}:${toString cardanoNodePrometheusExporterPort}";
+
+            toUnderscore = s: replaceStrings ["-"] ["_"] s;
+          in ''
+
+            // Cardano-node instance ${toString i} integration component
+            prometheus.scrape "integrations_${toUnderscore (serviceName i)}" {
+              targets = [{
+                __address__ = "${target}",
+                instanceNum = "${toString i}",
+                ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+              }]
+              forward_to = [prometheus.remote_write.integrations.receiver]
+              job_name = "integrations/${serviceName i}"
+              metrics_path = "${metricsPath}"
+            }
+
+          ''
+        ) (range 0 (cfgSvc.cardano-node.instances - 1))));
+
+        cardanoSmash = concatStringsSep "\n" (optional (cfgSvc ? cardano-smash) ''
+          // Cardano-smash integration component
+          prometheus.scrape "integrations_cardano_smash" {
+            targets = [{
+              __address__ = "${hostAddr}:${toString cfgSvc.cardano-smash.registeredRelaysExporterPort}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            job_name = "integrations/cardano-smash"
+            metrics_path = "/"
+          }
+
+        '');
+
+        mithrilSigner = concatStringsSep "\n" (optional (cfgSvc ? mithril-signer && cfgSvc.mithril-signer.enable && cfgSvc.mithril-signer.enableMetrics) ''
+          // Mithril-signer integration component
+          prometheus.scrape "integrations_mithril_signer" {
+            targets = [{
+              __address__ = "${cfgSvc.mithril-signer.metricsAddress}:${toString cfgSvc.mithril-signer.metricsPort}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            job_name = "integrations/mithril-signer"
+            metrics_path = "/metrics"
+          }
+
+        '');
+
+        nginxVts = concatStringsSep "\n" (optional (cfgSvc ? nginx-vhost-exporter && cfgSvc.nginx-vhost-exporter.enable) ''
+          // Nginx-vts integration component
+          prometheus.scrape "integrations_nginx_vts" {
+            targets = [{
+              __address__ = "${cfgSvc.nginx-vhost-exporter.address}:${toString cfgSvc.nginx-vhost-exporter.port}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            job_name = "integrations/nginx-vts"
+            metrics_path = "/status/format/prometheus"
+          }
+
+        '');
+
+        varnishCache = concatStringsSep "\n" (optional (cfgSvc.prometheus.exporters ? varnish && cfgSvc.prometheus.exporters.varnish.enable) ''
+          // Varnish cache integration components
+          prometheus.scrape "integrations_varnish_cache" {
+            targets = [{
+              __address__ = "${cfgSvc.prometheus.exporters.varnish.listenAddress}:${toString cfgSvc.prometheus.exporters.varnish.port}",
+              ${concatStringsSep ", \n" (mapAttrsToList (n: v: "${n} = \"${v}\"") cfg.labels)},
+            }]
+            forward_to = [prometheus.relabel.integrations_varnish_cache.receiver]
+            job_name = "integrations/varnish-cache"
+            metrics_path = "${cfgSvc.prometheus.exporters.varnish.telemetryPath}"
+          }
+
+          prometheus.relabel "integrations_varnish_cache" {
+            forward_to = [prometheus.remote_write.integrations.receiver]
+            rule {
+              source_labels = ["__name__"]
+              regex = "${"^"
+            + concatMapStringsSep "|" (s: "${s}") [
+              "varnish_backend_beresp_(bodybytes|hdrbytes)"
+              "varnish_main_backend_(busy|conn|recycle|req|reuse|unhealthy)"
+              "varnish_main_cache_(hit|hitpass|miss)"
+              "varnish_main_client_req"
+              "varnish_main_n_expired"
+              "varnish_main_n_lru_nuked"
+              "varnish_main_pools"
+              "varnish_main_s_resp_(bodybytes|hdrbytes)"
+              "varnish_main_sessions"
+              "varnish_main_sessions_total"
+              "varnish_main_thread_queue_len"
+              "varnish_main_threads"
+              "varnish_main_threads_(created|failed|limited)"
+              "varnish_sma_g_bytes"
+              "varnish_sma_g_space"
+            ]
+            + "$"}"
+              action = "keep"
+            }
+          }
+
+        '');
+      };
+
+      cfgSvc = config.services;
+      cfg = config.services.alloy;
+    in {
+      options = {
+        services.alloy = {
+          enableLiveDebugging = mkOption {
+            type = bool;
+            default = true;
+            description = "Whether to enable live debugging for grafana alloy.";
+          };
+
+          labels = mkOption {
+            type = attrsOf str;
+            default = {
+              instance = name;
+              environment = environmentName;
+              group = groupName;
+            };
+            description = "The default set of labels to add to non-default component metrics.";
+          };
+
+          logLevel = mkOption {
+            type = enum ["debug" "info" "warn" "error"];
+            default = "debug";
+            description = "The default log level for grafana alloy.";
+          };
+
+          prometheusExporterUnixNodeSetCollectors = mkOption {
+            type = listOf str;
+            default = [
+              "boottime"
+              "conntrack"
+              "cpu"
+              "diskstats"
+              "filefd"
+              "filesystem"
+              "loadavg"
+              "meminfo"
+              "netdev"
+              "netstat"
+              "os"
+              "sockstat"
+              "softnet"
+              "stat"
+              "systemd"
+              "time"
+              "timex"
+              "uname"
+              "vmstat"
+            ];
+            description = "The default set collectors to use for the prometheus unix exporter component.";
+          };
+
+          prometheusRelabelAlloyKeepRegex = mkOption {
+            type = str;
+            default = "^alloy_build.*|alloy_resources.*|prometheus_remote_write_wal_samples_appended_total|prometheus_sd_discovered_targets|process_start_time_seconds|prometheus_target_.*|up$";
+            description = "The default keep regex string for the prometheus relabel alloy integration component.";
+          };
+
+          prometheusRelabelNodeKeepRegex = mkOption {
+            type = str;
+            default =
+              "^"
+              + concatMapStringsSep "|" (s: "${s}") [
+                "node_boot_time_seconds"
+                "node_context_switches_total"
+                "node_cpu_seconds_total"
+                "node_disk_io_time_(seconds|weighted_seconds)_total"
+                "node_disk_(read|reads|writes|written)_.*"
+                "node_filefd_.*"
+                "node_filesystem_.*"
+                "node_intr_total"
+                "node_load([[:digit:]]+)"
+                "node_memory_(Active(|_file|_anon)|Inactive(|_file|_anon))_bytes"
+                "node_memory_Anon(HugePages|Pages)_bytes"
+                "node_memory_(Bounce|Committed_AS|CommitLimit|Dirty|Mapped)_bytes"
+                "node_memory_DirectMap(1G|2M|4k)_bytes"
+                "node_memory_HugePages_(Free|Rsvd|Surp|Total)"
+                "node_memory_Hugepagesize_bytes"
+                "node_memory_(Mem(Available|Free|Total)|Buffers|Cached|SwapTotal)_bytes"
+                "node_memory_Shmem(|HugPages|PmdMapped)_bytes"
+                "node_memory_S(Reclaimable|Unreclaim)_bytes"
+                "node_memory_Vmalloc(Chunk|Total|Used)_bytes"
+                "node_memory_Writeback(|Tmp)_bytes"
+                "node_netstat_Icmp6_(InErrors|InMsgs|OutMsgs)"
+                "node_netstat_Icmp_(InErrors|InMsgs|OutMsgs)"
+                "node_netstat_IpExt_(InOctets|OutOctets)"
+                "node_netstat_TcpExt_(ListenDrops|ListenOverflows|SyncookiesFailed|SyncookiesRecv|SyncookiesSent|TCPOFOQueue|TCPRcvQDrop|TCPSynRetrans|TCPTimeouts)"
+                "node_netstat_Tcp_(ActiveOpens|CurrEstab|InErrs|InSegs|OutRsts|OutSegs|PassiveOpens|RetransSegs)"
+                "node_netstat_Udp6_(InDatagrams|InErrors|NoPorts|OutDatagrams|RcvbufErrors|SndbufErrors)"
+                "node_netstat_Udp_(InDatagrams|InErrors|NoPorts|OutDatagrams|RcvbufErrors|SndbufErrors)"
+                "node_netstat_UdpLite_InErrors"
+                "node_network_.*"
+                "node_nf_conntrack_entries(|_limit)"
+                "node_os_info"
+                "node_sockstat_(FRAG|FRAG6|RAW|RAW6)_inuse"
+                "node_sockstat_sockets_used"
+                "node_sockstat_TCP6_inuse"
+                "node_sockstat_TCP_(alloc|inuse|mem|orphan|tw)"
+                "node_sockstat_(TCP|UDP)_mem_bytes"
+                "node_sockstat_UDP_mem"
+                "node_sockstat_(UDP|UDP6|UDPLITE|UDPLITE6)_inuse"
+                "node_softnet_(dropped|processed|times_squeezed)_total"
+                "node_systemd_.*"
+                "node_timex_(estimated_error|maxerror|offset)_seconds"
+                "node_timex_sync_status"
+                "node_time_zone_offset_seconds"
+                "node_uname_info"
+                "node_vmstat_(pgmajfault|pgfault|pgpgin|pgpgout|pswpin|pswpout|oom_kill)"
+              ]
+              + "$";
+            description = "The default keep regex string for the prometheus relabel alloy node exporter integration component.";
+          };
+
+          systemdEnableRestartMetrics = mkOption {
+            type = bool;
+            default = true;
+            description = "Enables service unit metric service_restart_total collection.";
+          };
+
+          systemdEnableStartTimeMetrics = mkOption {
+            type = bool;
+            default = false;
+            description = "Enables service unit metric unit_start_time_seconds collection.";
+          };
+
+          systemdEnableTaskMetrics = mkOption {
+            type = bool;
+            default = false;
+            description = "Enables service unit tasks metrics unit_tasks_current and unit_tasks_max collection.";
+          };
+
+          systemdUnitExclude = mkOption {
+            type = str;
+            default = ".+\\\\.(automount|device|mount|scope|slice)";
+            description = ''
+              Regexp of systemd units to exclude.
+              Units must both match include and not match exclude to be collected.
+            '';
+          };
+
+          systemdUnitInclude = mkOption {
+            type = str;
+            default = "(^cardano.*)|(^metadata.*)|(^nginx.*)|(^smash.*)|(^varnish.*)";
+            description = ''
+              Regexp of systemd units to include.
+              Units must both match include and not match exclude to be collected.
+            '';
+          };
+
+          useSopsSecrets = mkOption {
+            type = bool;
+            default = true;
+            description = ''
+              Whether to use the default configurated sops secrets if true,
+              or user defined secrets if false.
+
+              If false, the following required secrets files, each containing
+              one secret indicated by filename and without newline termination,
+              will need to be provided to the target machine either by
+              additional module code or out of band:
+
+                /run/secrets/grafana-alloy-metrics-url
+                /run/secrets/grafana-alloy-metrics-username
+                /run/secrets/grafana-alloy-metrics-password
+            '';
+          };
+        };
+      };
+
+      config = {
+        environment.etc."alloy/config.alloy".source = let
+          alloyCfg' =
+            toFile "alloy-unformatted.config"
+            (
+              #
+              # Base required component configuration snippets
+              #
+              alloyComponentCfg.logging
+              + alloyComponentCfg.livedebugging
+              + alloyComponentCfg.secrets
+              + alloyComponentCfg.remoteWrite
+              + alloyComponentCfg.alloy
+              + alloyComponentCfg.exporter
+              #
+              # Cardano-parts optional component configuration snippets
+              #
+              + cardanoPartsComponentCfg.blockperf
+              + cardanoPartsComponentCfg.cardanoCustomMetrics
+              + cardanoPartsComponentCfg.cardanoDbSync
+              + cardanoPartsComponentCfg.cardanoFaucet
+              + cardanoPartsComponentCfg.cardanoNode
+              + cardanoPartsComponentCfg.cardanoSmash
+              + cardanoPartsComponentCfg.mithrilSigner
+              + cardanoPartsComponentCfg.nginxVts
+              + cardanoPartsComponentCfg.varnishCache
+            );
+        in
+          (pkgs.runCommandNoCCLocal "alloy.config" {} ''
+            ${getExe cfg.package} fmt ${alloyCfg'} > $out
+          '')
+          .out;
+
+        services.alloy = {
+          enable = true;
+
+          extraFlags = [
+            "--disable-reporting"
+            "--stability.level=experimental"
+          ];
+
+          package = inputs'.nixpkgs-unstable.legacyPackages.grafana-alloy;
+        };
+
+        systemd.services.alloy = {
+          # The alloy collector may error when collecting systemd metrics with a dynamic user.
+          # Also, this allows for using non-root systemd process with non-root secrets files.
+          serviceConfig = {
+            User = "grafana-alloy";
+            Group = "grafana-alloy";
+            DynamicUser = mkForce false;
+          };
+        };
+
+        users = {
+          groups.grafana-alloy = {};
+          users.grafana-alloy = {
+            group = "grafana-alloy";
+            isSystemUser = true;
+          };
+        };
+
+        sops.secrets = mkIf cfg.useSopsSecrets (
+          mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-url")
+          // mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-username")
+          // mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-password")
+        );
+      };
+    });
+}

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -462,9 +462,9 @@ in
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             # Mithril unstable tag is unavailable likely due to upstream tag moving; re-assign unstable tag to sanchonet when availability to capkgs returns
             (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-ef0c28a {meta.mainProgram = "mithril-client";}))
             (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-ef0c28a {meta.mainProgram = "mithril-signer";}))
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
           ];
         };

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -174,7 +174,7 @@ in
         inputs.cardano-parts.nixosModules.profile-cardano-parts
         inputs.cardano-parts.nixosModules.profile-basic
         inputs.cardano-parts.nixosModules.profile-common
-        inputs.cardano-parts.nixosModules.profile-grafana-agent
+        inputs.cardano-parts.nixosModules.profile-grafana-alloy
         nixosModules.common
         nixosModules.ip-module-check
       ];

--- a/templates/cardano-parts-project/flake/opentofu/grafana/alerts/cardano-parts.nix-import
+++ b/templates/cardano-parts-project/flake/opentofu/grafana/alerts/cardano-parts.nix-import
@@ -11,7 +11,7 @@ in {
   rule = [
     {
       alert = "unexpected_missing_machine";
-      expr = ''count(up{job="integrations/agent-check"}) < ${machines}'';
+      expr = ''count(up{job=~"integrations/(agent|alloy)-check"}) < ${machines}'';
       for = "5m";
       labels.severity = "page";
       annotations = {
@@ -21,7 +21,7 @@ in {
     }
     {
       alert = "unexpected_new_machine";
-      expr = ''count(up{job="integrations/agent-check"}) > ${machines}'';
+      expr = ''count(up{job=~"integrations/(agent|alloy)-check"}) > ${machines}'';
       for = "5m";
       labels.severity = "warning";
       annotations = {

--- a/templates/cardano-parts-project/flake/opentofu/grafana/dashboards/node-exporter-filesystem-and-disk.json
+++ b/templates/cardano-parts-project/flake/opentofu/grafana/dashboards/node-exporter-filesystem-and-disk.json
@@ -1077,7 +1077,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "process_max_fds{job=~\"$job\",instance=~\"$instance\"}",
+          "expr": "process_max_fds{job=~\"$job\",instance=~\"$instance\"} or node_filefd_maximum{job=~\"$job\",instance=~\"$instance\"}",
           "format": "timeseries",
           "intervalFactor": 1,
           "legendFormat": "Maximum open file descriptors",
@@ -1087,7 +1087,7 @@
           "datasource": {
             "uid": "$datasource"
           },
-          "expr": "process_open_fds{job=~\"$job\",instance=~\"$instance\"}",
+          "expr": "process_open_fds{job=~\"$job\",instance=~\"$instance\"} or node_filefd_allocated{job=~\"$job\",instance=~\"$instance\"}",
           "format": "timeseries",
           "intervalFactor": 1,
           "legendFormat": "Open file descriptors",


### PR DESCRIPTION
## Overview:
Migrates [Grafana Agent](https://grafana.com/docs/agent/latest/) to [Grafana Alloy](https://grafana.com/docs/alloy/latest/).  Drops deprecated cardano-node service features and iohk-nix legacy mainnet relay filtering.  Fixes cardano-parts jobs for cardano-cli breaking change compatibility.

## Details:

* Bumps capkgs for mithril-unstable update
* Drops deprecated cardano-node nixos service handling features (<= 8.9.0)
* Drops iohk-nix legacy mainnet non-p2p relay filtering
* Updates flakeModule jobs to adapt to breaking changes in cardano-cli (>= 9.4.0.0) which no longer support transaction build in pre-conway eras
* Cleans up the `profile-grafana-agent` nixosModule
* Adds `profile-grafana-alloy` nixosModule which replaces `profile-grafana-agent` -- see migration notes below
* Adds template files for grafana alloy migration

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:

* Grafana agent has been deprecated with long term support from Grafana ending in Oct 2025.
* Grafana alloy is the replacement, and this PR introduces a supporting nixosModule `profile-grafana-alloy` and migration instructions
* Migration to grafana alloy is optional, but if done, the change is breaking in the sense secrets will need to be modified
* In the action items below, the diff in `flake/colmena.nix` in particular will enforce the migration to grafana alloy; it contains only a single line change which swaps the grafana alloy nixosModule for the grafana agent nixosModule.
* Migration is recommended -- see the migration notes below

### Recommended Updates:

* Update the cardano-parts pin to this release version `v2024-10-22`
* Apply the template Justfile diff and patch or clone recipes on files described below.

### Action Items:

* Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"` applying the diffs relevant for your cluster.  Looking at the short PR diff for these files found under directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the `just template-clone "$FILE"` recipe.

```
flake/colmena.nix                                                         # Migrates from grafana agent to grafana alloy
flake/opentofu/grafana/alerts/cardano-parts.nix-import                    # Adds grafana alloy compatibility with alerts
flake/opentofu/grafana/dashboards/node-exporter-filesystem-and-disk.json  # Fixes a panel not showing metrics in grafana agent and alloy
```

### Grafana Alloy Migration:

* If you have applied the diff in `flake/colmena.nix` above, you are migrating to grafana alloy and will need to do the following before deploying any machines:
  * Create secrets for grafana alloy.  By default, these secrets are expected to be:
    ```
    secrets/monitoring/grafana-alloy-metrics-password.enc
    secrets/monitoring/grafana-alloy-metrics-url.enc
    secrets/monitoring/grafana-alloy-metrics-username.enc
    ```
  * These secrets can be copied from the corresponding grafana-agent secrets from the same directory
  * Edit the copied alloy secrets using `sops $FILENAME` and save each secret again with no end-of-file newline
    * In vim type editors, this can be done by applying `:set noeol nofixeol` and then saving and exiting `:wq`
  * Ensure the secrets are still encrypted and then git add and commit them
  * Keep existing grafana-agent secrets for at least a short time to ensure an easy rollback is possible if needed

  * Apply grafana-alloy alert and dashboard compatibility changes with `just tf grafana apply`

### Grafana Alloy Migration Rollback:

* If you need to revert back to grafana-agent, simply revert the applied `flake/colmena.nix` diff and ensure the original grafana-agent secrets are still available in the repo, then redeploy machines as needed:
```
secrets/monitoring/grafana-agent-metrics-password.enc
secrets/monitoring/grafana-agent-metrics-url.enc
secrets/monitoring/grafana-agent-metrics-username.enc
```