### PR TITLE
Nixpkgs 24.11, nix 2.25.3, GHA for spinup

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,5 +1,5 @@
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.3; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.3/direnvrc" "sha256-0EVQVNSRQWsln+rgPW3mXVmnF5sfcmKEYOmOSfLYxHg="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
 fi
 
 IGREEN='\e[0;92m'

--- a/.github/workflows/nix-jobs-test.yaml
+++ b/.github/workflows/nix-jobs-test.yaml
@@ -1,0 +1,108 @@
+on:
+  pull_request:
+
+jobs:
+  nix-jobs-test:
+    name: "Test nix jobs"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+         ref: "${{github.head_ref || github.ref_name}}"
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+            experimental-features = fetch-closure flakes nix-command
+            substituters = https://cache.iog.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - name: Test
+        run: |
+          nix --version
+
+          # Enable tracing
+          export DEBUG="true"
+
+          # Default base paths
+          export GENESIS_DIR="workbench"
+          export KEY_DIR="workbench/envs/custom"
+          export DATA_DIR="workbench/rundir"
+
+          # Fake testing UTxOs
+          export BYRON_UTXO='{
+            "txin":"1e6f026dfa9aa3deb43a7a4c64d9e002d3224ce707e2a4bb45b0a93e465a4e20#0",
+            "address":"2657WMsDfac6yNxPyqZPCamHhH8pfYAaMgXFTxsag4n3ttWqVAz2gxRMomvJJMyF4",
+            "amount":30000000000000000}'
+          export UTXO='{
+            "txin":"cde023e0da05739ebcfeb7ab3ffaa467fa38fb508eddcc2c10a78bf06ff23f2b#0",
+            "address":"addr_test1vzyhu8wp6sx85dukujyuk0ltvqzjfx6vlpvwdf9dla9zg8qlez2ut",
+            "amount":30000000000000000}'
+
+          # Fake testing epoch
+          export EPOCH="100"
+
+          # Other params
+          export BYRON_SIGNING_KEY="$KEY_DIR/utxo-keys/shelley.000.skey"
+          export ERA_CMD="alonzo"
+          export MAJOR_VERSION="7"
+          export NUM_GENESIS_KEYS="3"
+          export PAYMENT_KEY="$KEY_DIR/utxo-keys/rich-utxo"
+          export POOL_NAMES="sp-1 sp-2 sp-3"
+          export POOL_RELAY="test.local"
+          export POOL_RELAY_PORT="3001"
+          export STAKE_POOL_DIR="workbench/groups/stake-pools"
+          export SUBMIT_TX="false"
+          export TESTNET_MAGIC="42"
+          export UNSTABLE="false"
+          export UNSTABLE_LIB="false"
+          export USE_ENCRYPTION="false"
+          export USE_DECRYPTION="false"
+          export USE_NODE_CONFIG_BP="false"
+
+          JOB_SEQ=(
+            "job-gen-custom-node-config-data"
+            "job-create-stake-pool-keys"
+            "job-register-stake-pools"
+            "job-delegate-rewards-stake-key"
+            "job-update-proposal-hard-fork"
+          )
+
+          JOB_SEQ_LEGACY=(
+            "job-gen-custom-node-config"
+            "job-create-stake-pool-keys"
+            "job-move-genesis-utxo"
+            "job-register-stake-pools"
+            "job-delegate-rewards-stake-key"
+            "job-update-proposal-hard-fork"
+          )
+
+          RUN_TESTS() {
+            local JOBS=("$@")
+
+            rm -rf workbench
+            for i in ${JOBS[@]}; do
+              echo "Running nix job .#$i"
+              nix run ".#$i"
+            done
+          }
+
+          echo "Run nix job tests with release versioning..."
+          echo "Running legacy sequence tests..."
+          RUN_TESTS "${JOB_SEQ_LEGACY[@]}"
+
+          echo "Running sequence tests..."
+          RUN_TESTS "${JOB_SEQ[@]}"
+
+          echo "Now run nix job tests again with pre-release versioning..."
+          set -x
+          export UNSTABLE="true"
+          export UNSTABLE_LIB="true"
+          set +x
+
+          echo "Running legacy sequence tests on pre-release..."
+          RUN_TESTS "${JOB_SEQ_LEGACY[@]}"
+
+          echo "Running sequence tests on pre-release..."
+          RUN_TESTS "${JOB_SEQ[@]}"

--- a/flake.lock
+++ b/flake.lock
@@ -774,16 +774,15 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1734105428,
+        "lastModified": 1734618971,
         "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ef96685204b54f0a0fc1af3116418f74be295cfc",
+        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "est-peers-40",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -796,16 +795,15 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1734105428,
+        "lastModified": 1734618971,
         "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ef96685204b54f0a0fc1af3116418f74be295cfc",
