### PR TITLE
Node-ng 10.5.0, Cli-ng 10.11.0.0, ssh over ssm

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
 fi
@@ -5,13 +6,13 @@ fi
 IGREEN='\e[0;92m'
 IRED='\e[0;91m'
 NC='\e[0m'
-if [ $(nix eval --impure --expr 'let f = builtins.getFlake "git+file://${toString ./.}"; in f.lib.versionAtLeast builtins.nixVersion "2.17.0"') != "true" ]; then
+if [ "$(nix eval --impure --expr "let f = builtins.getFlake \"git+file://\${toString ./.}\"; in f.lib.versionAtLeast builtins.nixVersion \"2.17.0\"")" != "true" ]; then
   echo -e "The nix version must be at least ${IGREEN}2.17.0${NC} for fetchClosure of pure packages."
   echo -e "Your version is ${IRED}$(nix --version)${NC}"
   exit
 fi
 
-if [ $(nix eval --expr 'builtins ? fetchClosure') != "true" ]; then
+if [ "$(nix eval --expr 'builtins ? fetchClosure')" != "true" ]; then
   echo -e "Experimental nix feature \"${IGREEN}fetch-closure${NC}\" ${IRED}must be enabled${NC} for fetchClosure of pure packages."
   echo "You may need to add the following to your nix config:"
   echo
@@ -19,10 +20,11 @@ if [ $(nix eval --expr 'builtins ? fetchClosure') != "true" ]; then
   exit
 fi
 
+# shellcheck disable=SC1091
 [ -f .envrc.local ] && source .envrc.local
 
 if [ -n "${DEVSHELL_TARGET:-}" ]; then
-  use flake .#${DEVSHELL_TARGET}
+  use flake ".#$DEVSHELL_TARGET"
 else
   use flake
 fi

--- a/flake.lock
+++ b/flake.lock
@@ -101,11 +101,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1746627884,
-        "narHash": "sha256-wcu/pOW54b2t+tL8bzW7pcGNTzKGEbeAzCkScZzT3Ig=",
+        "lastModified": 1750254939,
+        "narHash": "sha256-P0N8TOddVyzHkIpDPdGsXbhR6W1vAhpOUvZPvyrrcNY=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "5645b1f13ecc500569754284b5f2ad2772c637d0",
+        "rev": "ba03172728d491a2a1619755c885a3bcdbdfb43c",
         "type": "github"
       },
       "original": {
@@ -201,17 +201,17 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1746450573,
-        "narHash": "sha256-Szhph7YncIbQ+/QmqzSW61WLConBa8XIA6K/3A8mP00=",
+        "lastModified": 1750182374,
+        "narHash": "sha256-fLNUecLWwZTvJuyekr53mb3fcC+tvCu6UBJuJ4vcYHI=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0983ac29304aadac74a5604eeefa76cfbcc91611",
+        "rev": "7e045ab501e99130a57f363f0964bb4f241c6550",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
+        "ref": "10.5.0",
         "repo": "cardano-node",
-        "rev": "0983ac29304aadac74a5604eeefa76cfbcc91611",
         "type": "github"
       }
     },
@@ -477,11 +477,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1747796208,
-        "narHash": "sha256-ZUBNrv+lO0CWhnN0R0ZiG/eIB+W5pnyAGsxf/lozECo=",
+        "lastModified": 1750025513,
+        "narHash": "sha256-WUNoYIZvU9moc5ccwJcF22r+bUJXO5dWoRyLPs8bJic=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "281f635b01f8fe843baefe010a694f67041c0848",
+        "rev": "f63aa2a49720526900fb5943db4123b5b8dcc534",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -106,8 +106,7 @@
     };
 
     cardano-node-service-ng = {
-      # Until node >= 10.5.0 is tagged, this commit allows the service to work on nixpkgs >= 25.05
-      url = "github:IntersectMBO/cardano-node/0983ac29304aadac74a5604eeefa76cfbcc91611";
+      url = "github:IntersectMBO/cardano-node/10.5.0";
       flake = false;
     };
 

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -30,11 +30,7 @@
 
         networking = {
           hostName = name;
-          firewall = {
-            enable = true;
-            allowedTCPPorts = [22];
-            allowedUDPPorts = [];
-          };
+          firewall.enable = true;
         };
 
         time.timeZone = "UTC";

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -53,49 +53,59 @@
           doc.enable = false;
         };
 
-        environment.systemPackages = with pkgs; [
-          awscli2
-          age
-          bat
-          bind
-          cloud-utils
-          di
-          dnsutils
-          fd
-          fx
-          file
-          git
-          glances
-          helix
-          htop
-          icdiff
-          ijq
-          iptables
-          self'.packages.isd
-          jiq
-          jq
-          lsof
-          nano
-          # For nix >= 2.24 build compatibility
-          inputs.nixpkgs-unstable.legacyPackages.${system}.neovim
-          ncdu
-          # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 24.11 causing missing features error
-          inputs.nixpkgs.legacyPackages.${system}.nushell
-          nvme-cli
-          parted
-          pciutils
-          procps
-          ripgrep
-          rsync
-          ssm-session-manager-plugin
-          smem
-          ssh-to-age
-          sops
-          sysstat
-          tcpdump
-          tree
-          wget
-        ];
+        environment = {
+          shellInit = ''
+            # This can be used to simplify ssh sessions, rsync, ex:
+            #   ssh -o "$(ssm-proxy-cmd "$REGION")" "$INSTANCE_ID"
+            ssm-proxy-cmd() {
+              echo "ProxyCommand=sh -c 'aws --region $1 ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p'"
+            }
+          '';
+
+          systemPackages = with pkgs; [
+            awscli2
+            age
+            bat
+            bind
+            cloud-utils
+            di
+            dnsutils
+            fd
+            fx
+            file
+            git
+            glances
+            helix
+            htop
+            icdiff
+            ijq
+            iptables
+            self'.packages.isd
+            jiq
+            jq
+            lsof
+            nano
+            # For nix >= 2.24 build compatibility
+            inputs.nixpkgs-unstable.legacyPackages.${system}.neovim
+            ncdu
+            # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 24.11 causing missing features error
+            inputs.nixpkgs.legacyPackages.${system}.nushell
+            nvme-cli
+            parted
+            pciutils
+            procps
+            ripgrep
+            rsync
+            ssm-session-manager-plugin
+            smem
+            ssh-to-age
+            sops
+            sysstat
+            tcpdump
+            tree
+            wget
+          ];
+        };
 
         programs = {
           tmux = {

--- a/flake/nixosModules/profile-basic.nix
+++ b/flake/nixosModules/profile-basic.nix
@@ -87,6 +87,7 @@
           procps
           ripgrep
           rsync
+          ssm-session-manager-plugin
           smem
           ssh-to-age
           sops

--- a/flake/nixosModules/profile-cardano-node-topology.nix
+++ b/flake/nixosModules/profile-cardano-node-topology.nix
@@ -97,6 +97,7 @@
           # These are also set from the role-block-producer nixos module
           extraNodeConfig = {
             PeerSharing = false;
+            TargetNumberOfKnownPeers = 100;
             TargetNumberOfRootPeers = 100;
           };
           publicProducers = mkForce (extraNodeListPublicProducers ++ extraPublicProducers);

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -434,68 +434,78 @@ in
           };
         };
 
