### PR TITLE
Node 10.1.1, mithril v2442, vote recipe

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -797,15 +797,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1728687575,
-        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
+        "lastModified": 1729533610,
+        "narHash": "sha256-3xN4TD13yz0pEW5wDAbvZD1kQQYxVjDO0sYPXvu8/FY=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
+        "rev": "884de552fb03cbbf0455cd98c223d763e39cc1dc",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "sanchonet-respin-2024-10-21",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1728397354,
-        "narHash": "sha256-5AB7mRXKMGDgrR0mbSnQsdBdR6ZwhpMDqYHInxuWC/U=",
+        "lastModified": 1729434577,
+        "narHash": "sha256-ncSU8v00wlsDqhZG6MMCFGBf/vvwSZM5a0AFi0hBtrg=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "427ccc70c7adcb3dec72bb9f8fd55898e13b931a",
+        "rev": "dcadd440fd218bf9ac5d157805a679b7204d2e23",
         "type": "github"
       },
       "original": {
@@ -241,16 +241,16 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1728686091,
-        "narHash": "sha256-gc4P+THcnnOEP34az+NncS97ETVlSTbZ/58bAYd2oec=",
+        "lastModified": 1729277176,
+        "narHash": "sha256-YFq/0HGlWqzij+9hOoXNhDHFH+5ltpMph8mmI4O8qeE=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "6cfedc9ada83f614b86833b6f3530d87f545e95c",
+        "rev": "cdb45dd5aa9b4cf43ef6a6c8ecd5b6afbef953e4",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/mn-relays-new",
+        "ref": "10.0.0-pre",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -258,16 +258,16 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1728686091,
-        "narHash": "sha256-gc4P+THcnnOEP34az+NncS97ETVlSTbZ/58bAYd2oec=",
+        "lastModified": 1729277176,
+        "narHash": "sha256-YFq/0HGlWqzij+9hOoXNhDHFH+5ltpMph8mmI4O8qeE=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "6cfedc9ada83f614b86833b6f3530d87f545e95c",
+        "rev": "cdb45dd5aa9b4cf43ef6a6c8ecd5b6afbef953e4",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/mn-relays-new",
+        "ref": "10.0.0-pre",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1729434577,
-        "narHash": "sha256-ncSU8v00wlsDqhZG6MMCFGBf/vvwSZM5a0AFi0hBtrg=",
+        "lastModified": 1729630617,
+        "narHash": "sha256-t+ZS7C4EMJkfR+OQX0eNUUQgzPDcza6pLp60N/86hx0=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "dcadd440fd218bf9ac5d157805a679b7204d2e23",
+        "rev": "a0652f1cd639d681e0871be471e642829cfbdeb2",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1729630617,
-        "narHash": "sha256-t+ZS7C4EMJkfR+OQX0eNUUQgzPDcza6pLp60N/86hx0=",
+        "lastModified": 1729804641,
+        "narHash": "sha256-v6TUW0qRKbkrRToE2WTSvafNtyo0hauykPyBJuTl4JE=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "a0652f1cd639d681e0871be471e642829cfbdeb2",
+        "rev": "431891b3565d1f646b3e882ee046911469dd52e5",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -797,11 +797,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1729533610,
-        "narHash": "sha256-3xN4TD13yz0pEW5wDAbvZD1kQQYxVjDO0sYPXvu8/FY=",
+        "lastModified": 1729558183,
+        "narHash": "sha256-n3f1iAmltKnorHWx7FrdbGIF/FmEG8SsZshS16vnpz0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "884de552fb03cbbf0455cd98c223d763e39cc1dc",
+        "rev": "4fbec5aaa1afe36fdf9a6438d9e1bf676c144352",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -776,11 +776,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1728687575,
-        "narHash": "sha256-38uD8SqT557eh5yyRYuthKm1yTtiWzAN0FH7L/01QKM=",
+        "lastModified": 1730297014,
+        "narHash": "sha256-n3f1iAmltKnorHWx7FrdbGIF/FmEG8SsZshS16vnpz0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "86c2bd46e8a08f62ea38ffe77cb4e9c337b42217",
+        "rev": "d407eedd4995e88d08e83ef75844a8a9c2e29b36",
         "type": "github"
       },
       "original": {
@@ -797,16 +797,15 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1729558183,
+        "lastModified": 1730297014,
         "narHash": "sha256-n3f1iAmltKnorHWx7FrdbGIF/FmEG8SsZshS16vnpz0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "4fbec5aaa1afe36fdf9a6438d9e1bf676c144352",
+        "rev": "d407eedd4995e88d08e83ef75844a8a9c2e29b36",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "sanchonet-respin-2024-10-21",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -58,12 +58,12 @@
     };
 
     cardano-node-service = {
-      url = "github:IntersectMBO/cardano-node/jl/mn-relays-new";
+      url = "github:IntersectMBO/cardano-node/10.0.0-pre";
       flake = false;
     };
 
     cardano-node-service-ng = {
-      url = "github:IntersectMBO/cardano-node/jl/mn-relays-new";
+      url = "github:IntersectMBO/cardano-node/10.0.0-pre";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     empty-flake.url = "github:input-output-hk/empty-flake";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/sanchonet-respin-2024-10-21";
 
     # For tmp local faucet testing
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";

--- a/flake.nix
+++ b/flake.nix
@@ -29,7 +29,7 @@
     empty-flake.url = "github:input-output-hk/empty-flake";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/sanchonet-respin-2024-10-21";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
 
     # For tmp local faucet testing
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";

--- a/flake/nixosModules/profile-cardano-db-sync-snapshots.nix
+++ b/flake/nixosModules/profile-cardano-db-sync-snapshots.nix
@@ -190,10 +190,17 @@ flake: {
             default = true;
             description = ''
               Whether to use the default configurated sops secrets if true,
-              or user defined secrets if false.
+              or user deployed secrets if false.
 
-              If false, any required secrets will need to be provided either
-              by additional module code or out of band.
+              If false, the secrets file will need to be provided to the target
+              machine either by additional module code or out of band and the
+              following option should be set with this secret's file path:
+
+                config.services.cardano-db-sync-snapshots.environmentFile
+
+              For consistency with sops secrets, a suggested secrets path is:
+
+                /run/secrets/cardano-db-sync-snapshots
             '';
           };
         };