+        "rev": "dc900a3448e805243b0ed196017e8eb631e32240",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "est-peers-40",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -158,11 +158,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1733159898,
-        "narHash": "sha256-gGmCVB1JZY2kvX75nwMhvr5e16EhVESA/beiuhKVmV0=",
+        "lastModified": 1733419103,
+        "narHash": "sha256-foiusZ6R0GxmiEwNBOr8lcY3jYnUDYiWnKw9FP07bE0=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "91c14ee26a3d0dd1ae0fa7153d6a6f6244e44e68",
+        "rev": "6ec8b27301d86ee9f4b46d179a1fa71c800432e7",
         "type": "github"
       },
       "original": {
@@ -241,16 +241,15 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1732127807,
-        "narHash": "sha256-YKyaF31DeHkHcBiA8jjQJxM3R6clsqd0j8RWMg0QKbk=",
+        "lastModified": 1733261293,
+        "narHash": "sha256-JaqXZDH//3a0RRCOpa6FpPdRhNV8qqcnej6hxyqTcEQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "d06275ba16f68b4295945ff11b6531373c885574",
+        "rev": "16c4484243e074aab8850a10625ada86df7c1597",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/10.1.2-svc-legacy-tracing",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -258,16 +257,15 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1732127807,
-        "narHash": "sha256-YKyaF31DeHkHcBiA8jjQJxM3R6clsqd0j8RWMg0QKbk=",
+        "lastModified": 1733261293,
+        "narHash": "sha256-JaqXZDH//3a0RRCOpa6FpPdRhNV8qqcnej6hxyqTcEQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "d06275ba16f68b4295945ff11b6531373c885574",
+        "rev": "16c4484243e074aab8850a10625ada86df7c1597",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/10.1.2-svc-legacy-tracing",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -774,15 +774,16 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1732287300,
-        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
+        "lastModified": 1734105428,
+        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
+        "rev": "ef96685204b54f0a0fc1af3116418f74be295cfc",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "est-peers-40",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -795,15 +796,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1732287300,
-        "narHash": "sha256-lURsE6HdJX0alscWhbzCWyLRK8GpAgKuXeIgX31Kfqg=",
+        "lastModified": 1734105428,
+        "narHash": "sha256-5StB/VhWHOj3zlBxshqVFa6cwAE0Mk/wxRo3eEfcy74=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "262cb2aec2ddd914124bab90b06fe24a1a74d02c",
+        "rev": "ef96685204b54f0a0fc1af3116418f74be295cfc",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "est-peers-40",
         "repo": "iohk-nix",
         "type": "github"
       }