-        pkgsSubmodule = submodule {
-          options = foldl' recursiveUpdate {} [
-            # TODO: Fix the missing meta/version info upstream
-            (mkPkg "bech32" caPkgs.bech32-input-output-hk-cardano-node-10-4-1-420c94f)
-            (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
-            # (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
-            (mkPkg "blockperf" localFlake.inputs.blockperf.packages.x86_64-linux.blockperf)
-            (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
-            (mkPkg "cardano-cli" (caPkgs.cardano-cli-input-output-hk-cardano-node-10-4-1-420c94f // {version = "10.8.0.0";}))
-            (mkPkg "cardano-cli-ng" (caPkgs.cardano-cli-input-output-hk-cardano-node-10-4-1-420c94f // {version = "10.8.0.0";}))
-            (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-6-0-5-cb61094")
-            (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-input-output-hk-cardano-db-sync-13-6-0-5-cb61094")
-            (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-input-output-hk-cardano-db-sync-13-6-0-5-cb61094")
-            (mkPkg "cardano-db-tool-ng" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-input-output-hk-cardano-db-sync-13-6-0-5-cb61094")
+        pkgsSubmodule = let
+          credential-manager-release = "IntersectMBO-credential-manager-0-1-3-0-2d82213";
+          dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
+          dbsync-pre-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
+          metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
+          mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
+          mithril-pre-release = "input-output-hk-mithril-unstable-867fdbb";
+          node-release = "input-output-hk-cardano-node-10-4-1-420c94f";
+          node-pre-release = "input-output-hk-cardano-node-10-5-0-7e045ab";
+        in
+          submodule {
+            options = foldl' recursiveUpdate {} [
+              # TODO: Fix the missing meta/version info upstream
+              (mkPkg "bech32" caPkgs."bech32-${node-release}")
+              (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
+              # (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
+              (mkPkg "blockperf" localFlake.inputs.blockperf.packages.x86_64-linux.blockperf)
+              (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
+              (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.8.0.0";}))
+              (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))
+              (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-release}")
+              (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-pre-release}")
+              (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-release}")
+              (mkPkg "cardano-db-tool-ng" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-pre-release}")
 
-            # For tmp local faucet testing:
-            # (mkPkg "cardano-faucet" localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet")
-            # (mkPkg "cardano-faucet-ng" localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet")
-            (mkPkg "cardano-faucet" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
-            (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
+              # For tmp local faucet testing:
+              # (mkPkg "cardano-faucet" localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet")
+              # (mkPkg "cardano-faucet-ng" localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet")
+              (mkPkg "cardano-faucet" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
+              (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
 
-            (mkPkg "cardano-node" (caPkgs."cardano-node-input-output-hk-cardano-node-10-4-1-420c94f" // {version = "10.4.1";}))
-            (mkPkg "cardano-node-ng" (caPkgs."cardano-node-input-output-hk-cardano-node-10-4-1-420c94f" // {version = "10.4.1";}))
-            (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
-            (mkPkg "cardano-smash" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-6-0-5-cb61094)
-            (mkPkg "cardano-smash-ng" caPkgs.cardano-smash-server-no-basic-auth-input-output-hk-cardano-db-sync-13-6-0-5-cb61094)
-            (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "cardano-testnet" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "cardano-tracer" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2025-03-31-1649791
-              // {
-                pname = "cardano-wallet";
-                meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
-              }))
-            (mkPkg "cc-sign" caPkgs.cc-sign-IntersectMBO-credential-manager-0-1-3-0-2d82213)
-            (mkPkg "colmena" localFlake.inputs.colmena.packages.${system}.colmena)
-            (mkPkg "db-analyser" caPkgs."db-analyser-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "db-analyser-ng" caPkgs."db-analyser-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "db-synthesizer" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "db-truncater" caPkgs."db-truncater-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "db-truncater-ng" caPkgs."db-truncater-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "isd" caPkgs.isd-isd-project-isd-v0-5-1-51d52a2)
-            (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v1-46-0-6a1799e)
-            (mkPkg "metadata-server" caPkgs.metadata-server-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
-            (mkPkg "metadata-sync" caPkgs.metadata-sync-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
-            (mkPkg "metadata-validator-github" caPkgs.metadata-validator-github-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
-            (mkPkg "metadata-webhook" caPkgs.metadata-webhook-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d)
-            (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-2517-1-b1a2faa {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs.mithril-client-cli-input-output-hk-mithril-unstable-346b447 {meta.mainProgram = "mithril-client";}))
-            (mkPkg "mithril-signer" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-2517-1-b1a2faa {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs.mithril-signer-input-output-hk-mithril-unstable-346b447 {meta.mainProgram = "mithril-signer";}))
-            (mkPkg "orchestrator-cli" caPkgs.orchestrator-cli-IntersectMBO-credential-manager-0-1-3-0-2d82213)
-            (mkPkg "snapshot-converter" caPkgs."snapshot-converter-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "snapshot-converter-ng" caPkgs."snapshot-converter-input-output-hk-cardano-node-10-4-1-420c94f")
-            (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs.token-metadata-creator-input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d {meta.mainProgram = "token-metadata-creator";}))
-            (mkPkg "tx-bundle" caPkgs.tx-bundle-IntersectMBO-credential-manager-0-1-3-0-2d82213)
-          ];
-        };
+              (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.4.1";}))
+              (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.0";}))
+              (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
+              (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")
+              (mkPkg "cardano-smash-ng" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-pre-release}")
+              (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-${node-release}")
+              (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-${node-pre-release}")
+              (mkPkg "cardano-testnet" caPkgs."cardano-testnet-${node-release}")
+              (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-${node-pre-release}")
+              (mkPkg "cardano-tracer" caPkgs."cardano-tracer-${node-release}")
+              (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-${node-pre-release}")
+              (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2025-03-31-1649791
+                // {
+                  pname = "cardano-wallet";
+                  meta.description = "HTTP server and command-line for managing UTxOs and HD wallets in Cardano.";
+                }))
+              (mkPkg "cc-sign" caPkgs."cc-sign-${credential-manager-release}")
+              (mkPkg "colmena" localFlake.inputs.colmena.packages.${system}.colmena)
+              (mkPkg "db-analyser" caPkgs."db-analyser-${node-release}")
+              (mkPkg "db-analyser-ng" caPkgs."db-analyser-${node-pre-release}")
+              (mkPkg "db-synthesizer" caPkgs."db-synthesizer-${node-release}")
+              (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-${node-pre-release}")
+              (mkPkg "db-truncater" caPkgs."db-truncater-${node-release}")
+              (mkPkg "db-truncater-ng" caPkgs."db-truncater-${node-pre-release}")
+              (mkPkg "isd" caPkgs.isd-isd-project-isd-v0-5-1-51d52a2)
+              (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v1-46-0-6a1799e)
+              (mkPkg "metadata-server" caPkgs."metadata-server-${metadata-server-release}")
+              (mkPkg "metadata-sync" caPkgs."metadata-sync-${metadata-server-release}")
+              (mkPkg "metadata-validator-github" caPkgs."metadata-validator-github-${metadata-server-release}")
+              (mkPkg "metadata-webhook" caPkgs."metadata-webhook-${metadata-server-release}")
+              (mkPkg "mithril-client-cli" (recursiveUpdate caPkgs."mithril-client-cli-${mithril-release}" {meta.mainProgram = "mithril-client";}))
+              (mkPkg "mithril-client-cli-ng" (recursiveUpdate caPkgs."mithril-client-cli-${mithril-pre-release}" {meta.mainProgram = "mithril-client";}))
+              (mkPkg "mithril-signer" (recursiveUpdate caPkgs."mithril-signer-${mithril-release}" {meta.mainProgram = "mithril-signer";}))
+              (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs."mithril-signer-${mithril-pre-release}" {meta.mainProgram = "mithril-signer";}))
+              (mkPkg "orchestrator-cli" caPkgs."orchestrator-cli-${credential-manager-release}")
+              (mkPkg "snapshot-converter" caPkgs."snapshot-converter-${node-release}")
+              (mkPkg "snapshot-converter-ng" caPkgs."snapshot-converter-${node-pre-release}")
+              (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs."token-metadata-creator-${metadata-server-release}" {meta.mainProgram = "token-metadata-creator";}))
+              (mkPkg "tx-bundle" caPkgs."tx-bundle-${credential-manager-release}")
+            ];
+          };
       in {
         # perSystem level option definition
         options.cardano-parts = mkOption {

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -259,7 +259,6 @@ in
                     moreutils
                     # Add a localFlake pin to avoid downstream repo nixpkgs pins <= 23.05 causing a missing features failure
                     localFlake.inputs.nixpkgs.legacyPackages.${system}.nushell
-                    localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellPlugins.polars
                     patch
                     ripgrep
                     statix
@@ -428,7 +427,6 @@ in
                     selectScope id optionalString "enableHooks" "defaultHooks"
                     + selectScope id optionalAttrs "enableFormatter" "defaultFormatterHook"
                     + ''
-                      export NUSHELL_PLUGINS_POLARS="${getExe localFlake.inputs.nixpkgs.legacyPackages.${system}.nushellPlugins.polars}"
                       [ -z "$NOMENU" ] && menu
                     '';
                 }

--- a/perSystem/packages/terraform.nix
+++ b/perSystem/packages/terraform.nix
@@ -69,6 +69,7 @@
           (providerFor "fgouteroux" "mimir")
           (providerFor "grafana" "grafana")
           (providerFor "opentofu" "aws")
+          (providerFor "opentofu" "awscc")
           (providerFor "opentofu" "local")
           (providerFor "opentofu" "external")
           (providerFor "opentofu" "null")

--- a/templates/cardano-parts-project/.envrc
+++ b/templates/cardano-parts-project/.envrc
@@ -1,3 +1,4 @@
+# shellcheck disable=SC2148
 if ! has nix_direnv_version || ! nix_direnv_version 3.0.6; then
   source_url "https://raw.githubusercontent.com/nix-community/nix-direnv/3.0.6/direnvrc" "sha256-RYcUJaRMf8oF5LznDrlCXbkOQrywm0HDv1VjYGaJGdM="
 fi
@@ -5,13 +6,13 @@ fi
 IGREEN='\033[0;92m'
 IRED='\033[0;91m'
 NC='\033[0m'
-if [ $(nix eval --impure --expr 'let f = builtins.getFlake "git+file://${toString ./.}"; in f.lib.versionAtLeast builtins.nixVersion "2.17.0"') != "true" ]; then
+if [ "$(nix eval --impure --expr "let f = builtins.getFlake \"git+file://\${toString ./.}\"; in f.lib.versionAtLeast builtins.nixVersion \"2.17.0\"")" != "true" ]; then
   echo -e "The nix version must be at least ${IGREEN}2.17.0${NC} for fetchClosure of pure packages."
   echo -e "Your version is ${IRED}$(nix --version)${NC}"
   exit
 fi
 
-if [ $(nix eval --expr 'builtins ? fetchClosure') != "true" ]; then
+if [ "$(nix eval --expr 'builtins ? fetchClosure')" != "true" ]; then
   echo -e "Experimental nix feature \"${IGREEN}fetch-closure${NC}\" ${IRED}must be enabled${NC} for fetchClosure of pure packages."
   echo "You may need to add the following to your nix config:"
   echo
@@ -19,6 +20,7 @@ if [ $(nix eval --expr 'builtins ? fetchClosure') != "true" ]; then
   exit
 fi
 
+# shellcheck disable=SC1091
 [ -f .envrc.local ] && source .envrc.local
 
 if [ -z "${SOPS_AGE_KEY_FILE:-}" ] && [ -f ~/.age/credentials ]; then
@@ -26,7 +28,7 @@ if [ -z "${SOPS_AGE_KEY_FILE:-}" ] && [ -f ~/.age/credentials ]; then
 fi
 
 if [ -n "${DEVSHELL_TARGET:-}" ]; then
-  use flake .#${DEVSHELL_TARGET}
+  use flake ".#$DEVSHELL_TARGET"
 else
   use flake
 fi

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -817,7 +817,13 @@ ssh-bootstrap HOSTNAME *ARGS:
 ssh-for-all *ARGS:
   #!/usr/bin/env nu
   let nodes = (nix eval --json '.#nixosConfigurations' --apply builtins.attrNames | from json)
-  $nodes | par-each {|node| just ssh -q $node {{ARGS}}}
+  $nodes | par-each {|node|
+    let result = (do -i { ^just ssh -q $node {{ARGS}} } | complete)
+    {
+      index: $node,
+      result: $result
+    }
+  }
 
 # Ssh for select
 ssh-for-each HOSTNAMES *ARGS:

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -58,155 +58,133 @@ checkSshConfig := '''
     exit 1
   }
 
-  let checkFile = ".consistency-check-ts"
-
-  # Checking modified timestamps to decide whether to eval nixosCfgs which costs ~0.5s per ssh command
-  let runCheck = if ($checkFile | path exists) {
-    let checkTs = (stat -c %Y $checkFile) | into int
-    let colmenaTs = (stat -c %Y flake/colmena.nix) | into int
-    let sshHostsTs = (stat -c %Y .ssh_config) | into int
-    let moduleIpsTs = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
-      (stat -c %Y flake/nixosModules/ips-DONT-COMMIT.nix) | into int
+  def file-ts [path] {
+    if ($path | path exists) {
+      (stat -c %Y $path) | into int
     } else {
       0
     }
+  }
 
+  def list-diff [left right lName rName] {
+    {
+      $lName: ($left | where $it not-in $right)
+      $rName: ($right | where $it not-in $left)
+      eq: ($left | where $it in $right)
+    }
+      | transpose where item
+      | flatten
+      | select item where
+      | where where != "eq"
+      | sort-by item
+      | enumerate
+      | each { |r| { index: ($r.index + 1) } | merge $r.item }
+  }
+
+  const checkFile = ".consistency-check-ts"
+  const hasIpModule = ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists)
+
+  let runCheck = if ($checkFile | path exists) {
+    let checkTs = (file-ts $checkFile)
+    let colmenaTs = (file-ts "flake/colmena.nix")
+    let sshHostsTs = (file-ts ".ssh_config")
+    let moduleIpsTs = (file-ts "flake/nixosModules/ips-DONT-COMMIT.nix")
     ($checkTs < $colmenaTs) or ($checkTs < $sshHostsTs) or ($checkTs < $moduleIpsTs)
   } else {
     true
   }
 
-  # Sanity check nixosConfigurations, ssh hosts and module ips agree
-  if ($runCheck == true) {
-    print "Checking nixosCfg, sshCfg and ipModuleCfg for consistency"
+  if $runCheck {
+    print "Checking nixosCfg, sshCfg, and ipModuleCfg for consistency..."
 
-    def list-diff [left: list<any>, right: list<any>, lName: string, rName: string]: nothing -> table<item: any, where: string> {
-      let comparison = {
-        $lName: ($left | where $it not-in $right)
-        $rName: ($right | where $it not-in $left)
-        eq: ($left | where $it in $right)
-      }
+    let nixosCfg = (nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames" | from json)
 
-      $comparison | transpose where item | flatten | select item where | sort-by item
-    }
-
-    mut consistent = true
-
-    let nixosCfg = (nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames") | from json
-
-    # Ssh config header manual changes can be made without breaking parsing as
-    # long as they come after the `Host *$` line. Host modifications can also be
-    # made as long as any host changes come after the `  HostName .*$` line for
-    # each respective host.
-    let sshCfg = (open .ssh_config
+    let sshCfg = (
+      open .ssh_config
       | collect
       | parse --regex `(?m)Host (.*)\n\s+HostName (.*)`
       | rename machine ip
-      | sort-by machine)
+      | sort-by machine
+    )
 
-    let ssh4Cfg = ($sshCfg
-      | where not ($it.machine | str ends-with ".ipv6")
+    let ssh4Cfg = (
+      $sshCfg
+      | where ($it.machine | str ends-with ".ipv4")
       | rename machine pubIpv4
-      | sort-by machine)
+      | update machine { $in | str replace ".ipv4" "" }
+      | sort-by machine
+    )
 
-    let ssh6Cfg = ($sshCfg
+    let ssh6Cfg = (
+      $sshCfg
       | where ($it.machine | str ends-with ".ipv6")
       | rename machine pubIpv6
-      | update machine {$in | str replace ".ipv6" ""}
-      | update pubIpv6 {if ($in == "unavailable.ipv6") {null} else {$in}}
-      | sort-by machine)
+      | update machine { $in | str replace ".ipv6" "" }
+      | update pubIpv6 { $in | if $in == "unavailable.ipv6" { null } else { $in } }
+      | sort-by machine
+    )
 
-    let moduleIps = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
-      (open flake/nixosModules/ips-DONT-COMMIT.nix
-        | collect
-        | parse --regex `(?ms)(.*)^  };\nin {.*`
-        | get capture0
-        | parse --regex `(?m)    (.*) = {$\n\s+privateIpv4 = \"(.*)";\n\s+publicIpv4 = \"(.*)";\n\s+publicIpv6 = \"(.*)";\n\s+};`
-        | rename machine privIpv4 pubIpv4 pubIpv6
-        | update pubIpv6 {if ($in == "") {null} else {$in}}
-        | sort-by machine)
+    let moduleIps = if $hasIpModule {
+      open flake/nixosModules/ips-DONT-COMMIT.nix
+      | collect
+      | parse --regex `(?ms)(.*)^  };\nin {.*`
+      | get capture0
+      | parse --regex `(?m)    (.*) = {$\n\s+privateIpv4 = \"(.*)";\n\s+publicIpv4 = \"(.*)";\n\s+publicIpv6 = \"(.*)";\n\s+};`
+      | rename machine privIpv4 pubIpv4 pubIpv6
+      | update pubIpv6 { $in | if $in == "" { null } else { $in } }
+      | sort-by machine
     } else {
       []
     }
 
-    # Set up comparison between list of nixos config machine names and ssh ipv4 machine names
-    let nixCompareSsh4 = list-diff $nixosCfg ($ssh4Cfg | get machine) onlyInNixosCfg onlyInSshCfg | where where != "eq"
+    let comparisons = [
+      {
+        label: "NixosConfigurations vs SSH hosts",
+        result: (list-diff $nixosCfg ($ssh4Cfg | get machine) onlyInNixosCfg onlyInSshCfg),
+        hint: "just save-ssh-config or just tf apply"
+      }
+      {
+        label: "SSH IPv4 vs SSH IPv6 machines",
+        result: (list-diff ($ssh4Cfg | get machine) ($ssh6Cfg | get machine) onlyInSsh4Cfg onlyInSsh6Cfg),
+        hint: "just save-ssh-config or just tf apply"
+      }
+      {
+        label: "NixosConfigurations vs IP module machines",
+        result: (if $hasIpModule {
+          list-diff $nixosCfg ($moduleIps | get machine) onlyInNixosCfg onlyInIpsModuleCfg
+        } else {[]}),
+        hint: "just update-ips"
+      }
+      {
+        label: "SSH public IPv4 vs IP module IPv4 values",
+        result: (if $hasIpModule {
+          list-diff ($ssh4Cfg | get pubIpv4) ($moduleIps | get pubIpv4) onlyInSshCfg onlyInIpsModuleCfg
+        } else {[]}),
+        hint: "just update-ips"
+      }
+      {
+        label: "SSH public IPv6 vs IP module IPv6 values",
+        result: (if $hasIpModule {
+          list-diff ($ssh6Cfg | get pubIpv6) ($moduleIps | get pubIpv6) onlyInSshCfg onlyInIpsModuleCfg
+        } else {[]}),
+        hint: "just update-ips"
+      }
+    ]
 
-    # Set up comparison between list of ssh public ipv4 and ssh public ipv6 machine names
-    let ssh4CompareSsh6 = list-diff ($ssh4Cfg | get machine) ($ssh6Cfg | get machine) onlyInSsh4Cfg onlyInSsh6Cfg | where where != "eq"
+    let inconsistent = (
+      $comparisons
+      | filter {|comp| $comp.result | is-not-empty }
+    )
 
-    # Set up comparison between list of nixos config machine names and ip module machine names
-    let nixCompareIps = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
-      list-diff $nixosCfg ($moduleIps | get machine) onlyInNixosCfg onlyInIpsModuleCfg | where where != "eq"
-    } else {
-      []
-    }
-
-    # Set up comparison between list of ssh public ipv4 and ip module public ipv4 values
-    let ssh4CompareIps4 = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
-      list-diff ($ssh4Cfg | get pubIpv4) ($moduleIps | get pubIpv4) onlyInSshCfg onlyInIpsModuleCfg | where where != "eq"
-    } else {
-      []
-    }
-
-    # Set up comparison between list of ssh public ipv6 and ip module public ipv6 values
-    let ssh6CompareIps6 = if ("flake/nixosModules/ips-DONT-COMMIT.nix" | path exists) {
-      list-diff ($ssh6Cfg | get pubIpv6) ($moduleIps | get pubIpv6) onlyInSshCfg onlyInIpsModuleCfg | where where != "eq"
-    } else {
-      []
-    }
-
-    # Validation output of any nixos config vs ssh ipv4 machine name differences
-    if ($nixCompareSsh4 | is-not-empty) {
-      print $"(ansi "bg_light_red")WARNING:(ansi reset) NixosConfigurations \(($nixosCfg | length)\) differ from ssh hosts \(($ssh4Cfg | length)\)"
-      print "         You may need to run `just save-ssh-config` or `just tf apply` to update the .ssh_config file."
+    $inconsistent | each {|comp|
+      print $"(ansi "bg_light_red")WARNING:(ansi reset) ($comp.label)"
+      print $"         You may need to run `($comp.hint)`"
       print "         Differences found are:"
-      print $nixCompareSsh4
+      print $comp.result
       print ""
-      $consistent = false
     }
 
-    # Validation output of any nixos config vs ip module machine name differences
-    if ($nixCompareIps | is-not-empty) {
-      print $"(ansi "bg_light_red")WARNING:(ansi reset) NixosConfigurations \(($nixosCfg | length)\) differ from ip module machines \(($moduleIps | length)\)"
-      print "         You may need to run `just update-ips` to update the flake/nixosModules/ips-DONT-COMMIT.nix file."
-      print "         Differences found are:"
-      print $nixCompareIps
-      print ""
-      $consistent = false
-    }
-
-    # Validation output of any ssh ipv4 vs ssh ipv6 machine name differences
-    if ($ssh4CompareSsh6 | is-not-empty) {
-      print $"(ansi "bg_light_red")WARNING:(ansi reset) Ssh config for public ipv4 \(($ssh4Cfg | length)\) differs from ssh config for public ipv6 hosts \(($ssh6Cfg | length)\)"
-      print "         You may need to run `just save-ssh-config` or `just tf apply` to update the .ssh_config file."
-      print "         Differences found are:"
-      print $ssh4CompareSsh6
-      print ""
-      $consistent = false
-    }
-
-    # Validation output of any ssh public ipv4 vs ip module public ipv4 value differences
-    if ($ssh4CompareIps4 | is-not-empty) {
-      print $"(ansi "bg_light_red")WARNING:(ansi reset) Ssh config for public ipv4 differs from ip module public ipv4 config:"
-      print "         You may need to run `just update-ips` to update the flake/nixosModules/ips-DONT-COMMIT.nix file."
-      print "         Differences found are:"
-      print $ssh4CompareIps4
-      print ""
-      $consistent = false
-    }
-
-    # Validation output of any ssh public ipv6 vs ip module public ipv6 value differences
-    if ($ssh6CompareIps6 | is-not-empty) {
-      print $"(ansi "bg_light_red")WARNING:(ansi reset) Ssh config for public ipv6 differs from ip module public ipv6 config:"
-      print "         You may need to run `just update-ips` to update the flake/nixosModules/ips-DONT-COMMIT.nix file."
-      print "         Differences found are:"
-      print $ssh6CompareIps6
-      print ""
-      $consistent = false
-    }
-
-    if ($consistent == true) {
+    if ($inconsistent | is-empty) {
       touch $checkFile
     }
   }
@@ -452,99 +430,74 @@ lint:
 
 # List machines
 list-machines:
-  #!/usr/bin/env bash
+  #!/usr/bin/env nu
 
-  # Enable polars (dataframe) usage by calling nushell indirectly with a plugins option.
-  # Otherwise, the plugin registry can't seem to be initialized successfully from within the script.
-  # Ref: https://github.com/nushell/nushell/issues/14466
-  #
-  # Polars outer join equivalent to pandas dfr can likey be simplified in a future nushell release.
-  # Ref: https://github.com/nushell/nushell/issues/14572
-  nu --plugins [$NUSHELL_PLUGINS_POLARS] -c '
-  let nixosNodes = (do -i {^nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames"} | complete)
-  if $nixosNodes.exit_code != 0 {
-     print "Nixos failed to evaluate the .#nixosConfigurations attribute."
-     print "The output was:"
-     print
-     print $nixosNodes
-     exit 1
+  def safe-run [block msg] {
+    let res = (do -i $block | complete)
+    if $res.exit_code != 0 {
+      print $msg
+      print "The output was:"
+      print
+      print $res
+      exit 1
+    }
+    $res.stdout
   }
 
-  {{checkSshConfig}}
-
-  let sshNodes = (do -i {^scj dump /dev/stdout -c .ssh_config} | complete)
-  if $sshNodes.exit_code != 0 {
-     print "Ssh-config-json failed to evaluate the .ssh_config file."
-     print "The output was:"
-     print
-     print $sshNodes
-     exit 1
+  def default-row [machine] {
+    {
+      Name: $machine,
+      Nix: $"(ansi green)OK",
+      pubIpv4: $"(ansi red)--",
+      pubIpv6: $"(ansi red)--",
+      Id: $"(ansi red)--",
+      Type: $"(ansi red)--"
+      Region: $"(ansi red)--"
+    }
   }
 
-  let nixosNodesDfr = (
-    let nodeList = ($nixosNodes.stdout | from json);
-    let sanitizedList = (if ($nodeList | is-empty) {$nodeList | insert 0 ""} else {$nodeList});
+  def main [] {
+    {{checkSshConfig}}
 
-    $sanitizedList
-      | wrap "machine"
-      | each {|i| insert inNixosCfg {"yes"}}
-      | polars into-df
-  )
+    let nixosJson = (safe-run { ^nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames" } "Nix eval failed.")
+    let sshJson = (safe-run { ^scj dump /dev/stdout -c .ssh_config } "scj failed.")
 
-  let sshNodesDfr = (
-    let ssh4Table = ($sshNodes.stdout
-      | from json
-      | where ("HostName" in $it) and not ($it.Host | str ends-with ".ipv6")
-      | select Host HostName
-      | rename Host pubIpv4
-    );
+    let baseTable = ($nixosJson | from json | each { |it| default-row $it })
+    let sshTable = ($sshJson | from json | where {|e| $e | get -i HostName | is-not-empty } | reject -i ProxyCommand)
 
-    let ssh6Table = ($sshNodes.stdout
-      | from json
-      | where ("HostName" in $it) and ($it.Host | str ends-with ".ipv6")
-      | select Host HostName
-      | rename Host pubIpv6
-      | update Host {$in | str replace ".ipv6" ""}
-      | update pubIpv6 {if ($in == "unavailable.ipv6") {null} else {$in}}
-      | select Host pubIpv6
-    );
+    let mergeTable = (
+      $sshTable | reduce --fold $baseTable { |it, acc|
+        let host = $it.Host
+        let hostData = $it.HostName
+        let machine = ($host | str replace -r '\.ipv(4|6)$' '')
 
-    let sshTable = ($ssh4Table
-      | polars into-df
-      | polars join -f ($ssh6Table | polars into-df) Host Host
-      | polars into-nu
-      | update Host {|i| default $i.Host_x}
-      | reject Host_x
-      | polars into-df
-    );
+        let update = if ($host | str ends-with ".ipv4") {
+          { pubIpv4: $hostData, Region: $it.Tag }
+        } else if ($host | str ends-with ".ipv6") {
+          { pubIpv6: $hostData }
+        } else {
+          { Id: $hostData, Type: $it.Tag }
+        }
 
-    if ($sshTable | is-empty) {
-      [[Host pubIpv4 pubIpv6]; ["" "" ""]] | polars into-df
-    }
-    else {
-      $sshTable
-    }
-  )
+        if ($acc | any {|row| $row.Name == $machine }) {
+          $acc | each {|row|
+            if $row.Name == $machine {
+              $row | merge $update
+            } else {
+              $row
+            }
+          }
+        } else {
+          $acc ++ [ (default-row $machine | merge $update) ]
+        }
+      }
+    )
 
-  (
-    $nixosNodesDfr
-      | polars join -f $sshNodesDfr machine Host
-      | polars into-nu
-      | update machine {|i| default $i.Host}
-      | reject Host
-      | polars into-df
-      | polars sort-by machine
-      | polars into-nu
-      | update inNixosCfg {if $in == null {$"(ansi bg_red)Missing(ansi reset)"} else {$in}}
-      | update pubIpv4 {if $in == null {$"(ansi bg_red)Missing(ansi reset)"} else {$in}}
-      | update pubIpv6 {|row|
-        if (
-          (($row.inNixosCfg | str contains "Missing") or ($row.pubIpv4 | str contains "Missing"))
-            and
-          ($row.pubIpv6 == null)
-        ) {$"(ansi bg_red)Missing(ansi reset)"} else {$in}}
-      | where machine != ""
-  )'
+    $mergeTable
+      | sort-by Name
+      | enumerate
+      | each { |r| { index: ($r.index + 1) } | merge $r.item }
+  }
 
 # Check mimir required config
 mimir-alertmanager-bootstrap:
@@ -840,18 +793,17 @@ ssh-config-example:
     ServerAliveInterval 60
 
   Host machine-example-1
-    HostName 1.2.3.4
+    HostName i-EXAMPLE_AWS_EC2ID
     # Per host customization should come after the HostName line to preserve pattern parsing
-    ProxyJump machine-example-2
+    ProxyCommand sh -c "aws --region eu-central-1 ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+    Tag t3a.medium
+
+  Host machine-example-1.ipv4
+    HostName 1.2.3.5
+    Tag eu-central-1
 
   Host machine-example-1.ipv6
     HostName ff00::01
-
-  Host machine-example-2
-    HostName 1.2.3.5
-
-  Host machine-example-2.ipv6
-    HostName unavailable.ipv6
   EOF
 
 # Ssh using cluster bootstrap key
@@ -871,29 +823,51 @@ ssh-for-all *ARGS:
 ssh-for-each HOSTNAMES *ARGS:
   colmena exec --verbose --parallel 0 --on {{HOSTNAMES}} {{ARGS}}
 
-# List machine ips based on regex pattern
-ssh-list-ips PATTERN:
+# List machine id, ipv4, ipv6, name or region based on regex pattern
+ssh-list TYPE PATTERN:
   #!/usr/bin/env nu
-  scj dump /dev/stdout -c .ssh_config
-    | from json
-    | default "" Host
-    | default "" HostName
-    | where not ($it.Host | str ends-with ".ipv6")
-    | where Host =~ "{{PATTERN}}"
-    | get HostName
-    | str join " "
+  const type = "{{TYPE}}"
 
-# List machine names based on regex pattern
-ssh-list-names PATTERN:
-  #!/usr/bin/env nu
-  scj dump /dev/stdout -c .ssh_config
-    | from json
-    | default "" Host
-    | default "" HostName
-    | where not ($it.Host | str ends-with ".ipv6")
-    | where Host =~ "{{PATTERN}}"
-    | get Host
-    | str join " "
+  let sshCfg = (
+    scj dump /dev/stdout -c .ssh_config
+      | from json
+      | default "" Host
+      | default "" HostName
+  )
+
+  if ($type == "id") {
+    $sshCfg
+      | where not ($it.Host =~ ".ipv(4|6)$")
+      | where Host =~ "{{PATTERN}}"
+      | get HostName
+      | str join " "
+  } else if ($type == "ipv4") {
+    $sshCfg
+      | where ($it.Host =~ ".ipv4$")
+      | where Host =~ "{{PATTERN}}"
+      | get HostName
+      | str join " "
+  } else if ($type == "ipv6") {
+    $sshCfg
+      | where ($it.Host =~ ".ipv6$")
+      | where Host =~ "{{PATTERN}}"
+      | get HostName
+      | str join " "
+  } else if ($type == "name") {
+    $sshCfg
+      | where not ($it.Host =~ ".ipv(4|6)$")
+      | where Host =~ "{{PATTERN}}"
+      | get Host
+      | str join " "
+  } else if ($type == "region") {
+    $sshCfg
+      | where ($it.Host =~ ".ipv4$")
+      | where Host =~ "{{PATTERN}}"
+      | get Tag
+      | str join " "
+  } else {
+    print "The TYPE must be one of: id, ipv4, ipv6, name or region"
+  }
 
 # Start a local node for a specific env
 start-node ENV:

--- a/templates/cardano-parts-project/README.md
+++ b/templates/cardano-parts-project/README.md
@@ -32,13 +32,56 @@ Note that the nix version must be at least `2.17` and `fetch-closure`,
 
 ## AWS
 
-Create an AWS user with your name and `AdministratorAccess` policy in the
-$REPO organization, then store your access key in
-`~/.aws/credentials` under the profile name `$REPO`:
+From the parent AWS org, create an IAM identity center user with your name and
+`AdministratorAccess` to the AWS account of the `$REPO` deployment, then store
+the config in `~/.aws/config` under the profile name `$REPO`:
+
+    [sso-session $PARENT_ORG_NAME]
+    sso_start_url = https://$IAM_CENTER_URL_ID.awsapps.com/start
+    sso_region = $REGION
+    sso_registration_scopes = sso:account:access
+
+    [profile $REPO]
+    sso_session = $PARENT_ORG_NAME
+    sso_account_id = $REPO_ARN_ORG_ID
+    sso_role_name = AdministratorAccess
+    region = $REGION
+
+The `$PARENT_ORG_NAME` can be set to what you prefer, ex: `ioe`.  The
+`$IAM_CENTER_URL_ID` and `$REGION` will be provided when creating your IAM
+identity center user and the `$REPO_ARN_ORG_ID` will be obtained in AWS as
+the `$REPO` org ARN account number.
+
+If your AWS setup uses a flat or single org structure, then adjust IAM identity
+center account access and the above config to reflect this.  The above config
+can also be generated from the devshell using:
+
+    aws configure sso
+
+When adding additional profiles the `aws configure sso` command may create
+duplicate sso-session blocks or cause other issues, so manually adding new
+profiles is preferred.  Before accessing or using `$REPO` org resources, you
+will need to start an sso session which can be done by:
+
+    just aws-sso-login
+
+While the identity center approach above gives session based access, it also
+requires periodic manual session refreshes which are more difficult to
+accomplish on a headless system or shared deployer.  For those use cases, IAM
+of the `$REPO` organization can be used to create an AWS user with your name and
+`AdministratorAccess` policy.  With this approach, create an access key set for
+your IAM user and store them in `~/.aws/credentials` under the profile name
+`$REPO`:
 
     [$REPO]
     aws_access_key_id = XXXXXXXXXXXXXXXXXXXX
     aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
+
+No session initiation will be required and AWS resources in the org can be used
+immediately.
+
+In the case that a profile exists in both `~/.aws/config` and
+`~/.aws/credentials`, the `~/.aws/config` sso definition will take precedence.
 
 ## AGE Admin
 
@@ -113,6 +156,13 @@ With that you can then get started with:
 
     # Find many other operations recipes to use
     just --list
+
+Behind the scenes ssh is using AWS SSM and no open port 22 is required.  In
+fact, the default template for a cardano-parts repo does not open port 22 for
+ingress on security groups.
+
+For special use cases which still utilize port 22 ingress for ssh, ipv4 or ipv6
+ssh_config can be used by appending `.ipv4` or `.ipv6` to the target hostname.
 
 ## Colmena
 

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -71,6 +71,9 @@ in
           # Config for cardano-node group deployments
           inputs.cardano-parts.nixosModules.profile-cardano-node-group
           inputs.cardano-parts.nixosModules.profile-cardano-custom-metrics
+
+          # Until 10.5 is released -- see description below
+          absPeerSnap
         ];
       };
 
@@ -184,6 +187,9 @@ in
           inputs.cardano-parts.nixosModules.profile-cardano-postgres
           {services.cardano-node.shareNodeSocket = true;}
           {services.cardano-postgres.enablePsqlrc = true;}
+
+          # Until 10.5 is released -- see description below
+          absPeerSnap
         ];
       };
 
@@ -197,6 +203,17 @@ in
           {services.cardano-faucet.acmeEmail = "devops@iohk.io";}
         ];
       };
+
+      # Until 10.5.x is released, 10.4.1 will fail to start without this because
+      # node doesn't yet properly look up the relative path from topology to
+      # peer snapshot file.
+      #
+      # Setting this option null fixes the problem, but will leave a
+      # dangling peer snapshot file until 10.6.
+      #
+      # So until then, we'll switch from relative path that causes node failure
+      # to absolute path which does not.
+      absPeerSnap = {services.cardano-node.peerSnapshotFile = i: "/etc/cardano-node/peer-snapshot-${toString i}.json";};
     in {
       meta = {
         nixpkgs = import inputs.nixpkgs {

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -451,17 +451,32 @@ in {
 
           aws_iam_role_policy_attachment = let
             mkRoleAttachments = roleResourceName: policyList:
-              listToAttrs (map (policy: {
+              listToAttrs (map (policy:
+                if isString policy
+                then {
                   name = "${roleResourceName}_policy_attachment_${policy}";
                   value = {
                     role = "\${aws_iam_role.${roleResourceName}.name}";
                     policy_arn = "\${aws_iam_policy.${policy}.arn}";
                   };
+                }
+                else {
+                  name = "${roleResourceName}_policy_attachment_${policy.name}";
+                  value = {
+                    role = "\${aws_iam_role.${roleResourceName}.name}";
+                    policy_arn = policy.arn;
+                  };
                 })
-                policyList);
+              policyList);
           in
             foldl' recursiveUpdate {} [
-              (mkRoleAttachments "ec2_role" ["kms_user"])
+              (mkRoleAttachments "ec2_role" [
+                "kms_user"
+                {
+                  name = "ssm";
+                  arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore";
+                }
+              ])
             ];
 
           aws_iam_policy.kms_user = {
@@ -545,11 +560,12 @@ in {
                     from_port = 443;
                     to_port = 443;
                   })
-                  (mkRule {
-                    description = "Allow SSH";
-                    from_port = 22;
-                    to_port = 22;
-                  })
+                  # No longer required with SSH over SSM
+                  # (mkRule {
+                  #   description = "Allow SSH";
+                  #   from_port = 22;
+                  #   to_port = 22;
+                  # })
                   (mkRule {
                     description = "Allow Cardano";
                     from_port = 3001;
@@ -630,7 +646,13 @@ in {
               ${
                 concatStringsSep "\n" (map (name: ''
                     Host ${name}
+                      HostName ''${aws_instance.${name}[0].id}
+                      ProxyCommand sh -c "aws --region ${nodes.${name}.aws.region} ssm start-session --target %h --document-name AWS-StartSSHSession --parameters 'portNumber=%p'"
+                      Tag ${nodes.${name}.aws.instance.instance_type}
+
+                    Host ${name}.ipv4
                       HostName ''${aws_eip.${name}[0].public_ip}
+                      Tag ${nodes.${name}.aws.region}
 
                     Host ${name}.ipv6
                       HostName ''${length(aws_instance.${name}[0].ipv6_addresses) > 0 ? aws_instance.${name}[0].ipv6_addresses[0] : "unavailable.ipv6"}

--- a/templates/cardano-parts-project/scripts/bash-fns.sh
+++ b/templates/cardano-parts-project/scripts/bash-fns.sh
@@ -1,0 +1,76 @@
+# shellcheck disable=SC2148
+#
+# Various bash helper fns which aren't used enough to move to just recipes.
+
+# This can be used to simplify ssh sessions, rsync, ex:
+#   ssh -o "$(ssm-proxy-cmd "$REGION")" "$INSTANCE_ID"
+ssm-proxy-cmd() {
+  echo "ProxyCommand=sh -c 'aws --region $1 ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p'"
+}
+
+
+# A handy transaction submission function with mempool monitoring.
+# CARDANO_NODE_{NETWORK_ID,SOCKET_PATH}, TESTNET_MAGIC should already be exported.
+submit() (
+  set -euo pipefail
+  TX_SIGNED="$1"
+
+  TXID=$(cardano-cli latest transaction txid --tx-file "$TX_SIGNED")
+
+  echo "Submitting $TX_SIGNED with txid $TXID..."
+  cardano-cli latest transaction submit --tx-file "$TX_SIGNED"
+
+  EXISTS="true"
+  while [ "$EXISTS" = "true" ]; do
+    EXISTS=$(cardano-cli latest query tx-mempool tx-exists "$TXID" | jq -r .exists)
+    if [ "$EXISTS" = "true" ]; then
+      echo "The transaction still exists in the mempool, sleeping 5s: $TXID"
+    else
+      echo "The transaction has been removed from the mempool."
+    fi
+    sleep 5
+  done
+  echo "Transaction $TX_SIGNED with txid $TXID submitted successfully."
+  echo
+)
+
+foreach-pair() (
+  set -euo pipefail
+
+  [ -n "${DEBUG:-}" ] && set -x
+
+  if [ "$#" -ne 3 ]; then
+    echo "Usage:"
+    echo "  foreach-pair \$STRING_LIST_1 \$STRING_LIST_2 \$STRING_CMD"
+    echo
+    echo "Where:"
+    echo "  \$STRING_CMD has \$i and \$j embedded as iters from the two lists"
+    echo
+    echo "Example:"
+    echo "  foreach-pair \"\$(just ssh-list name "preview1.*")\" \"\$(just ssh-list region "preview1.*")\" 'just aws-ec2-status \$i \$j'"
+    exit 1
+  fi
+
+  local l1="$1"
+  local l2="$2"
+  local cmd="$3"
+
+  read -r -a l1 <<< "$l1"
+  read -r -a l2 <<< "$l2"
+
+  if [[ ${#l1[@]} -ne ${#l2[@]} ]]; then
+    echo "Error: Lists are not the same length." >&2
+    exit 1
+  fi
+
+  local length=${#l1[@]}
+
+  for ((n = 0; n < length; n++)); do
+    # shellcheck disable=SC2034
+    local i="${l1[n]}"
+    # shellcheck disable=SC2034
+    local j="${l2[n]}"
+
+    eval "$cmd" || true
+  done
+)

--- a/templates/cardano-parts-project/scripts/recipes/aws.just
+++ b/templates/cardano-parts-project/scripts/recipes/aws.just
@@ -39,3 +39,49 @@ aws-ec2-stop NAME REGION:
   set -e
   ID=$(just aws-ec2-id {{NAME}} {{REGION}})
   aws --region {{REGION}} ec2 stop-instances --instance-ids "$ID"
+
+# Describe ssm active sessions
+aws-ssm-sessions:
+  #!/usr/bin/env bash
+  set -e
+  aws ssm describe-sessions --state Active
+
+# Export short term aws sso credentials
+aws-sso-export FILE="aws-sso.sh" AWS_PROFILE=null:
+  #!/usr/bin/env bash
+  set -e
+  if [ -n "{{AWS_PROFILE}}" ]; then
+    PROFILE="{{AWS_PROFILE}}"
+    echo "Exporting short term AWS SSO credentials for profile \"$PROFILE\" to file: {{FILE}}..."
+  elif [ -n "$AWS_PROFILE" ]; then
+    PROFILE="$AWS_PROFILE"
+    echo "Exporting short term AWS SSO credentials for profile \"$PROFILE\" from env var AWS_PROFILE to file {{FILE}}..."
+  else
+    echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
+  fi
+
+  if ! aws sts get-caller-identity --profile "$AWS_PROFILE" &> /dev/null; then
+    echo
+    nu -c 'print $"(ansi "bg_light_red")Please run:(ansi reset) `just aws-sso-login` first to obtain sso credentials"'
+    exit 1
+  fi
+
+  echo
+  aws configure export-credentials --format env > {{FILE}}
+
+# Login to aws sso
+aws-sso-login AWS_PROFILE=null:
+  #!/usr/bin/env bash
+  set -e
+  if [ -n "{{AWS_PROFILE}}" ]; then
+    PROFILE="{{AWS_PROFILE}}"
+    echo "Logging into AWS SSO using profile \"$PROFILE\" from cli..."
+  elif [ -n "$AWS_PROFILE" ]; then
+    PROFILE="$AWS_PROFILE"
+    echo "Logging into AWS SSO using profile \"$PROFILE\" from env var AWS_PROFILE..."
+  else
+    echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
+  fi
+
+  echo
+  aws sso login --profile "$PROFILE"

--- a/templates/cardano-parts-project/scripts/recipes/demo.just
+++ b/templates/cardano-parts-project/scripts/recipes/demo.just
@@ -195,7 +195,7 @@ start-demo:
   )
   DECISION=yes \
     ROLE=cc \
-    VOTE_KEY="$CC_DIR/cc-1-hot \
+    VOTE_KEY="$CC_DIR/cc-1-hot" \
     nix run .#job-submit-vote
   echo "Sleeping $FIXED_DELAY_SECS seconds until $(date -d  @$(($(date +%s) + $FIXED_DELAY_SECS)))"
   sleep "$FIXED_DELAY_SECS"

--- a/templates/cardano-parts-project/scripts/recipes/demo.just
+++ b/templates/cardano-parts-project/scripts/recipes/demo.just
@@ -158,7 +158,7 @@ start-demo:
   echo "Submitting a Plomin prep cost model action..."
   PROPOSAL_ARGS=("--cost-model-file" "scripts/cost-models/mainnet-plutusv3-pv10-prep.json")
   ACTION="create-protocol-parameters-update" \
-    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/sp-1-owner-stake" \
+    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/$(cut -f1 -d' ' <<< "$POOL_NAMES")-owner-stake" \
     nix run .#job-submit-gov-action -- "${PROPOSAL_ARGS[@]}"
   echo "Sleeping $FIXED_DELAY_SECS seconds until $(date -d  @$(($(date +%s) + $FIXED_DELAY_SECS)))"
   echo "Sleeping until cost model can be voted on, epoch 5"
@@ -168,7 +168,7 @@ start-demo:
   echo "Submitting a Plomin hard fork action..."
   PROPOSAL_ARGS=("--protocol-major-version" "10" "--protocol-minor-version" "0")
   ACTION="create-hardfork" \
-    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/sp-1-owner-stake" \
+    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/$(cut -f1 -d' ' <<< "$POOL_NAMES")-owner-stake" \
     nix run .#job-submit-gov-action -- "${PROPOSAL_ARGS[@]}"
   echo "Sleeping $FIXED_DELAY_SECS seconds until $(date -d  @$(($(date +%s) + $FIXED_DELAY_SECS)))"
   sleep "$FIXED_DELAY_SECS"
@@ -206,7 +206,7 @@ start-demo:
     echo "Submitting the pool $i vote for the Plomin hard fork..."
     DECISION=yes \
       ROLE=spo \
-      VOTE_KEY="$STAKE_POOL_DIR/no-deploy/sp-${i}-cold" \
+      VOTE_KEY="$STAKE_POOL_DIR/no-deploy/$(cut -f${i} -d' ' <<< "$POOL_NAMES")-cold" \
       nix run .#job-submit-vote
     echo "Sleeping $FIXED_DELAY_SECS seconds until $(date -d  @$(($(date +%s) + $FIXED_DELAY_SECS)))"
     sleep "$FIXED_DELAY_SECS"
@@ -263,6 +263,7 @@ start-demo-ng:
   export USE_DECRYPTION="${USE_DECRYPTION:-true}"
   export USE_NODE_CONFIG_BP="${USE_NODE_CONFIG_BP:-false}"
   export DEBUG="${DEBUG:-true}"
+  export RETIRE_BOOTSTRAP_POOL="${RETIRE_BOOTSTRAP_POOL:-true}"
   export SECURITY_PARAM="${SECURITY_PARAM:-8}"
   export SLOT_LENGTH="${SLOT_LENGTH:-100}"
   export FIXED_DELAY_SECS="${FIXED_DELAY_SECS:-10}"
@@ -309,13 +310,18 @@ start-demo-ng:
   sleep 10
   echo
 
-  echo "Retiring the bootstrap pool..."
-  BOOTSTRAP_POOL_DIR="$KEY_DIR/bootstrap-pool" \
-    RICH_KEY="$KEY_DIR/utxo-keys/rich-utxo" \
-    nix run .#job-retire-bootstrap-pool
-  echo "Sleeping 10 seconds until $(date -d  @$(($(date +%s) + 10)))"
-  sleep 10
-  echo
+  if [ "$RETIRE_BOOTSTRAP_POOL" = "true" ]; then
+    echo "Retiring the bootstrap pool..."
+    BOOTSTRAP_POOL_DIR="$KEY_DIR/bootstrap-pool" \
+      RICH_KEY="$KEY_DIR/utxo-keys/rich-utxo" \
+      nix run .#job-retire-bootstrap-pool
+    echo "Sleeping 10 seconds until $(date -d  @$(($(date +%s) + 10)))"
+    sleep 10
+    echo
+  else
+    echo "Skipping bootstrap pool retirement..."
+    echo
+  fi
 
   WAIT_FOR_TIP() {
     TYPE="$1"
@@ -340,7 +346,7 @@ start-demo-ng:
   echo "Submitting a Plomin prep cost model action..."
   PROPOSAL_ARGS=("--cost-model-file" "scripts/cost-models/mainnet-plutusv3-pv10-prep.json")
   ACTION="create-protocol-parameters-update" \
-    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/sp-1-owner-stake" \
+    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/$(cut -f1 -d' ' <<< "$POOL_NAMES")-owner-stake" \
     nix run .#job-submit-gov-action -- "${PROPOSAL_ARGS[@]}"
   echo "Sleeping until cost model can be voted on, epoch 1"
   WAIT_FOR_TIP "epoch" "1"
@@ -349,7 +355,7 @@ start-demo-ng:
   echo "Submitting a Plomin hard fork action..."
   PROPOSAL_ARGS=("--protocol-major-version" "10" "--protocol-minor-version" "0")
   ACTION="create-hardfork" \
-    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/sp-1-owner-stake" \
+    STAKE_KEY="$STAKE_POOL_DIR/no-deploy/$(cut -f1 -d' ' <<< "$POOL_NAMES")-owner-stake" \
     nix run .#job-submit-gov-action -- "${PROPOSAL_ARGS[@]}"
   echo "Sleeping $FIXED_DELAY_SECS seconds until $(date -d  @$(($(date +%s) + $FIXED_DELAY_SECS)))"
   sleep "$FIXED_DELAY_SECS"
@@ -387,17 +393,18 @@ start-demo-ng:
     echo "Submitting the pool $i vote for the Plomin hard fork..."
     DECISION=yes \
       ROLE=spo \
-      VOTE_KEY="$STAKE_POOL_DIR/no-deploy/sp-${i}-cold" \
+      VOTE_KEY="$STAKE_POOL_DIR/no-deploy/$(cut -f${i} -d' ' <<< "$POOL_NAMES")-cold" \
       nix run .#job-submit-vote
     echo "Sleeping $FIXED_DELAY_SECS seconds until $(date -d  @$(($(date +%s) + $FIXED_DELAY_SECS)))"
     sleep "$FIXED_DELAY_SECS"
   done
-  echo "Sleeping until epoch 3 for the plomin HF votes to register..."
-  WAIT_FOR_TIP "epoch" "3"
+  CURRENT_EPOCH=$(jq -re ".epoch" <<< "$(just query-tip demo "$TESTNET_MAGIC")")
+  echo "Sleeping until epoch $((CURRENT_EPOCH + 1)) for the plomin HF votes to register..."
+  WAIT_FOR_TIP "epoch" "$((CURRENT_EPOCH + 1))"
   echo
 
-  echo "Sleeping until epoch 4 for the Plomin HF action to ratify..."
-  WAIT_FOR_TIP "epoch" "4"
+  echo "Sleeping until epoch $((CURRENT_EPOCH + 2)) for the Plomin HF action to ratify..."
+  WAIT_FOR_TIP "epoch" "$((CURRENT_EPOCH + 2))"
   echo
 
   just query-tip demo "$TESTNET_MAGIC"


### PR DESCRIPTION
## Overview:

Cardano-node pre-release has been updated to `10.5.0`, cardano-cli pre-release to `10.11.0.0` and mithril to `v2524.0`.  Opentofu resources, just recipes and other code has been updated to transition to use of ssh over AWS SSM with the closure of port 22 ingress.  Other miscellaneous improvements are detailed below.

## Details:

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
| :---: | :---: | :---: |
| cardano-address | 4.0.0 | N/A |
| cardano-cli | 10.8.0.0 | <ins>***10.11.0.0***</ins> |
| cardano-db-sync | 13.6.0.5 | 13.6.0.5 |
| cardano-node | 10.4.1 | <ins>***10.5.0***</ins> |
| cardano-ogmios | 6.11.2 | N/A |
| mithril | <ins>***2524.0***</ins> | <ins>***867fdbb***</ins> |
| nix* | 2.29.1 | N/A |
| nixpkgs* | 25.05 | N/A |

\* = For nixos machine deployments

* Bumps cardano-node-ng (pre-release) to `10.5.0` and cardano-cli-ng (pre-release) to `10.11.0.0`
* Bumps mithril release to `v2425.0` and unstable to latest unstable moving tag
* Bumps the `cardano-node-service-ng` nixos service to `10.5.0` tag for isFunction fix, RTS mods, peerSnapshot and network param default updates
* Adds template colmena code to fix a node startup failure with node release 10.4.1 when preview/preprod includes a relative path peer snapshot
* Adds template recipe updates for list-machines, ssh-for-all, checkSshConfig code for compatibility with ssh over ssm and other optimizations
* Adds template recipes specific for aws sso and ssm workflows
* Adds sourceable bash functions which are better there than just recipes
* Adds opentofu `awscc` provider to the default providers
* Adds an ssm-proxy-cmd bash fn to machine nixosCfgs to enable easy use of deployed machine to machine ssh over ssm connections
* Adds pool spin up demo configuration flexibility
* Updates template readme doc to include sso and ssh over ssm changes
* Updates opentofu cluster resources to enable and utilize ssm and permit ssh over ssm
* Updates template .envrc to be shellcheck compliant
* Updates the default bp node configuration to match iohk-nix `TargetNumberOfKnownPeers` parameter
* Refactors the `pkgs` flakeModule for easier release and pre-release pin updating
* Fixes cardano-cli-ng breaking change behavior in the cli interface for CI GHA and nix jobs
* Removes no longer required nushell polars in-lieu of a more efficient set of recipes

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* This release changes from ssh over public ingress port 22 to ssh over AWS SSM.  These changes should be transparent after applying the action items below and then updating the opentofu resources to apply new IAM machine policy and close port 22 ingress on security groups:
```bash
just tofu apply
```
* The above tofu changes will take approximately 1 hour to take effect on deployed machines.
* If any issues are encountered, port 22 can be reopened by adjusting `flake/opentofu/cluster.nix` accordingly, re-running `just tofu apply` and ssh'ing over `ipv4` or `ipv6` using `just ssh $HOSTNAME.(ipv4|ipv6)`


### Recommended Updates:
* Update the cardano-parts pin to this release version `v2025-06-24`
* Apply the template Justfile diff and patch or clone recipes on files described below.

### Action Items:
Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`.  Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the
 just template-clone "$FILE"` recipe.
```
.envrc                      # Shellcheck compliance
flake/colmena.nix           # Update for node 10.4.1 peer snapshot path fix
flake/opentofu/cluster.nix  # Updates for ssh over AWS SSM
Justfile                    # Updates for ssh over AWS SSM and recipe optimization
README.md                   # Updates for ssh over AWS SSM and IAM identity center
scripts/bash-fns.sh         # New sourceable bash helper fns
scripts/recipes/aws.just    # Updates for AWS Identity Center SSO, SSM
scripts/recipes/demo.just   # Updates for pool spin-up flexibility
```
