### PR TITLE
add: blockfrost-platform

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -175,11 +175,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1743612537,
-        "narHash": "sha256-BYLK37BKUCOK2Fos3XzLiIDgORVHeepDO5/HwJm0lug=",
+        "lastModified": 1744253041,
+        "narHash": "sha256-sqLdsTncR+FXxRC+fID8Zj+jkP6djC+EeF0Pabx7+u4=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "d4b494b3d9a3811eac67c0558ce1d805b69f229e",
+        "rev": "55e6885aff7c6dcc5aa5fba9abd3805e222cdb46",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -74,16 +74,15 @@
     "blockfrost-platform-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1743771926,
-        "narHash": "sha256-EOg/tCAJKPmK1xKBeetlGDQuKRrioct3InXej7QymMo=",
+        "lastModified": 1744287517,
+        "narHash": "sha256-0PSDq5rT0SvvSQ3TMnc1vjhrefMlIwt1d2eO06OUrVM=",
         "owner": "blockfrost",
         "repo": "blockfrost-platform",
-        "rev": "8638d10bf41b495660df44840a8ff3cc6c5757c3",
+        "rev": "9480822973bc156cda3b1bca9e92d70fa9a1a3dc",
         "type": "github"
       },
       "original": {
         "owner": "blockfrost",
-        "ref": "pull/273/head",
         "repo": "blockfrost-platform",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -71,6 +71,23 @@
         "type": "github"
       }
     },