@@ -890,16 +892,16 @@
         "nixpkgs-regression": "nixpkgs-regression_2"
       },
       "locked": {
-        "lastModified": 1727313940,
-        "narHash": "sha256-mJJRmU4cLnIS3ByoWHsJCmoRroH3Oj6Gj6mKcdjJX8Y=",
+        "lastModified": 1733805479,
+        "narHash": "sha256-GFKV+bwye+Rj7G3JtJ/sljGLeN3A+jnVb71m84noheI=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "b23812a59c6854378f042e33f5e006c4d9dc516a",
+        "rev": "fe3c94d5c27c53c4b31f02c7be825d4acc67ab3c",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "2.24-maintenance",
+        "ref": "2.25-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -1152,11 +1154,11 @@
     },
     "nixpkgs-unstable_2": {
       "locked": {
-        "lastModified": 1728538411,
-        "narHash": "sha256-f0SBJz1eZ2yOuKUr5CA9BHULGXVSn6miBuUWdTyhUhU=",
+        "lastModified": 1733749988,
+        "narHash": "sha256-+5qdtgXceqhK5ZR1YbP1fAUsweBIrhL38726oIEAtDs=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b69de56fac8c2b6f8fd27f2eca01dcda8e0a4221",
+        "rev": "bc27f0fde01ce4e1bfec1ab122d72b7380278e68",
         "type": "github"
       },
       "original": {
@@ -1248,16 +1250,16 @@
     },
     "nixpkgs_7": {
       "locked": {
-        "lastModified": 1717281328,
-        "narHash": "sha256-evZPzpf59oNcDUXxh2GHcxHkTEG4fjae2ytWP85jXRo=",
+        "lastModified": 1733808091,
+        "narHash": "sha256-KWwINTQelKOoQgrXftxoqxmKFZb9pLVfnRvK270nkVk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "b3b2b28c1daa04fe2ae47c21bb76fd226eac4ca1",
+        "rev": "a0f3e10d94359665dba45b71b4227b0aeb851f8e",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-24.05",
+        "ref": "nixos-24.11",
         "repo": "nixpkgs",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -58,12 +58,12 @@
     };
 
     cardano-node-service = {
-      url = "github:IntersectMBO/cardano-node/jl/10.1.2-svc-legacy-tracing";
+      url = "github:IntersectMBO/cardano-node";
       flake = false;
     };
 
     cardano-node-service-ng = {
-      url = "github:IntersectMBO/cardano-node/jl/10.1.2-svc-legacy-tracing";
+      url = "github:IntersectMBO/cardano-node";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     inputs-check.url = "github:input-output-hk/inputs-check";
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.05";
-    nix.url = "github:nixos/nix/2.24-maintenance";
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-24.11";
+    nix.url = "github:nixos/nix/2.25-maintenance";
     opentofu-registry = {
       url = "github:opentofu/registry";
       flake = false;
@@ -28,8 +28,8 @@
     capkgs.url = "github:input-output-hk/capkgs";
     empty-flake.url = "github:input-output-hk/empty-flake";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
-    iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
+    iohk-nix.url = "github:input-output-hk/iohk-nix/est-peers-40";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/est-peers-40";
 
     # For tmp local faucet testing
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";

--- a/flake.nix
+++ b/flake.nix
@@ -28,8 +28,8 @@
     capkgs.url = "github:input-output-hk/capkgs";
     empty-flake.url = "github:input-output-hk/empty-flake";
     haskell-nix.url = "github:input-output-hk/haskell.nix";
-    iohk-nix.url = "github:input-output-hk/iohk-nix/est-peers-40";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/est-peers-40";
+    iohk-nix.url = "github:input-output-hk/iohk-nix";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
 
     # For tmp local faucet testing
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -72,8 +72,8 @@
         # For nix >= 2.24 build compatibility
         inputs.nixpkgs-unstable.legacyPackages.${system}.neovim
         ncdu
-        # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a non-existent pkg failure
-        inputs.nixpkgs.legacyPackages.${system}.nushellFull
+        # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 24.11 causing missing features error
+        inputs.nixpkgs.legacyPackages.${system}.nushell
         parted
         pciutils
         procps
@@ -89,10 +89,6 @@
       ];
 
       programs = {
-        # Added to address openssh CVE-2024-6387
-        # Remove on the next nixpkgs major version update so openssh 9.8p1+ version is maintained
-        ssh.package = inputs.nixpkgs-unstable.legacyPackages.${system}.openssh;
-
         tmux = {
           enable = true;
           aggressiveResize = true;

--- a/flake/nixosModules/profile-cardano-smash.nix
+++ b/flake/nixosModules/profile-cardano-smash.nix
@@ -409,7 +409,7 @@ flake: {
             startLimitIntervalSec = 0;
             serviceConfig = {
               User = "registered-relays-dump";
-              SupplementaryGroups = "cardano-node";
+              SupplementaryGroups = ["cardano-node"];
               StateDirectory = "registered-relays-dump";
               Restart = "always";
               RestartSec = "30s";
@@ -602,7 +602,7 @@ flake: {
         systemd.services.nginx.serviceConfig = {
           LimitNOFILE = 65535;
           LogNamespace = "nginx";
-          SupplementaryGroups = "registered-relays-dump";
+          SupplementaryGroups = ["registered-relays-dump"];
         };
 
         services.prometheus.exporters = {

--- a/flake/nixosModules/profile-common.nix
+++ b/flake/nixosModules/profile-common.nix
@@ -28,7 +28,6 @@
       imports = [
         inputs.sops-nix.nixosModules.default
         inputs.auth-keys-hub.nixosModules.auth-keys-hub
-        (inputs.nixpkgs-unstable.outPath + "/nixos/modules/services/monitoring/alloy.nix")
       ];
 
       programs = {

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -366,7 +366,7 @@ in {
             fi
 
             # Use the new create-testnet-data cli cmd
-            "''${CARDANO_CLI[@]}" genesis create-testnet-data \
+            /nix/store/1lr14zrh8kqpdr7ssbladbj0af9angrh-cardano-cli-exe-cardano-cli-10.1.1.0/bin/cardano-cli alonzo  genesis create-testnet-data \
               --genesis-keys "$NUM_GENESIS_KEYS" \
               --utxo-keys 1 \
               --total-supply "$MAX_SUPPLY" \
@@ -377,23 +377,6 @@ in {
               --spec-conway "$TEMPLATE_DIR/conway.json" \
               --start-time "$START_TIME" \
               --out-dir "$GENESIS_DIR"
-
-            # cardano-cli "$ERA_CMD" genesis create-testnet-data doesn't provide a byron genesis
-            "''${CARDANO_CLI_NO_ERA[@]}" byron genesis genesis \
-              --protocol-magic "$TESTNET_MAGIC" \
-              --start-time "$(date +%s -d "$START_TIME")" \
-              --k "$SECURITY_PARAM" \
-              --n-poor-addresses 0 \
-              --n-delegate-addresses "$NUM_GENESIS_KEYS" \
-              --total-balance "$MAX_SUPPLY" \
-              --delegate-share 0 \
-              --avvm-entry-count 0 \
-              --avvm-entry-balance 0 \
-              --protocol-parameters-file "$TEMPLATE_DIR/byron.json" \
-              --genesis-output-dir "$GENESIS_DIR/byron-config"
-
-            # Move the byron genesis into the same dir as shelley, alonzo, conway genesis files
-            mv "$GENESIS_DIR/byron-config/genesis.json" "$GENESIS_DIR/byron-genesis.json"
 
             # If initial funds is explicitly declared for the rich key, set it here
             if [ -n "''${INITIAL_FUNDS:-}" ]; then
@@ -451,9 +434,8 @@ in {
                 mv "genesis$((i + 1))/key.skey" "shelley.$(printf "%03d" "$i").skey"
                 mv "genesis$((i + 1))/key.vkey" "shelley.$(printf "%03d" "$i").vkey"
                 rmdir "genesis$((i + 1))/"
-
-                mv ../byron-config/genesis-keys."$(printf "%03d" "$i")".key "byron.$(printf "%03d" "$i").key"
               done
+                mv ../byron-gen-command/genesis-keys.000.key byron.000.key
             popd &> /dev/null
 
             # Transform the delegate key subdirs into a create-cardano compatible layout
@@ -468,11 +450,10 @@ in {
                 mv "delegate$((i + 1))/vrf.skey" "shelley.$(printf "%03d" "$i").vrf.skey"
                 mv "delegate$((i + 1))/vrf.vkey" "shelley.$(printf "%03d" "$i").vrf.vkey"
                 rmdir "delegate$((i + 1))/"
-
-                mv ../byron-config/delegate-keys."$(printf "%03d" "$i")".key "byron.$(printf "%03d" "$i").key"
-                mv ../byron-config/delegation-cert."$(printf "%03d" "$i")".json "byron.$(printf "%03d" "$i").cert.json"
               done
-              rmdir ../byron-config/
+              mv ../byron-gen-command/delegate-keys.000.key byron.000.key
+              mv ../byron-gen-command/delegation-cert.000.json byron.000.cert.json
+              rmdir ../byron-gen-command/
             popd &> /dev/null
 
             # Transform the rich key into a create-cardano compatible layout

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -39,6 +39,8 @@
 #   perSystem.cardano-parts.pkgs.cardano-smash-ng
 #   perSystem.cardano-parts.pkgs.cardano-submit-api
 #   perSystem.cardano-parts.pkgs.cardano-submit-api-ng
+#   perSystem.cardano-parts.pkgs.cardano-testnet
+#   perSystem.cardano-parts.pkgs.cardano-testnet-ng
 #   perSystem.cardano-parts.pkgs.cardano-tracer
 #   perSystem.cardano-parts.pkgs.cardano-wallet
 #   perSystem.cardano-parts.pkgs.cc-sign
@@ -445,6 +447,8 @@ in
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-6-0-4-0b7c281)
             (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-1-3-36871ba")
             (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-1-3-36871ba")
+            (mkPkg "cardano-testnet" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-1-3-36871ba")
+            (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-1-3-36871ba")
             (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-3-36871ba")
             (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-1-3-36871ba")
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2024-11-18-9eb5f59
@@ -465,9 +469,9 @@ in
             (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2445-0-pre-67dc6e4 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-e6922b8 {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-490e2c9 {meta.mainProgram = "mithril-client";}))
             (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2445-0-pre-67dc6e4 {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-e6922b8 {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-490e2c9 {meta.mainProgram = "mithril-signer";}))
             (mkPkg "orchestrator-cli" caPkgs.orchestrator-cli-IntersectMBO-credential-manager-0-1-2-0-081cc8c)
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
             (mkPkg "tx-bundle" caPkgs.tx-bundle-IntersectMBO-credential-manager-0-1-2-0-081cc8c)
@@ -498,6 +502,7 @@ in
               cardano-ogmios
               cardano-smash
               cardano-submit-api
+              cardano-testnet
               cardano-tracer
               cardano-wallet
               db-analyser
@@ -523,6 +528,7 @@ in
             cardano-node-ng = mkWrapper "cardano-node-ng" cfgPkgs.cardano-node-ng;
             cardano-smash-ng = mkWrapper "cardano-smash-ng" cfgPkgs.cardano-smash-ng;
             cardano-submit-api-ng = mkWrapper "cardano-submit-api-ng" cfgPkgs.cardano-submit-api-ng;
+            cardano-testnet-ng = mkWrapper "cardano-testnet-ng" cfgPkgs.cardano-testnet-ng;
             cardano-tracer-ng = mkWrapper "cardano-tracer-ng" cfgPkgs.cardano-tracer-ng;
             db-analyser-ng = mkWrapper "db-analyser-ng" cfgPkgs.db-analyser-ng;
             db-synthesizer-ng = mkWrapper "db-synthesizer-ng" cfgPkgs.db-synthesizer-ng;

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -293,6 +293,7 @@ in
                         cardano-address
                         cardano-cli
                         cardano-node
+                        cardano-testnet
                         cardano-wallet
                         db-analyser
                         db-synthesizer
@@ -303,6 +304,7 @@ in
                         # the wrapped binary to avoid cli name collision.
                         self'.packages.cardano-cli-ng
                         self'.packages.cardano-node-ng
+                        self'.packages.cardano-testnet-ng
                         self'.packages.db-analyser-ng
                         self'.packages.db-synthesizer-ng
                         self'.packages.db-truncater-ng

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -257,8 +257,9 @@ in
                     localFlake.inputs.nixpkgs.legacyPackages.${system}.jq
                     just
                     moreutils
-                    # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a non-existent pkg failure
-                    localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellFull
+                    # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a missing features failure
+                    localFlake.inputs.nixpkgs.legacyPackages.${system}.nushell
+                    localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellPlugins.polars
                     patch
                     ripgrep
                     statix
@@ -287,8 +288,7 @@ in
                     ++ (with pkgs;
                       with cfgPkgs; [
                         b2sum
-                        # Currently marked as broken in nixpkgs-23.11 and nixpkgs-unstable
-                        # haskellPackages.cbor-tool
+                        haskellPackages.cbor-tool
                         bech32
                         cardano-address
                         cardano-cli
@@ -390,7 +390,7 @@ in
             (pkgs.writeShellApplication
               {
                 name = "menu-${id}";
-                runtimeInputs = [localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellFull];
+                runtimeInputs = [localFlake.inputs.nixpkgs.legacyPackages.${system}.nushell];
 
                 text = let
                   minWidth =
@@ -449,6 +449,7 @@ in
                     selectScope id optionalString "enableHooks" "defaultHooks"
                     + selectScope id optionalAttrs "enableFormatter" "defaultFormatterHook"
                     + ''
+                      export NUSHELL_PLUGINS_POLARS="${getExe localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellPlugins.polars}"
                       [ -z "$NOMENU" ] && menu
                     '';
                 }

--- a/templates/cardano-parts-project/.envrc
+++ b/templates/cardano-parts-project/.envrc
@@ -1,5 +1,5 @@
-if ! has nix_direnv_version || ! nix_direnv_version 3.0.5; then
-  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.5/direnvrc" "sha256-RuwIS+QKFj/T9M2TFXScjBsLR6V3A17YVoEW/Q6AZ1w="
+if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
+  source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
 fi
 
 IGREEN='\033[0;92m'

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -922,10 +922,12 @@ start-demo:
     ERA_CMD="alonzo" \
       nix run .#job-gen-custom-node-config-data
   else
-    nix run .#job-gen-custom-node-config
+    ERA_CMD="alonzo" \
+      nix run .#job-gen-custom-node-config
   fi
 
-  nix run .#job-create-stake-pool-keys
+  ERA_CMD="alonzo" \
+    nix run .#job-create-stake-pool-keys
 
   if [ "$USE_DECRYPTION" = true ]; then
     BFT_CREDS=$(just sops-decrypt-binary "$KEY_DIR"/delegate-keys/bulk.creds.bft.json)

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -289,6 +289,29 @@ build-machines *ARGS:
   let nodes = (nix eval --json '.#nixosConfigurations' --apply builtins.attrNames | from json)
   for node in $nodes {just build-machine $node {{ARGS}}}
 
+# Run a local cardano-testnet
+cardano-testnet isNg *ARGS:
+  #!/usr/bin/env bash
+  set -euo pipefail
+
+  if [ "{{isNg}}" = "true" ]; then
+    CARDANO_CLI=$(command -v cardano-cli-ng)
+    CARDANO_NODE=$(command -v cardano-node-ng)
+    CARDANO_TESTNET="cardano-testnet-ng"
+  elif [ "{{isNg}}" = "false" ]; then
+    CARDANO_CLI=$(command -v cardano-cli)
+    CARDANO_NODE=$(command -v cardano-node)
+    CARDANO_TESTNET="cardano-testnet"
+  else
+    echo "ERROR: isNg must be either true to use the pre-release (aka next generation or \"ng\") version of node and cli,"
+    echo "       or false to use the release version of node and cli."
+    exit 1
+  fi
+
+  export CARDANO_CLI
+  export CARDANO_NODE
+  eval "$CARDANO_TESTNET" {{ARGS}}
+
 # Deploy a cloudFormation stack
 cf STACKNAME:
   #!/usr/bin/env nu

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -58,19 +58,19 @@ checkEnvWithoutOverride := '''
 '''
 
 checkSshConfig := '''
-  if not ('.ssh_config' | path exists) {
+  if not (".ssh_config" | path exists) {
     print $"(ansi "bg_light_red")Please run:(ansi reset) `just save-ssh-config` first to create the .ssh_config file"
     exit 1
   }
 
-  let checkFile = '.consistency-check-ts'
+  let checkFile = ".consistency-check-ts"
 
   # Checking modified timestamps to decide whether to eval nixosCfgs which costs ~0.5s per ssh command
   let runCheck = if ($checkFile | path exists) {
     let checkTs = (stat -c %Y $checkFile) | into int
     let colmenaTs = (stat -c %Y flake/colmena.nix) | into int
     let sshHostsTs = (stat -c %Y .ssh_config) | into int
-    let moduleIpsTs = if ('flake/nixosModules/ips-DONT-COMMIT.nix' | path exists) {
+    let moduleIpsTs = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
       (stat -c %Y flake/nixosModules/ips-DONT-COMMIT.nix) | into int
     } else {
       0
@@ -89,7 +89,7 @@ checkSshConfig := '''
       let comparison = {
         $lName: ($left | where $it not-in $right)
         $rName: ($right | where $it not-in $left)
-        =: ($left | where $it in $right)
+        eq: ($left | where $it in $right)
       }
 
       $comparison | transpose where item | flatten | select item where | sort-by item
@@ -97,14 +97,15 @@ checkSshConfig := '''
 
     mut consistent = true
 
-    let nixosCfg = (nix eval --json '.#nixosConfigurations' --apply 'builtins.attrNames') | from json
+    let nixosCfg = (nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames") | from json
 
     # Ssh config header manual changes can be made without breaking parsing as
     # long as they come after the `Host *$` line. Host modifications can also be
     # made as long as any host changes come after the `  HostName .*$` line for
     # each respective host.
     let sshCfg = (open .ssh_config
-      | parse --regex '(?m)Host (.*)\n\s+HostName (.*)'
+      | collect
+      | parse --regex `(?m)Host (.*)\n\s+HostName (.*)`
       | rename machine ip
       | sort-by machine)
 
@@ -116,45 +117,46 @@ checkSshConfig := '''
     let ssh6Cfg = ($sshCfg
       | where ($it.machine | str ends-with ".ipv6")
       | rename machine pubIpv6
-      | update machine {$in | str replace '.ipv6' ''}
-      | update pubIpv6 {if ($in == "unavailable.ipv6") { null } else { $in }}
+      | update machine {$in | str replace ".ipv6" ""}
+      | update pubIpv6 {if ($in == "unavailable.ipv6") {null} else {$in}}
       | sort-by machine)
 
-    let moduleIps = if ('flake/nixosModules/ips-DONT-COMMIT.nix' | path exists) {
+    let moduleIps = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
       (open flake/nixosModules/ips-DONT-COMMIT.nix
-        | parse --regex '(?ms)(.*)^  };\nin {.*'
+        | collect
+        | parse --regex `(?ms)(.*)^  };\nin {.*`
         | get capture0
-        | parse --regex '(?m)    (.*) = {$\n\s+privateIpv4 = \"(.*)";\n\s+publicIpv4 = \"(.*)";\n\s+publicIpv6 = \"(.*)";\n\s+};'
+        | parse --regex `(?m)    (.*) = {$\n\s+privateIpv4 = \"(.*)";\n\s+publicIpv4 = \"(.*)";\n\s+publicIpv6 = \"(.*)";\n\s+};`
         | rename machine privIpv4 pubIpv4 pubIpv6
-        | update pubIpv6 {if ($in == "") { null } else { $in }}
+        | update pubIpv6 {if ($in == "") {null} else {$in}}
         | sort-by machine)
     } else {
       []
     }
 
     # Set up comparison between list of nixos config machine names and ssh ipv4 machine names
-    let nixCompareSsh4 = list-diff $nixosCfg ($ssh4Cfg | get machine) onlyInNixosCfg onlyInSshCfg | where where != "="
+    let nixCompareSsh4 = list-diff $nixosCfg ($ssh4Cfg | get machine) onlyInNixosCfg onlyInSshCfg | where where != "eq"
 
     # Set up comparison between list of ssh public ipv4 and ssh public ipv6 machine names
-    let ssh4CompareSsh6 = list-diff ($ssh4Cfg | get machine) ($ssh6Cfg | get machine) onlyInSsh4Cfg onlyInSsh6Cfg | where where != "="
+    let ssh4CompareSsh6 = list-diff ($ssh4Cfg | get machine) ($ssh6Cfg | get machine) onlyInSsh4Cfg onlyInSsh6Cfg | where where != "eq"
 
     # Set up comparison between list of nixos config machine names and ip module machine names
-    let nixCompareIps = if ('flake/nixosModules/ips-DONT-COMMIT.nix' | path exists) {
-      list-diff $nixosCfg ($moduleIps | get machine) onlyInNixosCfg onlyInIpsModuleCfg | where where != "="
+    let nixCompareIps = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
+      list-diff $nixosCfg ($moduleIps | get machine) onlyInNixosCfg onlyInIpsModuleCfg | where where != "eq"
     } else {
       []
     }
 
     # Set up comparison between list of ssh public ipv4 and ip module public ipv4 values
-    let ssh4CompareIps4 = if ('flake/nixosModules/ips-DONT-COMMIT.nix' | path exists) {
-      list-diff ($ssh4Cfg | get pubIpv4) ($moduleIps | get pubIpv4) onlyInSshCfg onlyInIpsModuleCfg | where where != "="
+    let ssh4CompareIps4 = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
+      list-diff ($ssh4Cfg | get pubIpv4) ($moduleIps | get pubIpv4) onlyInSshCfg onlyInIpsModuleCfg | where where != "eq"
     } else {
       []
     }
 
     # Set up comparison between list of ssh public ipv6 and ip module public ipv6 values
-    let ssh6CompareIps6 = if ('flake/nixosModules/ips-DONT-COMMIT.nix' | path exists) {
-      list-diff ($ssh6Cfg | get pubIpv6) ($moduleIps | get pubIpv6) onlyInSshCfg onlyInIpsModuleCfg | where where != "="
+    let ssh6CompareIps6 = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
+      list-diff ($ssh6Cfg | get pubIpv6) ($moduleIps | get pubIpv6) onlyInSshCfg onlyInIpsModuleCfg | where where != "eq"
     } else {
       []
     }
@@ -465,8 +467,16 @@ lint:
 
 # List machines
 list-machines:
-  #!/usr/bin/env nu
-  let nixosNodes = (do -i { ^nix eval --json '.#nixosConfigurations' --apply 'builtins.attrNames' } | complete)
+  #!/usr/bin/env bash
+
+  # Enable polars (dataframe) usage by calling nushell indirectly with a plugins option.
+  # Otherwise, the plugin registry can't seem to be initialized successfully from within the script.
+  # Ref: https://github.com/nushell/nushell/issues/14466
+  #
+  # Polars outer join equivalent to pandas dfr can likey be simplified in a future nushell release.
+  # Ref: https://github.com/nushell/nushell/issues/14572
+  nu --plugins [$NUSHELL_PLUGINS_POLARS] -c '
+  let nixosNodes = (do -i {^nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames"} | complete)
   if $nixosNodes.exit_code != 0 {
      print "Nixos failed to evaluate the .#nixosConfigurations attribute."
      print "The output was:"
@@ -477,7 +487,7 @@ list-machines:
 
   {{checkSshConfig}}
 
-  let sshNodes = (do -i { ^scj dump /dev/stdout -c .ssh_config } | complete)
+  let sshNodes = (do -i {^scj dump /dev/stdout -c .ssh_config} | complete)
   if $sshNodes.exit_code != 0 {
      print "Ssh-config-json failed to evaluate the .ssh_config file."
      print "The output was:"
@@ -491,38 +501,40 @@ list-machines:
     let sanitizedList = (if ($nodeList | is-empty) {$nodeList | insert 0 ""} else {$nodeList});
 
     $sanitizedList
-      | insert 0 "machine"
-      | each {|i| [$i] | into record}
-      | headers
+      | wrap "machine"
       | each {|i| insert inNixosCfg {"yes"}}
-      | dfr into-df
+      | polars into-df
   )
 
   let sshNodesDfr = (
     let ssh4Table = ($sshNodes.stdout
       | from json
-      | where ('HostName' in $it) and not ($it.Host | str ends-with ".ipv6")
+      | where ("HostName" in $it) and not ($it.Host | str ends-with ".ipv6")
       | select Host HostName
       | rename Host pubIpv4
     );
 
     let ssh6Table = ($sshNodes.stdout
       | from json
-      | where ('HostName' in $it) and ($it.Host | str ends-with ".ipv6")
+      | where ("HostName" in $it) and ($it.Host | str ends-with ".ipv6")
       | select Host HostName
       | rename Host pubIpv6
-      | update Host {$in | str replace '.ipv6' ''}
-      | update pubIpv6 {if ($in == "unavailable.ipv6") { null } else { $in }}
+      | update Host {$in | str replace ".ipv6" ""}
+      | update pubIpv6 {if ($in == "unavailable.ipv6") {null} else {$in}}
       | select Host pubIpv6
     );
 
     let sshTable = ($ssh4Table
-      | dfr into-df
-      | dfr join -o ($ssh6Table | dfr into-df) Host Host
+      | polars into-df
+      | polars join -f ($ssh6Table | polars into-df) Host Host
+      | polars into-nu
+      | update Host {|i| default $i.Host_x}
+      | reject Host_x
+      | polars into-df
     );
 
     if ($sshTable | is-empty) {
-      [[Host pubIpv4 pubIpv6]; ["" "" ""]] | dfr into-df
+      [[Host pubIpv4 pubIpv6]; ["" "" ""]] | polars into-df
     }
     else {
       $sshTable
@@ -531,9 +543,13 @@ list-machines:
 
   (
     $nixosNodesDfr
-      | dfr join -o $sshNodesDfr machine Host
-      | dfr sort-by machine
-      | dfr into-nu
+      | polars join -f $sshNodesDfr machine Host
+      | polars into-nu
+      | update machine {|i| default $i.Host}
+      | reject Host
+      | polars into-df
+      | polars sort-by machine
+      | polars into-nu
       | update inNixosCfg {if $in == null {$"(ansi bg_red)Missing(ansi reset)"} else {$in}}
       | update pubIpv4 {if $in == null {$"(ansi bg_red)Missing(ansi reset)"} else {$in}}
       | update pubIpv6 {|row|
@@ -541,9 +557,9 @@ list-machines:
           (($row.inNixosCfg | str contains "Missing") or ($row.pubIpv4 | str contains "Missing"))
             and
           ($row.pubIpv6 == null)
-        ) {$"(ansi bg_red)Missing(ansi reset)"} else {$in} }
+        ) {$"(ansi bg_red)Missing(ansi reset)"} else {$in}}
       | where machine != ""
-  )
+  )'
 
 # Check mimir required config
 mimir-alertmanager-bootstrap:

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -180,7 +180,7 @@ in {
               filter = [
                 {
                   name = "name";
-                  values = ["nixos/24.05*"];
+                  values = ["nixos/24.11*"];
                 }
                 {
                   name = "architecture";

--- a/templates/cardano-parts-project/flake/opentofu/grafana/alerts/varnish.nix-import
+++ b/templates/cardano-parts-project/flake/opentofu/grafana/alerts/varnish.nix-import
@@ -6,7 +6,7 @@
     {
       alert = "VarnishCacheLowCacheHitRate";
       annotations = {
-        description = "The Cache hit rate is {{ printf \"%.0f\" $value }} percent over the last 10 minutes on {{$labels.instance}}, which is below the threshold of 80 percent.";
+        description = "The Cache hit rate is {{ printf \"%.0f\" $value }} percent over the last 1 hour on {{$labels.instance}}, which is below the threshold of 80 percent.";
         summary = "Cache is not answering a sufficient percentage of read requests.";
       };
 
@@ -36,7 +36,7 @@
           )
         > 100)
       '';
-      for = "10m";
+      for = "1h";
       labels = {severity = "warning";};
     }
     {

--- a/templates/cardano-parts-project/scripts/setup-delegation-accounts.py
+++ b/templates/cardano-parts-project/scripts/setup-delegation-accounts.py
@@ -105,7 +105,6 @@ def derive_payment_address_cli_skey(payment_key_file_str):
 def derive_stake_address(stake):
   cli_args = [
       "cardano-address",
-      "latest",
       "address",
       "stake",
       "--network-tag",
@@ -120,7 +119,6 @@ def derive_stake_address(stake):
 def derive_payment_address(payment):
   cli_args = [
       "cardano-address",
-      "latest",
       "address",
       "payment",
       "--network-tag",
@@ -135,7 +133,6 @@ def derive_payment_address(payment):
 def derive_delegation_address(payment_address, stake_vkey):
   cli_args = [
       "cardano-address",
-      "latest",
       "address",
       "delegation",
       stake_vkey


### PR DESCRIPTION
## Overview:
Nixpkgs has been updated to `24.11` and nix to `2.25.3`.  NixosModules and template just recipes with breaking changes from those updates were fixed.  A nix jobs GHA CI test was added to verify environment spin up procedure.  Template scripts were updated for compatibility with latest cardano-node protocol version and recent cardano-cli breaking changes, along with other miscellaneous improvements.

## Details:

* Important versioning updates:
  * Nixpkgs is now `24.11`
  * Nix is now `2.25.3` (maintenance)
  * Nushell (used in devShell just recipes) is now `0.100.0`
* Adds `cardano-testnet` to flakeModule pkgs and test+ devShells (ops included)
* Adds a template just `cardano-testnet` recipe to handle env setup for the cardano-testnet binary
* Adds a GHA CI test for nix jobs involving `create-cardano` and `create-testnet-data` environment spinups
* Adds nushell polars to the min+ devShells (ops included)
* Updates nixpkgs to `24.11` and includes required breaking change fixes to nixosModules
* Updates the template faucet dedelegation script for compatibility with cardano-node protocol version 10
* Updates the template tofu file for nixos 24.11 AMI images
* Fixes template recipes involving nushell breaking changes from `0.93` to `0.100`
* Fixes a bug in the template setup delegation accounts python script
* Fixes the template just start-demo recipe for cardano-cli 10.x breaking changes
* Tunes the template alert for the varnish low cache hit rate threshold to reduce false positives
* Bumps iohk-nix[-ng] for p2p established peers tuning
* Adds template colmena TCP transmission optimization code for reducing round-tripping over long distances

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* If you have a pre-existing nushell config at `~/.config/nu/config.nu`, the nushell update to version `0.100.0` which came with nixpkgs `24.11` may generate an error when entering a `nu` shell or running nushell scripts.  In this case, simply delete the existing `~/.config/nu/config.nu` file, or update it to a compatible version, for example, [here](https://github.com/nushell/nushell/blob/30f98f7e64a63a159ce70f02aa6c4c1196cd9ca7/crates/nu-utils/src/sample_config/default_config.nu)

### Recommended Updates:
* Apply the template Justfile diff and patch on the `Justfile` *before* bumping the cardano-parts pin to this release
  * This will break the just recipes until the cardano-parts pin is updated in the next step
* Update the cardano-parts pin to this release version `v2024-12-19`
  * This will fix the just recipes which already have the breaking change fixes from the prior step
* Continue to apply the template Justfile diff and patch or clone recipes on files described below.

### Action Items:
Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`.  Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the `just template-clone "$FILE"` recipe.

```
# Apply the diff and patch or clone *before* updating the cardano-parts pin to `v2024-12-19`
Justfile                                          # Nixpkgs 24.11 breaking change fixes 

# Apply the diff and patch or clone *after* updating the cardano-parts pin to `v2024-12-19`
.envrc                                            # For nix-direnv 3.0.6
flake/colmena.nix                                 # Optional: for the transmission optimization `tcpTxOpt` module code
flake/opentofu/cluster.nix                        # For 24.11 nixos AMI tofu filtering
flake/opentofu/grafana/alerts/varnish.nix-import  # For a less noisy varnish low cache rate alert
scripts/restore-delegation-accounts.py            # For PV 10 compatible dedelegation script
scripts/setup-delegation-accounts.py              # For a script bug fix
```

* Machines deployed with this release should be rebooted after the initial deployment to nixpkgs `24.11` to ensure use of the new kernel.