### PR TITLE
Node-ng 10.5.1, cardano-signer, nix job updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -51,16 +51,16 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1746509278,
-        "narHash": "sha256-/pcYYOKgD2+1Zl0jV+3S4h3GSp/3TSfokrqu0rDAijo=",
-        "owner": "johnalotoski",
+        "lastModified": 1752150659,
+        "narHash": "sha256-S49YIfVSUwkbEHJNHs8ZGjop9/lTMfOqNfO+5yKxJwA=",
+        "owner": "cardano-foundation",
         "repo": "blockperf",
-        "rev": "cfc8155b9c14fedd569f879f2b3cf7ead91d47be",
+        "rev": "aae8cf46af695fdb0888fa28f9f860079e765f10",
         "type": "github"
       },
       "original": {
-        "owner": "johnalotoski",
-        "ref": "preview-network",
+        "owner": "cardano-foundation",
+        "ref": "develop",
         "repo": "blockperf",
         "type": "github"
       }
@@ -101,11 +101,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1750254939,
-        "narHash": "sha256-P0N8TOddVyzHkIpDPdGsXbhR6W1vAhpOUvZPvyrrcNY=",
+        "lastModified": 1752770082,
+        "narHash": "sha256-w1jz9DIOsGDONx/mcOozAyMYE7vs6HiaaT2Ii0Tz32o=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "ba03172728d491a2a1619755c885a3bcdbdfb43c",
+        "rev": "a959c48c71e44a0a53f0ddecf12893f4e4d35edc",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,28 +43,6 @@
         "type": "github"
       }
     },
