### PR TITLE
Node 10.3.1, Cli 10.7.0.0, release

### DIFF
--- a/.github/workflows/nix-jobs-test.yaml
+++ b/.github/workflows/nix-jobs-test.yaml
@@ -130,14 +130,12 @@ jobs:
             done
           }
 
-          # Pause release tests on versions < node 10.3.1
-          # Re-enable when node release is >= 10.3.1
-          # echo "Run nix job tests with release versioning..."
-          # echo "Running legacy sequence tests..."
-          # RUN_TESTS "${JOB_SEQ_LEGACY[@]}"
-          #
-          # echo "Running sequence tests..."
-          # RUN_TESTS "${JOB_SEQ[@]}"
+          echo "Run nix job tests with release versioning..."
+          echo "Running legacy sequence tests..."
+          RUN_TESTS "${JOB_SEQ_LEGACY[@]}"
+
+          echo "Running sequence tests..."
+          RUN_TESTS "${JOB_SEQ[@]}"
 
           echo "Now run nix job tests again with pre-release versioning..."
           set -x

--- a/flake.lock
+++ b/flake.lock
@@ -90,16 +90,16 @@
     "blst": {
       "flake": false,
       "locked": {
-        "lastModified": 1691598027,
-        "narHash": "sha256-oqljy+ZXJAXEB/fJtmB8rlAr4UXM+Z2OkDa20gpILNA=",
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "3dd0f804b1819e5d03fb22ca2e6fac105932043a",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.11",
+        "ref": "v0.3.14",
         "repo": "blst",
         "type": "github"
       }
@@ -792,11 +792,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1740527380,
-        "narHash": "sha256-0sF0RUsnFVdRMoS9amtRQs6TnCFynDFdbzn8zBLD5Bg=",
+        "lastModified": 1744130217,
+        "narHash": "sha256-Lql0s3Occ6gKLvjcqTPK6vW4l1jwNn/UV7uaVpB/jTg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ea26f2ca1686656d89bb5760f717f713168cd5a5",
+        "rev": "dd47887a0482bfb1399c9da77175933876d0f4ab",
         "type": "github"
       },
       "original": {

--- a/flake/nixosModules/profile-cardano-custom-metrics.nix
+++ b/flake/nixosModules/profile-cardano-custom-metrics.nix
@@ -24,6 +24,8 @@
     perNodeCfg = config.cardano-parts.perNode;
     cfg = config.services.cardano-custom-metrics;
   in {
+    key = ./profile-cardano-custom-metrics.nix;
+
     options.services.cardano-custom-metrics = {
       address = mkOption {
         type = str;

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -93,6 +93,8 @@
     cfg = nixos.config.services.cardano-node;
     cfgMithril = nixos.config.services.mithril-client;
   in {
+    key = ./profile-cardano-node-group.nix;
+
     # Leave the import of the upstream cardano-node service for
     # cardano-parts consuming repos so that service import can be customized.
     #

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -434,11 +434,11 @@ in
         pkgsSubmodule = submodule {
           options = foldl' recursiveUpdate {} [
             # TODO: Fix the missing meta/version info upstream
-            (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "bech32" caPkgs."bech32-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
             (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
-            (mkPkg "cardano-address" caPkgs.cardano-address-cardano-foundation-cardano-wallet-v2025-03-31-1649791)
-            (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.4.0.0";}))
+            (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
+            (mkPkg "cardano-cli" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-3-1-b3f237b" // {version = "10.7.0.0";}))
             (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-input-output-hk-cardano-node-10-3-1-b3f237b" // {version = "10.7.0.0";}))
             (mkPkg "cardano-db-sync" (recursiveUpdate caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-6-0-5-cb61094" {meta.mainProgram = "cardano-db-sync";}))
             (mkPkg "cardano-db-sync-ng" (recursiveUpdate caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-6-0-5-cb61094" {meta.mainProgram = "cardano-db-sync";}))
@@ -451,16 +451,16 @@ in
             (mkPkg "cardano-faucet" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
             (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
 
-            (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-10-2-1-52b708f" // {version = "10.2.1";}))
+            (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-10-3-1-b3f237b" // {version = "10.3.1";}))
             (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-3-1-b3f237b" // {version = "10.3.1";}))
             (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
             (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-6-0-5-cb61094)
             (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-6-0-5-cb61094)
-            (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-3-1-b3f237b")
-            (mkPkg "cardano-testnet" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "cardano-testnet" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-3-1-b3f237b")
-            (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2025-03-31-1649791
               // {
@@ -468,11 +468,11 @@ in
                 meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
               }))
             (mkPkg "cc-sign" caPkgs.cc-sign-IntersectMBO-credential-manager-0-1-3-0-2d82213)
-            (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-3-1-b3f237b")
-            (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-3-1-b3f237b")
-            (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-10-2-1-52b708f")
+            (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-3-1-b3f237b")
             (mkPkg "isd" caPkgs.isd-isd-project-isd-v0-5-1-51d52a2)
             (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v1-46-0-6a1799e)


### PR DESCRIPTION
## Overview:
Sets node release to `10.3.1`, cardano-cli release to `10.7.0.0`.

## Details:

* Important versioning updates:
  * Cardano-node release is now `10.3.1`
  * Cardano-cli release is now `10.7.0.0`
  * Cardano-address is now `4.0.0`
* Adds a module deduplication key
* Fixes CI spin up job tests for the node release version update

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* N/A

### Recommended Updates:
* Update the cardano-parts pin to this release version `v2025-04-28`

### Action Items:
* N/A