@@ -228,7 +235,7 @@ flake: {
                 User = cfg.user;
                 Group = cfg.group;
 
-                EnvironmentFile = mkIf cfg.useSopsSecrets cfg.environmentFile;
+                EnvironmentFile = cfg.environmentFile;
 
                 ExecStart = getExe (pkgs.writeShellApplication {
                   name = "cardano-db-sync-snapshots";

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -194,7 +194,7 @@
           '';
 
           cardano-show-kes-period = ''
-            echo "Current KES period for environment ${environmentName}: $(($(cardano-cli query tip | jq .slot) / ${toString slotsPerKESPeriod}))"
+            echo "Current KES period for environment ${environmentName}: $(($(cardano-cli latest query tip | jq .slot) / ${toString slotsPerKESPeriod}))"
           '';
 
           cardano-show-p2p-conns = ''

--- a/flake/nixosModules/profile-cardano-postgres.nix
+++ b/flake/nixosModules/profile-cardano-postgres.nix
@@ -195,6 +195,12 @@
                   WHERE ph.view = $1
                   ORDER BY pu.id DESC;
 
+              -- Show the pool stake distribution by epoch
+              PREPARE show_pool_stake_dist_fn (word31type) AS
+                SELECT pool_hash.view, SUM (amount) AS lovelace FROM epoch_stake
+                  INNER JOIN pool_hash ON epoch_stake.pool_id = pool_hash.id
+                  WHERE epoch_no = $1 GROUP BY pool_hash.id ORDER BY lovelace DESC;
+
               -- Show pool networking information as of the most recent active epoch update; this includes retired pools
               PREPARE show_pools_network_info AS
                 WITH
@@ -217,11 +223,39 @@
                   LEFT JOIN ${offChainTable} ON ${offChainTable}.pmr_id = pool_update.meta_id
                   ORDER BY pool_hash.view;
 
-              -- Show the pool stake distribution by epoch
-              PREPARE show_pool_stake_dist_fn (word31type) AS
-                SELECT pool_hash.view, SUM (amount) AS lovelace FROM epoch_stake
-                  INNER JOIN pool_hash ON epoch_stake.pool_id = pool_hash.id
-                  WHERE epoch_no = $1 GROUP BY pool_hash.id ORDER BY lovelace DESC;
+              -- Show pools over a threshold lovelace epoch stake which have not yet voted on a gov action
+              -- Arguments are: actionId, actionIdx, lovelaceThreshold
+              PREPARE show_pools_not_voted_fn (hash32type, word31type, lovelace) AS
+                WITH
+                  current_epoch AS (
+                    select max(epoch_no) as current_epoch from block),
+                  pool_epoch_stake AS (
+                    SELECT pool_hash.view, SUM (amount) AS lovelace FROM epoch_stake
+                      INNER JOIN pool_hash ON epoch_stake.pool_id = pool_hash.id
+                      WHERE epoch_no = (select * from current_epoch) GROUP BY pool_hash.id ORDER BY lovelace DESC),
+                  pool_analyze AS (
+                    SELECT * FROM pool_epoch_stake
+                      WHERE lovelace >= $3),
+                  gov_tx_id AS (
+                    SELECT id FROM (SELECT * FROM tx WHERE hash = $1 AND block_index = $2) AS gov_tx),
+                  gov_action_id AS (
+                    SELECT id FROM gov_action_proposal WHERE tx_id = (SELECT * FROM gov_tx_id) AND index = $2),
+                  vote_table AS (
+                    SELECT DISTINCT ON (pool_voter) voting_procedure.id, pool_hash.view as pool_id, pool_voter, vote FROM voting_procedure
+                      INNER JOIN pool_hash ON voting_procedure.pool_voter = pool_hash.id
+                      WHERE gov_action_proposal_id = (SELECT * FROM gov_action_id) AND voter_role = 'SPO' ORDER BY pool_voter, id DESC),
+                  pool_vote_record AS (
+                    SELECT view AS pool_id, lovelace, vote_table.vote FROM pool_analyze
+                    LEFT JOIN vote_table ON pool_analyze.view = vote_table.pool_id),
+                  pools_not_voted AS (
+                    SELECT * FROM pool_vote_record WHERE vote IS NULL),
+                  pool_table AS (
+                    SELECT DISTINCT pool_hash.id, hash_raw, view AS pool_view, ticker_name FROM pool_hash
+                    LEFT JOIN off_chain_pool_data ON pool_hash.id = off_chain_pool_data.pool_id),
+                  result_table AS (
+                    SELECT pool_id, lovelace, vote, pool_table.ticker_name FROM pools_not_voted
+                    INNER JOIN pool_table ON pools_not_voted.pool_id = pool_table.pool_view)
+                 SELECT * FROM result_table ORDER BY lovelace DESC;
 
               -- Show registered pools as of the current epoch
               PREPARE show_registered_pools AS

--- a/flake/nixosModules/profile-cardano-postgres.nix
+++ b/flake/nixosModules/profile-cardano-postgres.nix
@@ -166,7 +166,7 @@
                     WHERE pools_deleg_sum.view = active_pools.view
                   )
                   FROM active_pools
-                  ORDER by view;
+                  ORDER by lovelace_delegated DESC;
 
               -- Show pool info for a single pool, best viewed in extended view mode, \x
               PREPARE show_pool_info_fn AS
@@ -221,7 +221,7 @@
               PREPARE show_pool_stake_dist_fn (word31type) AS
                 SELECT pool_hash.view, SUM (amount) AS lovelace FROM epoch_stake
                   INNER JOIN pool_hash ON epoch_stake.pool_id = pool_hash.id
-                  WHERE epoch_no = $1 GROUP BY pool_hash.id ORDER BY view;
+                  WHERE epoch_no = $1 GROUP BY pool_hash.id ORDER BY lovelace DESC;
 
               -- Show registered pools as of the current epoch
               PREPARE show_registered_pools AS

--- a/flake/nixosModules/profile-cardano-smash.nix
+++ b/flake/nixosModules/profile-cardano-smash.nix
@@ -344,7 +344,7 @@ flake: {
               }
 
               run() {
-                epoch=$(cardano-cli query tip --testnet-magic $CARDANO_NODE_NETWORK_ID | jq .epoch)
+                epoch=$(cardano-cli latest query tip --testnet-magic $CARDANO_NODE_NETWORK_ID | jq .epoch)
                 db_sync_epoch=$(psql -X -U ${cfgSmash.postgres.user} -t --command="select no from epoch_sync_time order by id desc limit 1;")
 
                 if [ $(( $epoch - $db_sync_epoch )) -gt 1 ]; then

--- a/flake/nixosModules/profile-grafana-agent.nix
+++ b/flake/nixosModules/profile-grafana-agent.nix
@@ -95,7 +95,7 @@ flake: {
             default = true;
             description = ''
               Whether to use the default configurated sops secrets if true,
-              or user defined secrets if false.
+              or user deployed secrets if false.
 
               If false, the following required secrets files, each containing
               one secret indicated by filename will need to be provided to the

--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -572,7 +572,7 @@ flake @ {moduleWithSystem, ...}: {
             default = true;
             description = ''
               Whether to use the default configurated sops secrets if true,
-              or user defined secrets if false.
+              or user deployed secrets if false.
 
               If false, the following required secrets files, each containing
               one secret indicated by filename and without newline termination,

--- a/flake/nixosModules/profile-tcpdump.nix
+++ b/flake/nixosModules/profile-tcpdump.nix
@@ -161,11 +161,19 @@ flake: {
           type = bool;
           default = true;
           description = ''
-            Whether to use the default configurated sops secrets if true,
-            or user defined secrets if false.
 
-            If false, any required secrets will need to be provided either
-            by additional module code or out of band.
+            Whether to use the default configurated sops secrets if true,
+            or user deployed secrets if false.
+
+            If false, the secrets file will need to be provided to the target
+            machine either by additional module code or out of band and the
+            following option should be set with this secret file's path:
+
+              config.services.tcpdump.environmentFile
+
+            For consistency with sops secrets, a suggested secrets path is:
+
+              /run/secrets/tcpdump
           '';
         };
       };
@@ -227,7 +235,7 @@ flake: {
               User = cfg.user;
               Group = cfg.group;
 
-              EnvironmentFile = mkIf cfg.useSopsSecrets cfg.environmentFile;
+              EnvironmentFile = cfg.environmentFile;
 
               Restart = "always";
               StateDirectory = "tcpdump";

--- a/flake/nixosModules/role-block-producer.nix
+++ b/flake/nixosModules/role-block-producer.nix
@@ -266,7 +266,7 @@ flake: {
                 runtimeInputs = with pkgs; [cardano-cli curl gnugrep jq];
                 text = ''
                   echo "Starting mithril-signer-verifier"
-                  POOL_ID=$(cardano-cli stake-pool id \
+                  POOL_ID=$(cardano-cli latest stake-pool id \
                     --cold-verification-key-file /run/secrets/cardano-node-cold-verification \
                     --output-format bech32)
 
@@ -321,13 +321,13 @@ flake: {
 
         environment.shellAliases = {
           cardano-show-kes-period-info = ''
-            cardano-cli \
+            cardano-cli latest \
               query kes-period-info \
               --op-cert-file /run/secrets/cardano-node-operational-cert
           '';
 
           cardano-show-leadership-schedule = ''
-            cardano-cli \
+            cardano-cli latest \
               query leadership-schedule \
               --genesis ${ShelleyGenesisFile} \
               --cold-verification-key-file /run/secrets/cardano-node-cold-verification \
@@ -336,21 +336,21 @@ flake: {
           '';
 
           cardano-show-pool-hash = ''
-            cardano-cli \
+            cardano-cli latest \
               stake-pool id \
               --cold-verification-key-file /run/secrets/cardano-node-cold-verification \
               --output-format hex
           '';
 
           cardano-show-pool-id = ''
-            cardano-cli \
+            cardano-cli latest \
               stake-pool id \
               --cold-verification-key-file /run/secrets/cardano-node-cold-verification \
               --output-format bech32
           '';
 
           cardano-show-pool-stake-snapshot = ''
-            cardano-cli \
+            cardano-cli latest \
               query stake-snapshot \
               --stake-pool-id "$(cardano-show-pool-id)"
           '';

--- a/flake/nixosModules/role-block-producer.nix
+++ b/flake/nixosModules/role-block-producer.nix
@@ -3,6 +3,7 @@
 # TODO: Move this to a docs generator
 #
 # Attributes available on nixos module import:
+#   config.services.cardano-node.useSopsSecrets
 #   config.services.mithril-signer.enable
 #   config.services.mithril-signer.enableMetrics
 #   config.services.mithril-signer.metricsAddress
@@ -105,57 +106,83 @@ flake: {
 
       sopsPath = name: config.sops.secrets.${name}.path;
     in {
-      options.services.mithril-signer = {
-        enable = mkOption {
-          type = bool;
-          default = nodeCfg.environments.${environmentName} ? mithrilAggregatorEndpointUrl && nodeCfg.environments.${environmentName} ? mithrilSignerConfig;
-          description = "Enable this block producer to also run a mithril signer.";
+      options.services = {
+        cardano-node = {
+          useSopsSecrets = mkOption {
+            type = bool;
+            default = true;
+            description = ''
+              Whether to use the default configurated sops secrets if true,
+              or user deployed secrets if false.
+
+              If false, the following secrets files, each containing one secret
+              indicated by filename, will need to be provided to the target
+              machine when applicable either by additional module code or out of
+              band:
+
+                /run/secrets/cardano-node-bulk-credentials
+                /run/secrets/cardano-node-cold-verification
+                /run/secrets/cardano-node-delegation-cert
+                /run/secrets/cardano-node-kes-signing
+                /run/secrets/cardano-node-operational-cert
+                /run/secrets/cardano-node-signing
+                /run/secrets/cardano-node-vrf-signing
+            '';
+          };
         };
 
-        enableMetrics = mkOption {
-          type = bool;
-          default = true;
-          description = "Enable mithril-signer's built in prometheus metrics server.";
-        };
+        mithril-signer = {
+          enable = mkOption {
+            type = bool;
+            default = nodeCfg.environments.${environmentName} ? mithrilAggregatorEndpointUrl && nodeCfg.environments.${environmentName} ? mithrilSignerConfig;
+            description = "Enable this block producer to also run a mithril signer.";
+          };
 
-        metricsAddress = mkOption {
-          type = str;
-          default = "127.0.0.1";
-          description = "Set the address to serve mithril-signer's built in prometheus metrics server.";
-        };
+          enableMetrics = mkOption {
+            type = bool;
+            default = true;
+            description = "Enable mithril-signer's built in prometheus metrics server.";
+          };
 
-        metricsPort = mkOption {
-          type = port;
-          default = 12778;
-          description = "Set the port address to serve mithril-signer's built in prometheus metrics server.";
-        };
+          metricsAddress = mkOption {
+            type = str;
+            default = "127.0.0.1";
+            description = "Set the address to serve mithril-signer's built in prometheus metrics server.";
+          };
 
-        relayEndpoint = mkOption {
-          type = str;
-          default = null;
-          description = ''
-            The relay endpoint the mithril signer must use in a production setup.
-            May be either a fully qualified DNS or an IP.
-            The port should not be included.
-          '';
-        };
+          metricsPort = mkOption {
+            type = port;
+            default = 12778;
+            description = "Set the port address to serve mithril-signer's built in prometheus metrics server.";
+          };
 
-        relayPort = mkOption {
-          type = port;
-          default = 3132;
-          description = "The relay port the mithril signer must use in a production setup.";
-        };
+          relayEndpoint = mkOption {
+            type = str;
+            default = null;
+            description = ''
+              The relay endpoint the mithril signer must use in a production setup.
+              May be either a fully qualified DNS or an IP.
+              The port should not be included.
+            '';
+          };
 
-        useRelay = mkOption {
-          type = bool;
-          default = true;
-          description = "Whether to use a proxy relay for requests to avoid leaking the block producer's IP.";
-        };
+          relayPort = mkOption {
+            type = port;
+            default = 3132;
+            description = "The relay port the mithril signer must use in a production setup.";
+          };
 
-        useSignerVerifier = mkOption {
-          type = bool;
-          default = true;
-          description = "Whether to use a daily run systemd service that will monitor for signed mithril certificates and fail if none are signed by the block producer.";
+          useRelay = mkOption {
+            type = bool;
+            default = true;
+            description = "Whether to use a proxy relay for requests to avoid leaking the block producer's IP.";
+          };
+
+          useSignerVerifier = mkOption {
+            type = bool;
+            default = true;
+            description = "Whether to use a daily run systemd service that will monitor for signed mithril certificates and fail if none are signed by the block producer.";
+          };
         };
       };
 
@@ -316,8 +343,7 @@ flake: {
           };
         };
 
-        sops.secrets = keysCfg.${Protocol};
-        users.users.cardano-node.extraGroups = ["keys"];
+        sops.secrets = mkIf config.services.cardano-node.useSopsSecrets keysCfg.${Protocol};
 
         environment.shellAliases = {
           cardano-show-kes-period-info = ''

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -423,7 +423,7 @@ in
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-22180cb)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.4.1.0";}))
-            (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.4.1.0";}))
+            (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-0-0-pre-cdb45dd" // {version = "10.0.0.0";}))
             (mkPkg "cardano-db-sync" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-sync-ng" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5")
@@ -436,25 +436,25 @@ in
             (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-9-2-78124cd")
 
             (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.2.1";}))
-            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.2.1";}))
+            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-0-0-pre-cdb45dd" // {version = "10.0.0";}))
             (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-3-0-8ab5fd6)
             (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2
               // {
                 pname = "cardano-wallet";
                 meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
               }))
             (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-80-0-26bf212)
             (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
@@ -462,9 +462,9 @@ in
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             # Mithril unstable tag is unavailable likely due to upstream tag moving; re-assign unstable tag to sanchonet when availability to capkgs returns
             (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-ef0c28a {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-aea9363 {meta.mainProgram = "mithril-client";}))
             (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-ef0c28a {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-aea9363 {meta.mainProgram = "mithril-signer";}))
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
           ];
         };

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -419,10 +419,10 @@ in
         pkgsSubmodule = submodule {
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
-            (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2)
-            (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.4.1.0";}))
+            (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-1-1-pre-4184f92" // {version = "10.1.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-1-1-pre-4184f92" // {version = "10.1.0.0";}))
             (mkPkg "cardano-db-sync" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-sync-ng" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
@@ -435,25 +435,25 @@ in
             (mkPkg "cardano-faucet" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-9-2-78124cd")
             (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-9-2-78124cd")
 
-            (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.2.1";}))
+            (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-10-1-1-pre-4184f92" // {version = "10.1.1";}))
             (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-1-1-pre-4184f92" // {version = "10.1.1";}))
             (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-3-0-8ab5fd6)
             (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
-            (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
-            (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-1-1-pre-4184f92")
+            (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-1-1-pre-4184f92")
+            (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2
               // {
                 pname = "cardano-wallet";
                 meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
               }))
-            (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-1-1-pre-4184f92")
-            (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-1-1-pre-4184f92")
-            (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-9-2-1-5d3da8a")
+            (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-80-0-26bf212)
             (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -423,7 +423,7 @@ in
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.4.1.0";}))
-            (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-1-0-pre-cf78673" // {version = "10.1.0.0";}))
+            (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-1-1-pre-4184f92" // {version = "10.1.0.0";}))
             (mkPkg "cardano-db-sync" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-sync-ng" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5")
@@ -436,25 +436,25 @@ in
             (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-9-2-78124cd")
 
             (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.2.1";}))
-            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-1-0-pre-cf78673" // {version = "10.1.0";}))
+            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-1-1-pre-4184f92" // {version = "10.1.1";}))
             (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-3-0-8ab5fd6)
             (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-9-2-1-5d3da8a")
             (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-0-pre-cf78673")
+            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2
               // {
                 pname = "cardano-wallet";
                 meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
               }))
             (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-1-0-pre-cf78673")
+            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-1-0-pre-cf78673")
+            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-1-0-pre-cf78673")
+            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-1-1-pre-4184f92")
             (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-80-0-26bf212)
             (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
@@ -462,9 +462,9 @@ in
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             # Mithril unstable tag is unavailable likely due to upstream tag moving; re-assign unstable tag to sanchonet when availability to capkgs returns
             (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2442-0-pre-0d4d6bc {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-0cbc482 {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-63e1204 {meta.mainProgram = "mithril-client";}))
             (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2442-0-pre-0d4d6bc {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-0cbc482 {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-63e1204 {meta.mainProgram = "mithril-signer";}))
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
           ];
         };

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -420,7 +420,7 @@ in
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
             (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-22180cb)
+            (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.4.1.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-0-0-pre-cdb45dd" // {version = "10.0.0.0";}))

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -423,7 +423,7 @@ in
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.4.1.0";}))
-            (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-0-0-pre-cdb45dd" // {version = "10.0.0.0";}))
+            (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-1-0-pre-cf78673" // {version = "10.1.0.0";}))
             (mkPkg "cardano-db-sync" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-sync-ng" (caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5" // {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5")
@@ -436,35 +436,35 @@ in
             (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-9-2-78124cd")
 
             (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-9-2-1-5d3da8a" // {version = "9.2.1";}))
-            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-0-0-pre-cdb45dd" // {version = "10.0.0";}))
+            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-1-0-pre-cf78673" // {version = "10.1.0";}))
             (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-3-0-8ab5fd6)
             (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-5-0-2-fe05fc5)
             (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-9-2-1-5d3da8a")
             (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
             (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
+            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-0-pre-cf78673")
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2024-08-11-ece92a2
               // {
                 pname = "cardano-wallet";
                 meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
               }))
             (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
+            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-1-0-pre-cf78673")
             (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
+            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-1-0-pre-cf78673")
             (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-9-2-1-5d3da8a")
-            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-0-0-pre-cdb45dd")
+            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-1-0-pre-cf78673")
             (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v0-80-0-26bf212)
             (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             # Mithril unstable tag is unavailable likely due to upstream tag moving; re-assign unstable tag to sanchonet when availability to capkgs returns
-            (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-aea9363 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2437-1-pre-9fd9ae8 {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-aea9363 {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2442-0-pre-0d4d6bc {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-0cbc482 {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2442-0-pre-0d4d6bc {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-0cbc482 {meta.mainProgram = "mithril-signer";}))
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
           ];
         };

--- a/perSystem/process-compose/default.nix
+++ b/perSystem/process-compose/default.nix
@@ -245,7 +245,7 @@ flake @ {inputs, ...}: {
 
           while true; do
             date -u --rfc-3339=seconds
-            "$CLI" query tip
+            "$CLI" latest query tip
             echo
             sleep 10
           done

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -34,7 +34,7 @@ checkEnv := '''
 checkEnvWithoutOverride := '''
   ENV="${1:-}"
 
-  if ! [[ "$ENV" =~ mainnet$|preprod$|preview$|private$|sanchonet$|shelley-qa$|demo$ ]]; then
+  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^private$|^sanchonet$|^shelley-qa$|^demo$ ]]; then
     echo "Error: only node environments for demo, mainnet, preprod, preview, private, sanchonet and shelley-qa are supported"
     exit 1
   fi
@@ -371,7 +371,7 @@ dedelegate-pools ENV *IDXS=null:
   set -euo pipefail
   {{checkEnvWithoutOverride}}
 
-  if ! [[ "$ENV" =~ preprod$|preview$|private$|sanchonet$|shelley-qa$ ]]; then
+  if ! [[ "$ENV" =~ ^preprod$|^preview$|^private$|^sanchonet$|^shelley-qa$ ]]; then
     echo "Error: only node environments for preprod, preview, private, sanchonet and shelley-qa are supported"
     exit 1
   fi
@@ -393,9 +393,9 @@ dedelegate-pools ENV *IDXS=null:
     CARDANO_CLI="cardano-cli"
   elif [ "${UNSTABLE:-}" = "true" ]; then
     CARDANO_CLI="cardano-cli-ng"
-  elif [[ "$ENV" =~ preprod$|preview$|shelley-qa$ ]]; then
+  elif [[ "$ENV" =~ ^preprod$|^preview$|^shelley-qa$ ]]; then
     CARDANO_CLI="cardano-cli"
-  elif [[ "$ENV" =~ private$|sanchonet$ ]]; then
+  elif [[ "$ENV" =~ ^private$|^sanchonet$ ]]; then
     CARDANO_CLI="cardano-cli-ng"
   fi
 
@@ -584,9 +584,9 @@ query-tip ENV TESTNET_MAGIC=null:
     CARDANO_CLI="cardano-cli"
   elif [ "${UNSTABLE:-}" = "true" ]; then
     CARDANO_CLI="cardano-cli-ng"
-  elif [[ "$ENV" =~ mainnet$|preprod$|preview$|shelley-qa$ ]]; then
+  elif [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^shelley-qa$ ]]; then
     CARDANO_CLI="cardano-cli"
-  elif [[ "$ENV" =~ private$|sanchonet$|demo$ ]]; then
+  elif [[ "$ENV" =~ ^private$|^sanchonet$|^demo$ ]]; then
     CARDANO_CLI="cardano-cli-ng"
   fi
 
@@ -1012,7 +1012,7 @@ start-node ENV:
   set -euo pipefail
   {{stateDir}}
 
-  if ! [[ "{{ENV}}" =~ mainnet$|preprod$|preview$|private$|sanchonet$|shelley-qa$ ]]; then
+  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^private$|^sanchonet$|^shelley-qa$ ]]; then
     echo "Error: only node environments for mainnet, preprod, preview, private, sanchonet and shelley-qa are supported for start-node recipe"
     exit 1
   fi
@@ -1022,7 +1022,7 @@ start-node ENV:
   echo "Starting cardano-node for envrionment {{ENV}}"
   mkdir -p "$STATEDIR"
 
-  if [[ "{{ENV}}" =~ mainnet$|preprod$|preview$ ]]; then
+  if [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$ ]]; then
     UNSTABLE=false
     UNSTABLE_LIB=false
     UNSTABLE_MITHRIL=false
@@ -1189,7 +1189,7 @@ truncate-chain ENV SLOT:
   [ -n "${DEBUG:-}" ] && set -x
   {{stateDir}}
 
-  if ! [[ "{{ENV}}" =~ mainnet$|preprod$|preview$|private$|sanchonet$|shelley-qa$ ]]; then
+  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^private$|^sanchonet$|^shelley-qa$ ]]; then
     echo "Error: only node environments for mainnet, preprod, preview, private, sanchonet and shelley-qa are supported for truncate-chain recipe"
     exit 1
   fi
@@ -1215,7 +1215,7 @@ truncate-chain ENV SLOT:
   )
 
   nix run .#job-gen-env-config &> /dev/null
-  if [[ "{{ENV}}" =~ mainnet$|preprod$|preview$ ]]; then
+  if [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$ ]]; then
     cp result/environments/config/{{ENV}}/*  "$STATEDIR/config/{{ENV}}/"
     chmod -R +w "$STATEDIR/config/{{ENV}}/"
     db-truncater "${TRUNC_ARGS[@]}"
@@ -1382,3 +1382,183 @@ update-ips-example:
     };
   }
   EOF
+
+# Generate and submit an SPO vote on a gov action
+vote-with-pool ENV POOL ACTION_ID ACTION_IDX VOTE:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  {{checkEnvWithoutOverride}}
+
+  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^private$|^sanchonet$|^shelley-qa$|^demo$ ]]; then
+    echo "Error: only node environments for mainnet, preprod, preview, private, sanchonet, shelley-qa and demo are supported"
+    exit 1
+  fi
+
+  just set-default-cardano-env {{ENV}} "$MAGIC" "$PPID"
+
+  if [ "$(jq -re .syncProgress <<< "$(just query-tip {{ENV}})")" != "100.00" ]; then
+    echo "Please wait until the local tip of environment {{ENV}} is 100.00 before voting"
+    exit 1
+  fi
+
+  if ! [[ "{{VOTE}}" =~ ^yes$|^no$|^abstain$ ]]; then
+    echo "Error: VOTE arg must be one of \"yes\", \"no\" or \"abstain\""
+    exit 1
+  fi
+
+  if [ "${USE_SHELL_BINS:-}" = "true" ]; then
+    CARDANO_CLI="cardano-cli"
+  elif [ -n "${UNSTABLE:-}" ] && [ "${UNSTABLE:-}" != "true" ]; then
+    CARDANO_CLI="cardano-cli"
+  elif [ "${UNSTABLE:-}" = "true" ]; then
+    CARDANO_CLI="cardano-cli-ng"
+  elif [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^shelley-qa$ ]]; then
+    CARDANO_CLI="cardano-cli"
+  elif [[ "$ENV" =~ ^private$|^sanchonet$ ]]; then
+    CARDANO_CLI="cardano-cli-ng"
+  fi
+
+  STATE_BEFORE=$(eval "$CARDANO_CLI" latest query gov-state)
+  ACTION_BEFORE=$(
+    jq -r \
+      --arg actionId {{ACTION_ID}} \
+      --arg actionIdx {{ACTION_IDX}} \
+      '.proposals | map(
+        select(
+          .actionId.txId == $actionId
+            and
+          .actionId.govActionIx == ($actionIdx | tonumber)
+        )
+      )' \
+      <<< "$STATE_BEFORE"
+  )
+
+  echo
+  echo "Governance action {{ACTION_ID}}#{{ACTION_IDX}} has the following associated gov state:"
+  echo
+  echo "$ACTION_BEFORE"
+  echo
+  read -p "Do you wish pool \"{{POOL}}\" in environment \"{{ENV}}\" to vote \"{{VOTE}}\" on this governance action [yY]? " -n 1 -r
+  echo
+  if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborting the vote."
+    exit 1
+  fi
+
+  FILE="{{POOL}}-{{ACTION_ID}}#{{ACTION_IDX}}"
+
+  # An assumption is made here that users have their secret cold as $POOL-cold.skey.
+  # The vkey may be listed in both the deploy and no-deploy poolgroup directories,
+  # so limit the output to the first match.
+  COLD_SKEY=$(fd --max-results 1 {{POOL}}-cold.skey secrets)
+  COLD_VKEY=$(fd --max-results 1 {{POOL}}-cold.vkey secrets)
+
+  # Assume secrets are properly encrypted
+  eval "$CARDANO_CLI" latest governance vote create \
+    --{{VOTE}} \
+    --governance-action-tx-id {{ACTION_ID}} \
+    --governance-action-index {{ACTION_IDX}} \
+    --cold-verification-key-file <(just sops-decrypt-binary "$COLD_VKEY") \
+    --out-file "$FILE.vote"
+
+  echo
+  echo "The created vote to be submitted is the following:"
+  echo
+  eval "$CARDANO_CLI" latest governance vote view \
+    --vote-file "$FILE.vote"
+  echo
+  echo
+  read -p "Do you wish to proceed with this vote [yY]? " -n 1 -r
+  echo
+  if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborting the vote."
+    exit 1
+  fi
+
+  RICH_ADDR=$(just sops-decrypt-binary secrets/envs/${ENV}/utxo-keys/rich-utxo.addr)
+
+  # Select the smallest available UTxO without native tokens attached and greater than 5 ADA automatically with jq:
+  RICH_UTXOS=$(eval "$CARDANO_CLI" latest query utxo --address "$RICH_ADDR" --out-file /dev/stdout)
+
+  TX_SELECTED=$(jq -r '.
+    | to_entries
+    | map(select((.value.value | length == 1) and .value.value.lovelace > 5000000))
+    | sort_by(.value.value.lovelace)[0]' <<< "$RICH_UTXOS"
+  )
+
+  TXIN=$(jq -r '.key' <<< "$TX_SELECTED")
+  TXVALUE=$(jq -r '.value.value.lovelace' <<< "$TX_SELECTED")
+
+  echo
+  echo "Selected rich key funding TX \"$TXIN\" with value $TXVALUE lovelace"
+
+  eval "$CARDANO_CLI" latest transaction build \
+    --tx-in "$TXIN" \
+    --change-address "$RICH_ADDR" \
+    --testnet-magic "$TESTNET_MAGIC" \
+    --vote-file "$FILE.vote" \
+    --witness-override 2 \
+    --out-file "$FILE.raw"
+
+  eval "$CARDANO_CLI" latest transaction sign \
+    --tx-body-file "$FILE.raw" \
+    --signing-key-file <(just sops-decrypt-binary secrets/envs/${ENV}/utxo-keys/rich-utxo.skey) \
+    --signing-key-file <(just sops-decrypt-binary "$COLD_SKEY") \
+    --testnet-magic "$TESTNET_MAGIC" \
+    --out-file "$FILE.signed"
+
+  TXID=$(eval "$CARDANO_CLI" latest transaction txid --tx-file "$FILE.signed")
+
+  echo
+  echo "The signed vote containing transaction with txid \"$TXID\" is the following:"
+  echo
+
+  eval "$CARDANO_CLI" debug transaction view --tx-file "$FILE.signed"
+
+  echo
+  echo
+  read -p "Do you wish to submit this vote to the {{ENV}} network [yY]? " -n 1 -r
+  echo
+  if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Aborting the vote."
+    exit 1
+  fi
+
+  echo
+  echo "Submitting the vote."
+
+  eval "$CARDANO_CLI" latest transaction submit --tx-file "$FILE.signed"
+
+  EXISTS="true"
+
+  while [ "$EXISTS" = "true" ]; do
+    EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists)
+    if [ "$EXISTS" = "true" ]; then
+      echo "Vote transaction still exists in the mempool, sleeping 5s: $TXID"
+    else
+      echo "Vote transaction has been removed from the mempool."
+    fi
+    sleep 5
+  done
+  echo
+  echo
+
+  STATE_AFTER=$(eval "$CARDANO_CLI" latest query gov-state)
+  ACTION_AFTER=$(
+    jq -r \
+      --arg actionId {{ACTION_ID}} \
+      --arg actionIdx {{ACTION_IDX}} \
+      '.proposals | map(
+        select(
+          .actionId.txId == $actionId
+            and
+          .actionId.govActionIx == ($actionIdx | tonumber)
+        )
+      )' \
+      <<< "$STATE_AFTER"
+  )
+
+  echo "Differences in gov action state before and after submitting the vote transaction with txid \"$TXID\" are:"
+  echo
+
+  icdiff -L beforeTxSubmission -L afterTxSubmission <(echo "$ACTION_BEFORE") <(echo "$ACTION_AFTER")

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -411,11 +411,11 @@ dedelegate-pools ENV *IDXS=null:
       --wallet-mnemonic <(just sops-decrypt-binary secrets/envs/{{ENV}}/utxo-keys/faucet.mnemonic) \
       --delegation-index "$i"
 
-    TXID=$(eval "$CARDANO_CLI" transaction txid --tx-file tx-deleg-account-$i-restore.txsigned)
+    TXID=$(eval "$CARDANO_CLI" latest transaction txid --tx-file tx-deleg-account-$i-restore.txsigned)
     EXISTS="true"
 
     while [ "$EXISTS" = "true" ]; do
-      EXISTS=$(eval "$CARDANO_CLI" query tx-mempool tx-exists $TXID | jq -r .exists)
+      EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists)
       if [ "$EXISTS" = "true" ]; then
         echo "Pool de-delegation index $i tx still exists in the mempool, sleeping 5s: $TXID"
       else
@@ -590,7 +590,7 @@ query-tip ENV TESTNET_MAGIC=null:
     CARDANO_CLI="cardano-cli-ng"
   fi
 
-  eval "$CARDANO_CLI" query tip \
+  eval "$CARDANO_CLI" latest query tip \
     --socket-path "$STATEDIR/node-{{ENV}}.socket" \
     --testnet-magic "$MAGIC"
 

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -750,6 +750,15 @@ sops-decrypt-binary FILE:
   # This supports the common use case of obtaining decrypted state for cmd arg input while leaving the encrypted file intact on disk.
   sops --config "$(sops_config {{FILE}})" --input-type binary --output-type binary --decrypt {{FILE}}
 
+# Decrypt a file in place
+sops-decrypt-binary-in-place FILE:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  {{sopsConfigSetup}}
+  [ -n "${DEBUG:-}" ] && set -x
+
+  sops --config "$(sops_config {{FILE}})" --input-type binary --output-type binary --decrypt {{FILE}} | sponge {{FILE}}
+
 # Encrypt a file in place
 sops-encrypt-binary FILE:
   #!/usr/bin/env bash
@@ -993,6 +1002,7 @@ start-demo:
   echo
 
   just query-tip demo
+  echo
   echo "Finished sequence..."
   echo
 

--- a/templates/cardano-parts-project/scripts/lib/cli.py
+++ b/templates/cardano-parts-project/scripts/lib/cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 import subprocess
+from typing import Any
 
 def cardanoCliStr() -> str:
     if(os.getenv('USE_SHELL_BINS') == "true"):
@@ -26,7 +27,7 @@ def createTransaction(start, end, txin, payments_txouts, utxo_address, utxo_sign
     tx_out_amount = int(txin[1]) - 0 - total_payments_spent
 
     p = subprocess.run([
-        cardanoCliStr(), "transaction", "build-raw",
+        cardanoCliStr(), "latest", "transaction", "build-raw",
         "--out-file", f"{tx_prefix}.txbody",
         "--tx-in", txin_str,
         "--tx-out", f"{utxo_address}+{tx_out_amount}",
@@ -41,7 +42,7 @@ def createTransaction(start, end, txin, payments_txouts, utxo_address, utxo_sign
         raise Exception("Not enough funds")
 
     p = subprocess.run([
-        cardanoCliStr(), "transaction", "build-raw",
+        cardanoCliStr(), "latest", "transaction", "build-raw",
         "--out-file", f"{tx_prefix}.txbody",
         "--tx-in", txin_str,
         "--tx-out", f"{utxo_address}+{tx_out_amount}",
@@ -51,14 +52,14 @@ def createTransaction(start, end, txin, payments_txouts, utxo_address, utxo_sign
 
     signed_tx = signTx(tx_prefix, utxo_signing_key_str)
 
-    p = subprocess.run([cardanoCliStr(), "transaction", "txid", "--tx-file", signed_tx], capture_output=True, text=True)
+    p = subprocess.run([cardanoCliStr(), "latest", "transaction", "txid", "--tx-file", signed_tx], capture_output=True, text=True)
     new_txin = p.stdout.rstrip()
     return (f"{new_txin}#0", tx_out_amount, fee)
 
 
 def estimateFeeTx(txbody, txin_count, txout_count, pparams) -> int:
     cmd = [
-        cardanoCliStr(), "transaction", "calculate-min-fee",
+        cardanoCliStr(), "latest", "transaction", "calculate-min-fee",
         "--reference-script-size", "0",
         "--tx-in-count", str(txin_count),
         "--tx-out-count", str(txout_count),
@@ -82,7 +83,7 @@ def getAccountsFromFile(filename) -> list:
 
 
 def getLargestUtxoForAddress(address, *network_args) -> tuple:
-    subprocess.run([cardanoCliStr(), "query", "utxo", "--out-file", "tmp_utxo.json", *network_args, "--address", address])
+    subprocess.run([cardanoCliStr(), "latest", "query", "utxo", "--out-file", "tmp_utxo.json", *network_args, "--address", address])
     f = open("tmp_utxo.json")
     utxo = json.load(f)
     f.close()
@@ -105,13 +106,18 @@ def getLargestUtxoForAddress(address, *network_args) -> tuple:
 
 
 def getPParams(*network_args) -> str:
-    p = subprocess.Popen([cardanoCliStr(), "query", "protocol-parameters", *network_args, "--out-file", "pparams.json"])
+    p = subprocess.Popen([cardanoCliStr(), "latest", "query", "protocol-parameters", *network_args, "--out-file", "pparams.json"])
     p.wait()
     return "pparams.json"
 
+def getPParamsJson(*network_args) -> Any:
+    p = subprocess.Popen([cardanoCliStr(), "latest", "query", "protocol-parameters", *network_args, "--out-file", "/dev/stdout"], stdout=subprocess.PIPE)
+    p.wait()
+    output, _ = p.communicate()
+    return json.loads(output)
 
 def getTTL(*network_args, addnl_sec=3600) -> int:
-    p = subprocess.run([cardanoCliStr(), "query", "tip", *network_args], capture_output=True, text=True)
+    p = subprocess.run([cardanoCliStr(), "latest", "query", "tip", *network_args], capture_output=True, text=True)
     if p.returncode != 0:
         print(p.stderr)
         raise Exception("Unknown error getting ttl")
@@ -121,7 +127,7 @@ def getTTL(*network_args, addnl_sec=3600) -> int:
 def signTx(tx_body_prefix, utxo_signing_key_str) -> str:
     subprocess.run([
         "bash", "-c",
-        f"cardano-cli transaction sign --tx-body-file {tx_body_prefix}.txbody"
+        f"cardano-cli latest transaction sign --tx-body-file {tx_body_prefix}.txbody"
         f" --signing-key-file <(echo '{utxo_signing_key_str}')"
         f" --out-file {tx_body_prefix}.txsigned"])
     return f"{tx_body_prefix}.txsigned"

--- a/templates/cardano-parts-project/scripts/lib/cli.py
+++ b/templates/cardano-parts-project/scripts/lib/cli.py
@@ -11,6 +11,7 @@ def cardanoCliStr() -> str:
     else:
         return("cardano-cli")
 
+
 def createTransaction(start, end, txin, payments_txouts, utxo_address, utxo_signing_key_str, *network_args) -> tuple:
     payments_txout_args = []
     total_payments_spent = 0
@@ -110,11 +111,13 @@ def getPParams(*network_args) -> str:
     p.wait()
     return "pparams.json"
 
+
 def getPParamsJson(*network_args) -> Any:
     p = subprocess.Popen([cardanoCliStr(), "latest", "query", "protocol-parameters", *network_args, "--out-file", "/dev/stdout"], stdout=subprocess.PIPE)
     p.wait()
     output, _ = p.communicate()
     return json.loads(output)
+
 
 def getTTL(*network_args, addnl_sec=3600) -> int:
     p = subprocess.run([cardanoCliStr(), "latest", "query", "tip", *network_args], capture_output=True, text=True)

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-agent-metrics-password.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-agent-metrics-password.enc
@@ -4,6 +4,13 @@
 #   * encrypt this file with sops as a binary type using KMS
 #
 # Expect this file to generate a pre-push error until it is either encrypted or deleted
-
+#
+# WARNING: Grafana agent is deprecated.
+#          Once migration to grafana alloy is complete,
+#          grafana-agent secrets can be deleted.
+#
+# For migration instructions, see:
+#   https://github.com/input-output-hk/cardano-parts/releases/tag/v2024-10-22
+#
 # Mimir remote write endpoint token
 $PASSWORD

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-agent-metrics-url.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-agent-metrics-url.enc
@@ -4,4 +4,12 @@
 #   * encrypt this file with sops as a binary type using KMS
 #
 # Expect this file to generate a pre-push error until it is either encrypted or deleted
+#
+# WARNING: Grafana agent is deprecated.
+#          Once migration to grafana alloy is complete,
+#          grafana-agent secrets can be deleted.
+#
+# For migration instructions, see:
+#   https://github.com/input-output-hk/cardano-parts/releases/tag/v2024-10-22
+#
 https://${BASE_MONITORING_FQDN}/mimir/api/v1/push

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-agent-metrics-username.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-agent-metrics-username.enc
@@ -4,4 +4,12 @@
 #   * encrypt this file with sops as a binary type using KMS
 #
 # Expect this file to generate a pre-push error until it is either encrypted or deleted
+#
+# WARNING: Grafana agent is deprecated.
+#          Once migration to grafana alloy is complete,
+#          grafana-agent secrets can be deleted.
+#
+# For migration instructions, see:
+#   https://github.com/input-output-hk/cardano-parts/releases/tag/v2024-10-22
+#
 $USERNAME

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-password.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-password.enc
@@ -1,0 +1,10 @@
+# To enable nixos grafana-alloy monitoring functionality:
+#   * update the following with a grafana alloy metrics password
+#   * remove these comments
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * encrypt this file with sops as a binary type using KMS
+#
+# Expect this file to generate a pre-push error until it is either encrypted or deleted
+
+# Mimir remote write endpoint token
+$PASSWORD

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-url.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-url.enc
@@ -1,0 +1,8 @@
+# To enable nixos grafana-alloy monitoring functionality:
+#   * update the following with a grafana alloy metrics url
+#   * remove these comments
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * encrypt this file with sops as a binary type using KMS
+#
+# Expect this file to generate a pre-push error until it is either encrypted or deleted
+https://${BASE_MONITORING_FQDN}/mimir/api/v1/push

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-username.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-username.enc
@@ -1,0 +1,8 @@
+# To enable nixos grafana-alloy monitoring functionality:
+#   * update the following with a grafana alloy metrics username
+#   * remove these comments
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * encrypt this file with sops as a binary type using KMS
+#
+# Expect this file to generate a pre-push error until it is either encrypted or deleted
+$USERNAME


### PR DESCRIPTION
## Overview:
Sets cardano-node to `10.1.1`, mithril to `v2442.0` and updates iohk-nix-ng for the recent sanchonet respin.   Updates for cardano-cli breaking changes were incorporated into nix jobs, justfile recipes, bash and python scripts, process-compose processes.  New template just recipes and psql prepared statements were added for ease of governance action pool voting and follow up vote analysis.  Some nixosModule options were refactored to consistency across the module set.

## Details:

* Important versioning updates:
  * Cardano-node[-ng] is now `10.1.1`
  * BlockPerf main now includes inbound governor metrics reporting 
  * Mithril is now `v2442.0`
* Bumps capkgs and updates pkgs.nix flakeModule for node `10.0.0-pre`, `10.1.0-pre`, `10.1.1` and blockPerf and mithril
* Bumps iohk-nix-ng for sanchonet respin on `2024-10-21` and minNodeVersion update
* Modify cardano-cli cmds for upstream breaking changes in nix jobs, justfile recipes, bash and python scripts, process-compose processes
* Adds template recipe `sops-decrypt-binary-in-place`
* Adds `profile-cardano-postgres` nixosModule pgsqlRc `show_pools_not_voted_fn` for gov action query
* Adds template recipe `vote-with-pool` for easy SPO gov action voting
* Updates template recipe for switch to grafana alloy secrets setup in new downstream clusters
* Updates some `profile-cardano-postgres` nixosModule pgsqlRc prepared statements by to sort by lovelace
* Implements nix option useSopsSecrets uniformly across modules

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* N/A

### Recommended Updates:
* Update the cardano-parts pin to this release version `v2024-11-06`
* Apply the template Justfile diff and patch or clone recipes on files described below.

### Action Items:
Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`.  Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the `just template-clone "$FILE"` recipe.

```
Justfile                                # New recipes and fixes cardano-cli breaking changes
scripts/lib/cli.py                      # Fixes cardano-cli breaking changes
scripts/restore-delegation-accounts.py  # Fixes cardano-cli breaking changes
scripts/setup-delegation-accounts.py    # Fixes cardano-cli breaking changes
```