+    "blockfrost-platform-service": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743771926,
+        "narHash": "sha256-EOg/tCAJKPmK1xKBeetlGDQuKRrioct3InXej7QymMo=",
+        "owner": "blockfrost",
+        "repo": "blockfrost-platform",
+        "rev": "8638d10bf41b495660df44840a8ff3cc6c5757c3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "blockfrost",
+        "ref": "pull/273/head",
+        "repo": "blockfrost-platform",
+        "type": "github"
+      }
+    },
     "blst": {
       "flake": false,
       "locked": {
@@ -1367,6 +1384,7 @@
     "root": {
       "inputs": {
         "auth-keys-hub": "auth-keys-hub",
+        "blockfrost-platform-service": "blockfrost-platform-service",
         "capkgs": "capkgs",
         "cardano-db-sync-schema": "cardano-db-sync-schema",
         "cardano-db-sync-schema-ng": "cardano-db-sync-schema-ng",

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,11 @@
       flake = false;
     };
 
+    blockfrost-platform-service = {
+      url = "github:blockfrost/blockfrost-platform/pull/273/head";
+      flake = false;
+    };
+
     cardano-tracer-service = {
       url = "github:IntersectMBO/cardano-node/jl/tracer-service";
       flake = false;

--- a/flake.nix
+++ b/flake.nix
@@ -78,7 +78,7 @@
     };
 
     blockfrost-platform-service = {
-      url = "github:blockfrost/blockfrost-platform/pull/273/head";
+      url = "github:blockfrost/blockfrost-platform";
       flake = false;
     };
 

--- a/flake/nixosModules/profile-cardano-parts.nix
+++ b/flake/nixosModules/profile-cardano-parts.nix
@@ -8,6 +8,7 @@
 #   config.cardano-parts.perNode.lib.opsLib
 #   config.cardano-parts.perNode.lib.topologyLib
 #   config.cardano-parts.perNode.meta.addressType
+#   config.cardano-parts.perNode.meta.blockfrost-platform-service
 #   config.cardano-parts.perNode.meta.cardanoDbSyncPrometheusExporterPort
 #   config.cardano-parts.perNode.meta.cardanoNodePort
 #   config.cardano-parts.perNode.meta.cardanoNodePrometheusExporterPort
@@ -148,6 +149,12 @@ flake @ {moduleWithSystem, ...}: {
           type = enum ["fqdn" "namePrivateIpv4" "namePublicIpv4" "namePublicIpv6" "privateIpv4" "publicIpv4" "publicIpv6"];
           description = mdDoc "The default addressType for topologyLib mkProducer function.";
           default = cfg.group.meta.addressType;
+        };
+
+        blockfrost-platform-service = mkOption {
+          type = str;
+          description = mdDoc "The blockfrost-platform-service import path string.";
+          default = cfg.group.meta.blockfrost-platform-service;
         };
 
         cardanoDbSyncPrometheusExporterPort = mkOption {

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -28,11 +28,11 @@
 #   flake.cardano-parts.cluster.groups.<default|name>.lib.opsLib
 #   flake.cardano-parts.cluster.groups.<default|name>.lib.topologyLib
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.addressType
+#   flake.cardano-parts.cluster.groups.<default|name>.meta.blockfrost-platform-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoDbSyncPrometheusExporterPort
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoNodePort
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoNodePrometheusExporterPort
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoSmashDelistedPools
-#   flake.cardano-parts.cluster.groups.<default|name>.meta.blockfrost-platform-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-db-sync-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-faucet-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-metadata-service
@@ -405,6 +405,12 @@ flake @ {
           else "fqdn";
       };
 
+      blockfrost-platform-service = mkOption {
+        type = str;
+        description = mdDoc "Cardano-parts cluster group blockfrost-platform-service import path string.";
+        default = cfg.pkgs.special.blockfrost-platform-service;
+      };
+
       cardanoDbSyncPrometheusExporterPort = mkOption {
         type = port;
         description = mdDoc "Cardano-parts cluster group cardanoDbSyncPrometheusExporterPort.";
@@ -427,12 +433,6 @@ flake @ {
         type = listOf str;
         description = mdDoc "Cardano-parts cluster group cardano-smash delisted pools.";
         default = [];
-      };
-
-      blockfrost-platform-service = mkOption {
-        type = str;
-        description = mdDoc "Cardano-parts cluster group blockfrost-platform-service import path string.";
-        default = cfg.pkgs.special.blockfrost-platform-service;
       };
 
       cardano-db-sync-service = mkOption {
@@ -521,16 +521,16 @@ flake @ {
 
   pkgsSubmodule = submodule {
     options = {
-      blockperf = mkOption {
-        type = functionTo package;
-        description = mdDoc "Cardano-parts cluster group default blockperf package.";
-        default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.blockperf);
-      };
-
       blockfrost-platform = mkOption {
         type = functionTo package;
         description = mdDoc "Cardano-parts cluster group default blockfrost-platform package.";
         default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.blockfrost-platform);
+      };
+
+      blockperf = mkOption {
+        type = functionTo package;
+        description = mdDoc "Cardano-parts cluster group default blockperf package.";
+        default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.blockperf);
       };
 
       cardano-cli = mkOption {

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -32,6 +32,7 @@
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoNodePort
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoNodePrometheusExporterPort
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoSmashDelistedPools
+#   flake.cardano-parts.cluster.groups.<default|name>.meta.blockfrost-platform-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-db-sync-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-faucet-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-metadata-service
@@ -45,6 +46,7 @@
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.environmentName
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.hostsList
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.blockperf
+#   flake.cardano-parts.cluster.groups.<default|name>.pkgs.blockfrost-platform
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-cli
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-db-sync
 #   flake.cardano-parts.cluster.groups.<default|name>.pkgs.cardano-db-sync-pkgs
@@ -427,6 +429,12 @@ flake @ {
         default = [];
       };
 
+      blockfrost-platform-service = mkOption {
+        type = str;
+        description = mdDoc "Cardano-parts cluster group blockfrost-platform-service import path string.";
+        default = cfg.pkgs.special.blockfrost-platform-service;
+      };
+
       cardano-db-sync-service = mkOption {
         type = str;
         description = mdDoc "Cardano-parts cluster group cardano-db-sync-service import path string.";
@@ -517,6 +525,12 @@ flake @ {
         type = functionTo package;
         description = mdDoc "Cardano-parts cluster group default blockperf package.";
         default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.blockperf);
+      };
+
+      blockfrost-platform = mkOption {
+        type = functionTo package;
+        description = mdDoc "Cardano-parts cluster group default blockfrost-platform package.";
+        default = system: withSystem system ({config, ...}: config.cardano-parts.pkgs.blockfrost-platform);
       };
 
       cardano-cli = mkOption {

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -102,7 +102,7 @@ in {
 
             DB_DIR="$DATA_DIR/db-''${ENVIRONMENT:-custom}"
 
-            # XXX: The following environment variables may be used to modify default process compose mithril behavior:
+            # The following environment variables may be used to modify default process compose mithril behavior:
             #   MITHRIL_DISABLE
             #   MITHRIL_SNAPSHOT_DIGEST
             #   MITHRIL_VERIFY_SNAPSHOT

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -102,7 +102,7 @@ in {
 
             DB_DIR="$DATA_DIR/db-''${ENVIRONMENT:-custom}"
 
-            # The following environment variables may be used to modify default process compose mithril behavior:
+            # XXX: The following environment variables may be used to modify default process compose mithril behavior:
             #   MITHRIL_DISABLE
             #   MITHRIL_SNAPSHOT_DIGEST
             #   MITHRIL_VERIFY_SNAPSHOT

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -24,9 +24,9 @@
 #   flake.cardano-parts.pkgs.special.cardano-tracer-service-ng
 #   flake.cardano-parts.pkgs.special.cardano-smash-service
 #   perSystem.cardano-parts.pkgs.bech32
-#   perSystem.cardano-parts.pkgs.cardano-address
 #   perSystem.cardano-parts.pkgs.blockfrost-platform
 #   perSystem.cardano-parts.pkgs.blockperf
+#   perSystem.cardano-parts.pkgs.cardano-address
 #   perSystem.cardano-parts.pkgs.cardano-cli
 #   perSystem.cardano-parts.pkgs.cardano-cli-ng
 #   perSystem.cardano-parts.pkgs.cardano-db-sync
@@ -117,6 +117,12 @@
 
   specialPkgsSubmodule = submodule {
     options = {
+      blockfrost-platform-service = mkOption {
+        type = str;
+        description = mdDoc "The cardano-parts default blockfrost-platform-service import path string.";
+        default = "${localFlake.inputs.blockfrost-platform-service}/nix/nixos";
+      };
+
       cardanoLib = mkOption {
         type = anything;
         description = mdDoc ''
@@ -271,12 +277,6 @@
           cardano-submit-api = withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-submit-api-ng);
           cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLibNg system;
         };
-      };
-
-      blockfrost-platform-service = mkOption {
-        type = str;
-        description = mdDoc "The cardano-parts default blockfrost-platform-service import path string.";
-        default = "${localFlake.inputs.blockfrost-platform-service}/nix/nixos";
       };
 
       cardano-db-sync-service = mkOption {
@@ -435,8 +435,8 @@ in
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
             (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-10-2-1-52b708f")
-            (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
             (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
+            (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-11-18-9eb5f59)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -436,12 +436,7 @@ in
             # TODO: Fix the missing meta/version info upstream
             (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-10-2-1-52b708f")
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
-            (
-              mkPkg "blockfrost-platform"
-              # FIXME: once <https://github.com/input-output-hk/capkgs/pull/4> is merged
-              # This is the 0.0.2 release:
-              (builtins.getFlake "github:blockfrost/blockfrost-platform/e06029b9da747fa5daa027605a918fc9fe103b7c").packages.x86_64-linux.default
-            )
+            (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-11-18-9eb5f59)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))
@@ -486,10 +481,10 @@ in
             (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
             (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2513-0-pre-1fb85a7 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-0d66de9 {meta.mainProgram = "mithril-client";}))
+            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-c2b3494 {meta.mainProgram = "mithril-client";}))
             # To update once capkgs builds and caches 2506 signer successfully
             (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2513-0-pre-1fb85a7 {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-0d66de9 {meta.mainProgram = "mithril-signer";}))
+            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-c2b3494 {meta.mainProgram = "mithril-signer";}))
             (mkPkg "orchestrator-cli" caPkgs.orchestrator-cli-IntersectMBO-credential-manager-0-1-2-0-081cc8c)
             (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
             (mkPkg "tx-bundle" caPkgs.tx-bundle-IntersectMBO-credential-manager-0-1-2-0-081cc8c)

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -3,6 +3,7 @@
 # TODO: Move this to a docs generator
 #
 # Attributes available on flakeModule import:
+#   flake.cardano-parts.pkgs.special.blockfrost-platform-service
 #   flake.cardano-parts.pkgs.special.cardanoLib
 #   flake.cardano-parts.pkgs.special.cardanoLibCustom
 #   flake.cardano-parts.pkgs.special.cardanoLibNg
@@ -24,6 +25,7 @@
 #   flake.cardano-parts.pkgs.special.cardano-smash-service
 #   perSystem.cardano-parts.pkgs.bech32
 #   perSystem.cardano-parts.pkgs.cardano-address
+#   perSystem.cardano-parts.pkgs.blockfrost-platform
 #   perSystem.cardano-parts.pkgs.blockperf
 #   perSystem.cardano-parts.pkgs.cardano-cli
 #   perSystem.cardano-parts.pkgs.cardano-cli-ng
@@ -271,6 +273,12 @@
         };
       };
 
+      blockfrost-platform-service = mkOption {
+        type = str;
+        description = mdDoc "The cardano-parts default blockfrost-platform-service import path string.";
+        default = "${localFlake.inputs.blockfrost-platform-service}/nix/nixos";
+      };
+
       cardano-db-sync-service = mkOption {
         type = str;
         description = mdDoc "The cardano-parts default cardano-db-sync-service import path string.";
@@ -428,6 +436,12 @@ in
             # TODO: Fix the missing meta/version info upstream
             (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-10-2-1-52b708f")
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
+            (
+              mkPkg "blockfrost-platform"
+              # FIXME: once <https://github.com/input-output-hk/capkgs/pull/4> is merged
+              # This is the 0.0.2 release:
+              (builtins.getFlake "github:blockfrost/blockfrost-platform/e06029b9da747fa5daa027605a918fc9fe103b7c").packages.x86_64-linux.default
+            )
             (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2024-11-18-9eb5f59)
             (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))
@@ -495,6 +509,7 @@ in
             inherit
               (cfgPkgs)
               bech32
+              blockfrost-platform
               blockperf
               cc-sign
               cardano-address

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -273,8 +273,7 @@ in
                 extraCfg.pkgs = mkOption {
                   default =
                     config.cardano-parts.shell.min.pkgs
-                    # FIXME: revert, `nix-2.17.0` can’t build `blockfrost-platform`
-                    ++ builtins.filter (a: a ? pname && a.pname != "nix") localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
+                    ++ localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
                     ++ (with pkgs; [
                       ghcid
                     ]);
@@ -352,8 +351,7 @@ in
                 extraCfg.pkgs = mkOption {
                   default =
                     config.cardano-parts.shell.ops.pkgs
-                    # FIXME: revert, `nix-2.17.0` can’t build `blockfrost-platform`
-                    ++ builtins.filter (a: a ? pname && a.pname != "nix") localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
+                    ++ localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
                     ++ (with pkgs; [
                       ghcid
                     ]);

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -273,7 +273,8 @@ in
                 extraCfg.pkgs = mkOption {
                   default =
                     config.cardano-parts.shell.min.pkgs
-                    ++ localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
+                    # FIXME: revert, `nix-2.17.0` can’t build `blockfrost-platform`
+                    ++ builtins.filter (a: a ? pname && a.pname != "nix") localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
                     ++ (with pkgs; [
                       ghcid
                     ]);
@@ -290,6 +291,7 @@ in
                         b2sum
                         haskellPackages.cbor-tool
                         bech32
+                        blockfrost-platform
                         cardano-address
                         cardano-cli
                         cardano-node
@@ -350,7 +352,8 @@ in
                 extraCfg.pkgs = mkOption {
                   default =
                     config.cardano-parts.shell.ops.pkgs
-                    ++ localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
+                    # FIXME: revert, `nix-2.17.0` can’t build `blockfrost-platform`
+                    ++ builtins.filter (a: a ? pname && a.pname != "nix") localFlake.inputs.haskell-nix.devShells.${system}.default.buildInputs
                     ++ (with pkgs; [
                       ghcid
                     ]);


### PR DESCRIPTION
## Context

We (Blockfrost) were asked to add `blockfrost-platform` to `cardano-parts` – see the details in:
* https://github.com/blockfrost/blockfrost-platform/issues/272

Related PR in `capkgs`:
* https://github.com/input-output-hk/capkgs/pull/4

Related PR in `blockfrost-platform` (the NixOS service):
* https://github.com/blockfrost/blockfrost-platform/pull/273

## To-dos

- [x] it seems GitHub Actions [can’t check PRs](https://github.com/input-output-hk/cardano-parts/actions/runs/14266335899/job/39988960811?pr=62) from forks in this repo, too
- [x] fix & merge the `capkgs` PR
- [x] use the `capkgs` PR here
- [ ] ~~should we define a Grafana dashboard? There's one at [jadjei/icebreaker-dashboard](https://github.com/jadjei/icebreaker-dashboard/)~~\
      _yes, but later_
- [ ] ~~should we add it to `process-compose`?~~\
      _yes, but later_