### PR TITLE
Next 2025-08-07

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -79,11 +79,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1753194948,
-        "narHash": "sha256-c2u8JzI+KPquczoAZ0mlOtRm6q+himwvQod2k1Vpl/k=",
+        "lastModified": 1755190706,
+        "narHash": "sha256-/+6TQESSFiqoyT6LfBbcij0HeyCAMD9+AndDJHGKSFM=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "af0077b030b1e5e927e7d7ff27a80dadb59f0fb1",
+        "rev": "b2cd2938011557e0c7e767dc112510acdaed2b16",
         "type": "github"
       },
       "original": {

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -36,12 +36,15 @@
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoNodePrometheusExporterPort
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardanoSmashDelistedPools
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-db-sync-service
+#   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-db-sync-service-ng
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-faucet-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-metadata-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-node-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-node-service-ng
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-ogmios-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-smash-service
+#   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-submit-api-service
+#   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-submit-api-service-ng
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-tracer-service
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-tracer-service-ng
 #   flake.cardano-parts.cluster.groups.<default|name>.meta.domain
@@ -469,6 +472,12 @@ flake @ {
         default = cfg.pkgs.special.cardano-db-sync-service;
       };
 
+      cardano-db-sync-service-ng = mkOption {
+        type = str;
+        description = mdDoc "Cardano-parts cluster group cardano-db-sync-service-ng import path string.";
+        default = cfg.pkgs.special.cardano-db-sync-service-ng;
+      };
+
       cardano-faucet-service = mkOption {
         type = str;
         description = mdDoc "Cardano-parts cluster group cardano-faucet-service import path string.";
@@ -503,6 +512,18 @@ flake @ {
         type = str;
         description = mdDoc "Cardano-parts cluster group cardano-smash-service import path string.";
         default = cfg.pkgs.special.cardano-smash-service;
+      };
+
+      cardano-submit-api-service = mkOption {
+        type = str;
+        description = mdDoc "Cardano-parts cluster group cardano-submit-api-service import path string.";
+        default = cfg.pkgs.special.cardano-submit-api-service;
+      };
+
+      cardano-submit-api-service-ng = mkOption {
+        type = str;
+        description = mdDoc "Cardano-parts cluster group cardano-submit-api-service-ng import path string.";
+        default = cfg.pkgs.special.cardano-submit-api-service-ng;
       };
 
       cardano-tracer-service = mkOption {

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -465,7 +465,7 @@ in
           dbsync-pre-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
-          mithril-pre-release = "input-output-hk-mithril-unstable-b76f911";
+          mithril-pre-release = "input-output-hk-mithril-unstable-de4de82";
           node-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
           node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
         in
@@ -476,7 +476,7 @@ in
               (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
               (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-d757f38)
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
-              (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.8.0.0";}))
+              (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.11.0.0";}))
               (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))
               (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-release}")
               (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-pre-release}")
@@ -492,7 +492,7 @@ in
               (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.5.1";}))
               (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.1";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
-              (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-27-0-b71c3f1)
+              (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-29-0-2ef95e1)
               (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")
               (mkPkg "cardano-smash-ng" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-pre-release}")
               (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-${node-release}")

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -297,7 +297,7 @@
 
       cardano-db-sync-service-ng = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-db-sync-service import path string.";
+        description = mdDoc "The cardano-parts default cardano-db-sync-service-ng import path string.";
         default = "${localFlake.inputs.cardano-db-sync-service-ng}/nix/nixos/cardano-db-sync-service.nix";
       };
 


### PR DESCRIPTION
## Overview:

Updates cardano-signer to `v1.29.0` which allows for Byron era address claims for Midnight Glacier drop.  Bumps mithril unstable and adds some flakeModule cluster options for more service granularity.

## Details:

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
| :---: | :---: | :---: |
| blockperf | 2.0.2 | N/A |
| cardano-address | 4.0.0 | N/A |
| cardano-cli | 10.11.0.0 | 10.11.0.0 |
| cardano-db-sync | 13.6.0.5 | 13.6.0.5 |
| cardano-node | 10.5.1 | 10.5.1 |
| cardano-ogmios | 6.11.2 | N/A |
| cardano-signer | <ins>***1.29.0***</ins> | N/A |
| credential-manager | 0.1.5.0 | N/A |
| mithril | 2524.0 | <ins>***de4de82***</ins> |
| nix* | 2.29.2 | N/A |
| nixpkgs* | 25.05 | N/A |

\* = For nixos machine deployments

* Bumps cardano-signer to release `v1.29.0`
* Adds new flakeModule cluster options for more service granularity:
```
flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-db-sync-service-ng
flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-submit-api-service
flake.cardano-parts.cluster.groups.<default|name>.meta.cardano-submit-api-service-ng
```

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* N/A

### Recommended Updates:
* Update the cardano-parts pin to this release version `v2025-08-14`

### Action Items:
* N/A

## Known Issues:
* If a local node is started using `just start-node $NETWORK` with no or partial pre-existing state present, a file write error may be encountered during startup.  Resolve this by adding write permission to the config directory for the network, typically found at: `chmod -R +w ~/.local/share/$REPO/config`.