### PR TITLE
Node 10.5.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -162,17 +162,17 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1746450573,
-        "narHash": "sha256-Szhph7YncIbQ+/QmqzSW61WLConBa8XIA6K/3A8mP00=",
-        "owner": "input-output-hk",
+        "lastModified": 1752857436,
+        "narHash": "sha256-YAAwDfzMMTeEQa0zHin7yo2nMdxONJ983tJ3NrP7K6E=",
+        "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0983ac29304aadac74a5604eeefa76cfbcc91611",
+        "rev": "ca1ec278070baf4481564a6ba7b4a5b9e3d9f366",
         "type": "github"
       },
       "original": {
-        "owner": "input-output-hk",
+        "owner": "IntersectMBO",
+        "ref": "release/10.5.1",
         "repo": "cardano-node",
-        "rev": "0983ac29304aadac74a5604eeefa76cfbcc91611",
         "type": "github"
       }
     },
@@ -434,11 +434,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1747796208,
-        "narHash": "sha256-ZUBNrv+lO0CWhnN0R0ZiG/eIB+W5pnyAGsxf/lozECo=",
+        "lastModified": 1750025513,
+        "narHash": "sha256-WUNoYIZvU9moc5ccwJcF22r+bUJXO5dWoRyLPs8bJic=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "281f635b01f8fe843baefe010a694f67041c0848",
+        "rev": "f63aa2a49720526900fb5943db4123b5b8dcc534",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -89,8 +89,7 @@
     };
 
     cardano-node-service = {
-      # Until node >= 10.5.0 is tagged, this commit allows the service to work on nixpkgs >= 25.05
-      url = "github:input-output-hk/cardano-node/0983ac29304aadac74a5604eeefa76cfbcc91611";
+      url = "github:IntersectMBO/cardano-node/release/10.5.1";
       flake = false;
     };
 

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -442,7 +442,7 @@ in
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
           mithril-pre-release = "input-output-hk-mithril-unstable-b76f911";
-          node-release = "input-output-hk-cardano-node-10-4-1-420c94f";
+          node-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
           node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
         in
           submodule {
@@ -465,7 +465,7 @@ in
               (mkPkg "cardano-faucet" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
               (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
 
-              (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.4.1";}))
+              (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.5.1";}))
               (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.1";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-27-0-b71c3f1)


### PR DESCRIPTION
## Overview:

Cardano-node release has been updated to `10.5.1`.

## Details:

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
| :---: | :---: | :---: |
| blockperf | 2.0.2 | N/A |
| cardano-address | 4.0.0 | N/A |
| cardano-cli | 10.11.0.0 | 10.11.0.0 |
| cardano-db-sync | 13.6.0.5 | 13.6.0.5 |
| cardano-node | <ins>***10.5.1***</ins> | 10.5.1 |
| cardano-ogmios | 6.11.2 | N/A |
| cardano-signer | 1.27.0 | N/A |
| credential-manager | 0.1.5.0 | N/A |
| mithril | 2524.0 | b76f911 |
| nix* | 2.29.2 | N/A |
| nixpkgs* | 25.05 | N/A |

\* = For nixos machine deployments

* Bumps iohk-nix and cardano-node-service for release `10.5.1`
* Sets cardano-node release to `10.5.1`

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* N/A

### Recommended Updates:
* Update the cardano-parts pin to this release version `v2025-07-25`

### Action Items:
* N/A

## Known Issues:
* If a local node is started using `just start-node $NETWORK` with no or partial pre-existing state present, a file write error may be encountered during startup.  Resolve this by adding write permission to the config directory for the network, typically found at: `chmod -R +w ~/.local/share/$REPO/config`.