-    "blockperf": {
-      "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "nixpkgs": "nixpkgs"
-      },
-      "locked": {
-        "lastModified": 1752150659,
-        "narHash": "sha256-S49YIfVSUwkbEHJNHs8ZGjop9/lTMfOqNfO+5yKxJwA=",
-        "owner": "cardano-foundation",
-        "repo": "blockperf",
-        "rev": "aae8cf46af695fdb0888fa28f9f860079e765f10",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cardano-foundation",
-        "ref": "develop",
-        "repo": "blockperf",
-        "type": "github"
-      }
-    },
     "blst": {
       "flake": false,
       "locked": {
@@ -101,11 +79,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1752770082,
-        "narHash": "sha256-w1jz9DIOsGDONx/mcOozAyMYE7vs6HiaaT2Ii0Tz32o=",
+        "lastModified": 1753194948,
+        "narHash": "sha256-c2u8JzI+KPquczoAZ0mlOtRm6q+himwvQod2k1Vpl/k=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "a959c48c71e44a0a53f0ddecf12893f4e4d35edc",
+        "rev": "af0077b030b1e5e927e7d7ff27a80dadb59f0fb1",
         "type": "github"
       },
       "original": {
@@ -451,7 +429,7 @@
     "iohk-nix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -472,7 +450,7 @@
     "iohk-nix-ng": {
       "inputs": {
         "blst": "blst_2",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_2",
         "secp256k1": "secp256k1_2",
         "sodium": "sodium_2"
       },
@@ -495,7 +473,7 @@
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_2",
         "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_3",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression"
       },
@@ -537,16 +515,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1705458851,
-        "narHash": "sha256-uQvEhiv33Zj/Pv364dTvnpPwFSptRZgVedDzoM+HqVg=",
-        "owner": "NixOS",
+        "lastModified": 1684171562,
+        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "8bf65f17d8070a0a490daf5f1c784b87ee73982c",
+        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "ref": "nixos-23.11",
+        "owner": "nixos",
+        "ref": "release-22.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -632,22 +610,6 @@
     },
     "nixpkgs_3": {
       "locked": {
-        "lastModified": 1684171562,
-        "narHash": "sha256-BMUWjVWAUdyMWKk0ATMC9H0Bv4qAV/TXwwPUvTiC5IQ=",
-        "owner": "nixos",
-        "repo": "nixpkgs",
-        "rev": "55af203d468a6f5032a519cba4f41acf5a74b638",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nixos",
-        "ref": "release-22.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_4": {
-      "locked": {
         "lastModified": 1747179050,
         "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "NixOS",
@@ -662,7 +624,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_4": {
       "locked": {
         "lastModified": 1748162331,
         "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
@@ -713,7 +675,6 @@
       "inputs": {
         "auth-keys-hub": "auth-keys-hub",
         "blockfrost-platform-service": "blockfrost-platform-service",
-        "blockperf": "blockperf",
         "capkgs": "capkgs",
         "cardano-db-sync-schema": "cardano-db-sync-schema",
         "cardano-db-sync-schema-ng": "cardano-db-sync-schema-ng",
@@ -730,7 +691,7 @@
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_5",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",

--- a/flake.lock
+++ b/flake.lock
@@ -500,11 +500,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1748154947,
-        "narHash": "sha256-rCpANMHFIlafta6J/G0ILRd+WNSnzv/lzi40Y8f1AR8=",
+        "lastModified": 1751027644,
+        "narHash": "sha256-f3ar0uez/+tc+PFtOTyjo7Vfa2xsLxl6K3vZt2Bs4so=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "d761dad79c79af17aa476a29749bd9d69747548f",
+        "rev": "8f6c5d088ad49df471168b769ae44f4ea0b915f3",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -179,16 +179,16 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1750182374,
-        "narHash": "sha256-fLNUecLWwZTvJuyekr53mb3fcC+tvCu6UBJuJ4vcYHI=",
+        "lastModified": 1752857436,
+        "narHash": "sha256-YAAwDfzMMTeEQa0zHin7yo2nMdxONJ983tJ3NrP7K6E=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "7e045ab501e99130a57f363f0964bb4f241c6550",
+        "rev": "ca1ec278070baf4481564a6ba7b4a5b9e3d9f366",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.5.0",
+        "ref": "release/10.5.1",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -62,17 +62,6 @@
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
 
-    # Blockperf fork until PRs merged upstream
-    blockperf = {
-      url = "github:cardano-foundation/blockperf/develop";
-      inputs = {
-        # Requires nixpkgs specific pinning for locked python versioning
-        # nixpkgs.follows = "nixpkgs";
-        flake-parts.follows = "flake-parts";
-      };
-    };
-    # blockperf.url = "path:/home/jlotoski/work/johnalotoski/blockperf-wt/preview-network";
-
     # For tmp local testing pins
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";
     # cardano-faucet.url = "path:/home/jlotoski/work/iohk/cardano-faucet-wt/jl/node-9.2";

--- a/flake.nix
+++ b/flake.nix
@@ -64,7 +64,7 @@
 
     # Blockperf fork until PRs merged upstream
     blockperf = {
-      url = "github:johnalotoski/blockperf/preview-network";
+      url = "github:cardano-foundation/blockperf/develop";
       inputs = {
         # Requires nixpkgs specific pinning for locked python versioning
         # nixpkgs.follows = "nixpkgs";

--- a/flake.nix
+++ b/flake.nix
@@ -95,7 +95,7 @@
     };
 
     cardano-node-service-ng = {
-      url = "github:IntersectMBO/cardano-node/10.5.0";
+      url = "github:IntersectMBO/cardano-node/release/10.5.1";
       flake = false;
     };
 

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -41,6 +41,10 @@ in {
           cp -r "${envCfgs}/config/$ENV" "$DATA_DIR/config/"
         done
 
+        # Until https://github.com/IntersectMBO/cardano-node/pull/6282 is merged and released,
+        # remove PrometheusSimple from configs so multiple instances can be started without fatal error.
+        find "$DATA_DIR/config" -type f -exec sed -i '/PrometheusSimple/d' {} +
+
         # Prepare mithril client env configs
         ${
           concatStringsSep "\n"

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -436,22 +436,21 @@ in
         };
 
         pkgsSubmodule = let
-          credential-manager-release = "IntersectMBO-credential-manager-0-1-3-0-2d82213";
+          credential-manager-release = "IntersectMBO-credential-manager-0-1-5-0-ba221bd";
           dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           dbsync-pre-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
-          mithril-pre-release = "input-output-hk-mithril-unstable-5a699e2";
+          mithril-pre-release = "input-output-hk-mithril-unstable-b76f911";
           node-release = "input-output-hk-cardano-node-10-4-1-420c94f";
-          node-pre-release = "input-output-hk-cardano-node-10-5-0-7e045ab";
+          node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
         in
           submodule {
             options = foldl' recursiveUpdate {} [
               # TODO: Fix the missing meta/version info upstream
               (mkPkg "bech32" caPkgs."bech32-${node-release}")
               (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
-              # (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-87f6f67)
-              (mkPkg "blockperf" localFlake.inputs.blockperf.packages.x86_64-linux.blockperf)
+              (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-d757f38)
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
               (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.8.0.0";}))
               (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))
@@ -467,7 +466,7 @@ in
               (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
 
               (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.4.1";}))
-              (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.0";}))
+              (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.1";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-27-0-b71c3f1)
               (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -37,6 +37,7 @@
 #   perSystem.cardano-parts.pkgs.cardano-node
 #   perSystem.cardano-parts.pkgs.cardano-node-ng
 #   perSystem.cardano-parts.pkgs.cardano-ogmios
+#   perSystem.cardano-parts.pkgs.cardano-signer
 #   perSystem.cardano-parts.pkgs.cardano-smash
 #   perSystem.cardano-parts.pkgs.cardano-smash-ng
 #   perSystem.cardano-parts.pkgs.cardano-submit-api
@@ -440,7 +441,7 @@ in
           dbsync-pre-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
-          mithril-pre-release = "input-output-hk-mithril-unstable-867fdbb";
+          mithril-pre-release = "input-output-hk-mithril-unstable-5a699e2";
           node-release = "input-output-hk-cardano-node-10-4-1-420c94f";
           node-pre-release = "input-output-hk-cardano-node-10-5-0-7e045ab";
         in
@@ -468,6 +469,7 @@ in
               (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.4.1";}))
               (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.0";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
+              (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-27-0-b71c3f1)
               (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")
               (mkPkg "cardano-smash-ng" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-pre-release}")
               (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-${node-release}")
@@ -530,6 +532,7 @@ in
               cardano-faucet
               cardano-node
               cardano-ogmios
+              cardano-signer
               cardano-smash
               cardano-submit-api
               cardano-testnet

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -281,6 +281,7 @@ in
                         cardano-address
                         cardano-cli
                         cardano-node
+                        cardano-signer
                         cardano-testnet
                         cardano-wallet
                         db-analyser

--- a/templates/cardano-parts-project/scripts/bash-fns.sh
+++ b/templates/cardano-parts-project/scripts/bash-fns.sh
@@ -74,3 +74,135 @@ foreach-pair() (
     eval "$cmd" || true
   done
 )
+
+return-utxo() (
+  set -euo pipefail
+
+  [ -n "${DEBUG:-}" ] && set -x
+  SIGNING_TX_ARGS=()
+
+  if [ "$#" -ne 4 ] && [ "$#" -ne 5 ]; then
+    # shellcheck disable=SC2016
+    echo "$0"' $ENV $SEND_ADDR $UTXO $PAYMENT_SKEY [$STAKE_SKEY]'
+    echo
+    echo "  ENV          -- The environment to be used"
+    echo "  SEND_ADDR    -- The send to address"
+    echo "  UTXO         -- The UTXO including index in \$UTXO#IDX format"
+    echo "  PAYMENT_SKEY -- The path to the payment secret key"
+    echo "  [STAKE_SKEY] -- The path to the stake secret key [Optional]"
+    exit 1
+  else
+    # Read file contents rather than saving the path in case it is a streamed
+    # file input redirection from a decryption output.
+    ENV="$1"
+    SEND_ADDR="$2"
+    UTXO="$3"
+    PAYMENT_SKEY=$(< "$4")
+    if [ "$#" -eq 5 ]; then
+      STAKE_SKEY=$(< "$5")
+    fi
+  fi
+
+  just set-default-cardano-env "$ENV"
+  echo
+
+  PROMPT() {
+    echo
+    read -p "Does this look correct [yY]? " -n 1 -r
+    echo
+    if ! [[ $REPLY =~ ^[Yy]$ ]]; then
+      echo "Aborting the fund transfer."
+      exit 1
+    fi
+    echo
+  }
+
+  TS=$(date -u +%y-%m-%d_%H-%M-%S)
+  BASENAME="tx-fund-transfer-$ENV-$TS"
+
+  PAYMENT_VKEY=$(cardano-cli latest key verification-key --signing-key-file <(echo -n "$PAYMENT_SKEY") --verification-key-file /dev/stdout)
+
+  if [ "$#" -eq 5 ]; then
+    STAKE_VKEY=$(cardano-cli latest key verification-key --signing-key-file <(echo -n "$STAKE_SKEY") --verification-key-file /dev/stdout)
+
+    SIGNING_TX_ARGS+=(
+      "--signing-key-file" "<(echo -n \"\$STAKE_SKEY\")"
+    )
+  fi
+
+  SOURCE_ADDR=$(
+    if [ "$#" -eq 4 ]; then
+      cardano-cli latest address build \
+        --payment-verification-key-file <(echo -n "$PAYMENT_VKEY") 2> /dev/null
+    else
+      cardano-cli latest address build \
+        --payment-verification-key-file <(echo -n "$PAYMENT_VKEY") \
+        --stake-verification-key-file <(echo -n "$STAKE_VKEY") 2> /dev/null \
+      || { \
+        STAKE_VKEY_FROM_EXT=$(cardano-cli latest key non-extended-key --extended-verification-key-file <(echo -n "$STAKE_VKEY") --verification-key-file /dev/stdout)
+
+        cardano-cli latest address build \
+          --payment-verification-key-file <(echo -n "$PAYMENT_VKEY") \
+          --stake-verification-key-file <(echo -n "$STAKE_VKEY_FROM_EXT")
+        }
+    fi
+  )
+
+  echo "For environment $ENV, the source address of $SOURCE_ADDR contains the following lovelace only UTxOs:"
+  cardano-cli latest query utxo --address "$SOURCE_ADDR" | jq 'to_entries | map(select(.value.value | length == 1)) | sort_by(.value.value.lovelace) | from_entries'
+  PROMPT
+
+  echo "For environment $ENV, the send to address of $SEND_ADDR contains the following lovelace only UTxOs:"
+  cardano-cli latest query utxo --address "$SEND_ADDR" | jq 'to_entries | map(select(.value.value | length == 1)) | sort_by(.value.value.lovelace) | from_entries'
+  PROMPT
+
+  echo "The provided UTXO has an ID and value of:"
+  SELECTED_UTXO=$(
+    cardano-cli latest query utxo \
+      --address "$SOURCE_ADDR" \
+      --testnet-magic "$TESTNET_MAGIC" \
+    | jq -e -r --arg selectedUtxo "$UTXO" 'to_entries[]
+      |
+        select(.key == $selectedUtxo)
+          | {"txin": .key, "address": .value.address, "amount": .value.value.lovelace}'
+  )
+
+  TXIN=$(jq -r .txin <<< "$SELECTED_UTXO")
+  TXIN_VALUE=$(jq -r .amount <<< "$SELECTED_UTXO")
+  echo "  UTXO: $TXIN"
+  echo "  Value: $TXIN_VALUE"
+  echo
+  echo "Assembling transaction with details of:"
+  echo "  Send to address: $SEND_ADDR"
+  echo "  From address: $SOURCE_ADDR"
+  echo "  Send amount: $TXIN_VALUE lovelace"
+  echo "  Fee amount: 0.2 ADA"
+  echo "  Funding UTxO: $TXIN"
+  echo "  Funding UTxO value: $TXIN_VALUE lovelace"
+  PROMPT
+
+  cardano-cli latest transaction build-raw \
+    --tx-in "$TXIN" \
+    --tx-out "$SEND_ADDR+$((TXIN_VALUE - 200000))" \
+    --fee 200000 \
+    --out-file "$BASENAME.raw"
+
+  # shellcheck disable=2116
+  SIGNING_CMD=$(echo "cardano-cli latest transaction sign \
+    --tx-body-file \"\$BASENAME.raw\" \
+    --signing-key-file <(echo -n \"\$PAYMENT_SKEY\") \
+    ${SIGNING_TX_ARGS[*]} \
+    --testnet-magic \"\$TESTNET_MAGIC\" \
+    --out-file \$BASENAME.signed"
+  )
+  eval "$SIGNING_CMD"
+
+  echo
+  echo "The transaction has been prepared and signed:"
+  cardano-cli debug transaction view --tx-file "$BASENAME.signed"
+  echo
+  echo "If you answer affirmative to the next prompt this transaction will be submitted to the network!"
+  PROMPT
+
+  submit "$BASENAME.signed"
+)

--- a/templates/cardano-parts-project/scripts/recipes/governance.just
+++ b/templates/cardano-parts-project/scripts/recipes/governance.just
@@ -69,6 +69,22 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     exit 1
   fi
 
+  L_JUSTIFY() {
+    DESC="$1"
+    VALUE="$2"
+    COL="$3"
+
+    printf "  %s%*s%s\n" "$DESC" $((COL - ${#DESC})) "" "$VALUE"
+  }
+
+  R_JUSTIFY() {
+    DESC="$1"
+    VALUE="$2"
+    COL="$3"
+
+    printf "  %s%*s%s\n" "$DESC" $((COL - ${#DESC} - ${#VALUE})) "" "$VALUE"
+  }
+
   # Arg setup
   ACTION_UTXO="{{ACTION_ID}}"
   ACTION_IDX="{{ACTION_IDX}}"
@@ -77,8 +93,8 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
 
   # Basic query info
   echo "Current voting status for:"
-  echo "  ACTION_ID: $ACTION_ID"
-  echo "  ACTION_BECH: $ACTION_BECH"
+  L_JUSTIFY "ACTION_ID:" "$ACTION_ID" 35
+  L_JUSTIFY "ACTION_BECH:" "$ACTION_BECH" 35
   echo
 
   CURRENT_EPOCH=$(jq -re .epoch <<< "$TIP")
@@ -90,25 +106,48 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     exit 1
   fi
 
-  # DREP_PWR_DIST is similar to DREP_DIST but only includes active dreps and
-  # those without `drep-alwaysAbstain` and `drep-noConfidence`.
   EPOCH=$(jq -re .epoch <<< "$TIP")
+
+  # The drep-stake-distribution query includes expired dreps and system
+  # alwaysAbstain and alwaysNoConfidence dreps which are funded directly from
+  # stake delegation.
   DREP_DIST=$(eval "$CARDANO_CLI" latest query drep-stake-distribution --all-dreps 2> /dev/null)
+
+  # DREP_PWR_DIST is similar to DREP_DIST but excludes expired dreps and system dreps (alwaysAbstain and alwaysNoConfidence).
   DREP_PWR_DIST=$(eval "$CARDANO_CLI" latest query drep-state --all-dreps --include-stake \
     | jq -re "[ .[] | select( .[1].expiry >= $EPOCH ) | [\"drep-\(.[0] | keys[0])-\(.[0] | to_entries[].value)\", (.[1].stake // 0)]]" 2> /dev/null)
+
+  # Get a distribution of all expired dreps
+  DREP_EXP_PWR_DIST=$(eval "$CARDANO_CLI" latest query drep-state --all-dreps --include-stake \
+    | jq -re "[ .[] | select( .[1].expiry < $EPOCH ) | [\"drep-\(.[0] | keys[0])-\(.[0] | to_entries[].value)\", (.[1].stake // 0)]]" 2> /dev/null)
+
+  # Calculate active and inactive drep power based on valid or expired dreps
   DREP_PWR_ACTIVE=$(jq -re "[.[][1]] | add // 0" <<< "$DREP_PWR_DIST" 2> /dev/null)
-  DREP_STAKE_TOTAL=$(jq -re '[del(.[] | select(.[0] == "drep-alwaysAbstain" or .[0] == "drep-alwaysNoConfidence")) | .[][1]] | add' <<< "$DREP_DIST" 2> /dev/null)
+  DREP_PWR_INACTIVE=$(jq -re "[.[][1]] | add // 0" <<< "$DREP_EXP_PWR_DIST" 2> /dev/null)
+
+  # All drep stake, including stake held by expired dreps, and stake auto delegated to always abstain or always no-confidence
+  DREP_STAKE_TOTAL=$(jq -re '[.[][1]] | add' <<< "$DREP_DIST" 2> /dev/null)
+
+  # This is always 1 length for drep-alwaysNoConfidence;
   DREP_NOCONF_COUNT=$(jq -re '[.[] | select(.[0] == "drep-alwaysNoConfidence") | .[1]] | length' <<< "$DREP_DIST" 2> /dev/null)
   DREP_NOCONF_TOTAL=$(jq -re '(.[] | select(.[0] == "drep-alwaysNoConfidence") | .[1]) // 0' <<< "$DREP_DIST" 2> /dev/null)
-  echo "Some potentially useful metrics:"
-  echo "  CURRENT_EPOCH: $CURRENT_EPOCH"
-  echo "  DREP_POWER_ACTIVE: $DREP_PWR_ACTIVE"
-  echo "  DREP_STAKE_TOTAL: $DREP_STAKE_TOTAL"
-  echo "  DREP_NOCONF_TOTAL: $DREP_NOCONF_TOTAL"
+
+  DREP_ALWAYS_ABSTAIN_TOTAL=$(jq -re '(.[] | select(.[0] == "drep-alwaysAbstain") | .[1]) // 0' <<< "$DREP_DIST" 2> /dev/null)
+  echo "Some useful metrics:"
+  R_JUSTIFY "CURRENT_EPOCH:" "$CURRENT_EPOCH" 50
+  R_JUSTIFY "DREP_POWER_ACTIVE:" "$DREP_PWR_ACTIVE" 50
+  R_JUSTIFY "DREP_POWER_INACTIVE:" "$DREP_PWR_INACTIVE" 50
+  R_JUSTIFY "DREP_STAKE_TOTAL:" "$DREP_STAKE_TOTAL" 50
+  R_JUSTIFY "DREP_NOCONF_TOTAL:" "$DREP_NOCONF_TOTAL" 50
+  R_JUSTIFY "DREP_ALWAYS_ABSTAIN:" "$DREP_ALWAYS_ABSTAIN_TOTAL" 50
 
   POOL_DIST=$(eval "$CARDANO_CLI" latest query spo-stake-distribution --all-spos 2> /dev/null)
   POOL_STAKE_TOTAL=$(jq -re '[.[][1]] | add // 0' <<< "$POOL_DIST" 2> /dev/null)
-  echo "  POOL_STAKE_TOTAL: $POOL_STAKE_TOTAL"
+  POOL_ABSTAIN_TOTAL=$(jq -re '[(.[] | select(.[2] == "drep-alwaysAbstain")) | .[1]] | add' <<< "$POOL_DIST")
+  POOL_NOCONF_TOTAL=$(jq -re '[(.[] | select(.[2] == "drep-alwaysNoConfidence")) | .[1]] | add' <<< "$POOL_DIST")
+  R_JUSTIFY "POOL_STAKE_TOTAL:" "$POOL_STAKE_TOTAL" 50
+  R_JUSTIFY "POOL_ABSTAIN_TOTAL:" "$POOL_ABSTAIN_TOTAL" 50
+  R_JUSTIFY "POOL_NOCONF_TOTAL:" "$POOL_NOCONF_TOTAL" 50
 
   COMMITTEE_DIST=$(eval "$CARDANO_CLI" latest query committee-state \
     | jq -re '
@@ -127,7 +166,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
   COMMITTEE_TOTAL=$(jq -re "length // 0" <<< "$COMMITTEE_DIST" 2> /dev/null)
   COMMITTEE_THRESHOLD=$(jq -re '"\(.committee.threshold)" // 0' <<< "$GOV_STATE" 2> /dev/null)
   COMMITTEE_THRESHOLD_TYPE=$(jq -re "type" <<< "$COMMITTEE_THRESHOLD" 2> /dev/null)
-  echo "  COMMITTEE_TOTAL: $COMMITTEE_TOTAL"
+  R_JUSTIFY "COMMITTEE_TOTAL:" "$COMMITTEE_TOTAL" 50
 
   case "$COMMITTEE_THRESHOLD_TYPE" in
     "object")
@@ -147,7 +186,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
 
   PPARAMS=$(eval "$CARDANO_CLI" latest query protocol-parameters)
   PROT_MAJOR_VER=$(jq -re ".protocolVersion.major // -1" <<< "$PPARAMS" 2> /dev/null)
-  echo "  PROT_MAJOR_VER: $PROT_MAJOR_VER"
+  R_JUSTIFY "PROT_MAJOR_VER:" "$PROT_MAJOR_VER" 50
 
   {
     read -r ACTION_TAG
@@ -188,14 +227,14 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     (.committeeVotes | with_entries(select(.value | contains("No"))) | length),
     (.committeeVotes | with_entries(select(.value | contains("Abstain"))) | length)' <<< "$ACTION")"
 
-    echo "  ACTION_TAG: $ACTION_TAG"
-    echo "  ACTION_ANCHOR_URL: $ACTION_ANCHOR_URL"
-    echo "  ACTION_ANCHOR_HASH: $ACTION_ANCHOR_HASH"
-    echo "  ACTION_PROPOSED_IN_EPOCH: $ACTION_PROPOSED_IN_EPOCH"
-    echo "  ACTION_EXPIRES_AFTER_EPOCH: $ACTION_EXPIRES_AFTER_EPOCH"
-    echo "  ACTION_DEPOSIT_RETURN_KEY_TYPE: $ACTION_DEPOSIT_RETURN_KEY_TYPE"
-    echo "  ACTION_DEPOSIT_RETURN_HASH: $ACTION_DEPOSIT_RETURN_HASH"
-    echo "  ACTION_DEPOSIT_RETURN_NETWORK: $ACTION_DEPOSIT_RETURN_NETWORK"
+    L_JUSTIFY "ACTION_TAG:" "$ACTION_TAG" 35
+    L_JUSTIFY "ACTION_ANCHOR_URL:" "$ACTION_ANCHOR_URL" 35
+    L_JUSTIFY "ACTION_ANCHOR_HASH:" "$ACTION_ANCHOR_HASH" 35
+    L_JUSTIFY "ACTION_PROPOSED_IN_EPOCH:" "$ACTION_PROPOSED_IN_EPOCH" 35
+    L_JUSTIFY "ACTION_EXPIRES_AFTER_EPOCH:" "$ACTION_EXPIRES_AFTER_EPOCH" 35
+    L_JUSTIFY "ACTION_DEPOSIT_RETURN_KEY_TYPE:" "$ACTION_DEPOSIT_RETURN_KEY_TYPE" 35
+    L_JUSTIFY "ACTION_DEPOSIT_RETURN_HASH:" "$ACTION_DEPOSIT_RETURN_HASH" 35
+    L_JUSTIFY "ACTION_DEPOSIT_RETURN_NETWORK:" "$ACTION_DEPOSIT_RETURN_NETWORK" 35
 
     # Generate lists with the DRep hashes that are voted yes, no or abstain.
     # Add a 'drep-' in front of each entry to mach up the syntax in the `drep-stake-distribution` json.
@@ -222,6 +261,11 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
     # Calculate the acceptance percentage for the drep group
     if [ "$ACTION_TAG" != "NoConfidence" ]; then
       # Do a normal percentage calculation if not a `NoConfidence` action
+      # DREP_PWR_ACTIVE is drep stake for dreps who have not expired and it does not include alwaysNoConfidence or alwaysAbstain delegation
+      # DREP_NOCONF_TOTAL is only from direct stake key delegation and should be counted in the denominator
+      # DREP_STAKE_ABSTAIN is summed stake from explicit drep abstain votes
+      # which need to be removed from threshold denominator; the system
+      # alwaysAbstrain drep has already been excluded by using DREP_PWR_ACTIVE.
       DREP_PCT=$(bc <<< "scale=2; 100.00 * $DREP_STAKE_YES / ($DREP_PWR_ACTIVE + $DREP_NOCONF_TOTAL - $DREP_STAKE_ABSTAIN)" 2> /dev/null)
     else
       # Or, if a `NoConfidence` action, the always no confidence counts as yes
@@ -564,7 +608,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
             read -r DENOMINATOR
           } <<< "$(jq -re '.numerator // "-", .denominator // "-"' <<< "$COMMITTEE_THRESHOLD")"
           COMMITTEE_THRESHOLD=$(bc <<< "scale=0; ($NUMERATOR * 100 / $DENOMINATOR) / 1")
-          echo -e "Approval of a governance measure requires $NUMERATOR out of $DENOMINATOR ($COMMITEE_THRESHOLD%) of the votes of committee members.$OFF\n"
+          echo -e "Approval of a governance measure requires $NUMERATOR out of $DENOMINATOR ($COMMITTEE_THRESHOLD%) of the votes of committee members.$OFF\n"
           ;;
 
         "number")


### PR DESCRIPTION
## Overview:

Cardano-node pre-release has been updated to `10.5.1`.  Cardano-signer has been added, blockperf and credential manager tools updated.  Nix jobs for facilitating governance activities have been improved, easing operations.  Other miscellaneous improvements are detailed below.

## Details:

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
| :---: | :---: | :---: |
| blockperf | <ins>***2.0.2***</ins> | N/A |
| cardano-address | 4.0.0 | N/A |
| cardano-cli | 10.8.0.0 | 10.11.0.0 |
| cardano-db-sync | 13.6.0.5 | 13.6.0.5 |
| cardano-node | 10.4.1 | <ins>***10.5.1***</ins> |
| cardano-ogmios | 6.11.2 | N/A |
| cardano-signer | <ins>***1.27.0***</ins> | N/A |
| credential-manager | <ins>***0.1.5.0***</ins> | N/A |
| mithril | 2524.0 | <ins>***b76f911***</ins> |
| nix* | <ins>***2.29.2***</ins> | N/A |
| nixpkgs* | 25.05 | N/A |

\* = For nixos machine deployments

* Bumps nix `2.29-maint` input for cve update
* Bumps capkgs for node `10.5.1` as pre-release, blockperf `2.0.2`, creds mgr
* Bumps cardano-node-service-ng for internal TargetNumber cfg handling of `10.5.1`
* Updates the `job-submit-gov-action` job to handle guardrails changes in flakeModules jobs
* Updates node config entrypoints to avoid fatal error on multiple devShell node pids until node `10.6.0` is used in flakeModules entrypoints
* Updates the template recipe `query-gov-action-status` output for improved output and fixes a typo
* Adds `cardano-signer` to the flakeModules pkgs and default test devShell
* Adds a check for unencrypted files in the decrypt function in flakeModules jobs
* Adds an optional pool id for a registering drep to auto-delegate to and creates drep key hashes in flakeModules jobs
* Adds a new template script bash function of `return-utxo`

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* N/A

### Recommended Updates:
* Update the cardano-parts pin to this release version `v2025-07-23`
* Apply the template Justfile diff and patch or clone recipes on files described below.

### Action Items:
Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`.  Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the
 just template-clone "$FILE"` recipe.
```
scripts/bash-fns.sh               # For a new return-utxo function
scripts/recipes/governance.just   # For updates to query-gov-action-status recipe
```

## Known Issues:
* If a local node is started using `just start-node $NETWORK` with no or partial pre-existing state present, a file write error may be encountered during startup.  Resolve this by adding write permission to the config directory for the network, typically found at: `chmod -R +w ~/.local/share/$REPO/config`.