### PR TITLE
Node 10.6.0 pre-release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/.direnv
+/.direnv*
 /.envrc.local
 result*
 /.run/

--- a/flake.lock
+++ b/flake.lock
@@ -195,17 +195,17 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1753292803,
-        "narHash": "sha256-uP5B+vu/DsqknOAG9EutRSgZW5aAuMV9+NVY+tGJJCk=",
+        "lastModified": 1757635285,
+        "narHash": "sha256-dVYhbEYpl1G5hnQYz42DWFsYzrJ0DmSYhTQ1hIL0co8=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
+        "rev": "edae9912ff7569a48d531be6088470718f73e2cd",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
+        "ref": "jl/10.6.0-pre-nix-cfg-updates",
         "repo": "cardano-node",
-        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
         "type": "github"
       }
     },
@@ -280,17 +280,17 @@
     "cardano-tracer-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1753292803,
-        "narHash": "sha256-uP5B+vu/DsqknOAG9EutRSgZW5aAuMV9+NVY+tGJJCk=",
+        "lastModified": 1757635285,
+        "narHash": "sha256-dVYhbEYpl1G5hnQYz42DWFsYzrJ0DmSYhTQ1hIL0co8=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
+        "rev": "edae9912ff7569a48d531be6088470718f73e2cd",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
+        "ref": "jl/10.6.0-pre-nix-cfg-updates",
         "repo": "cardano-node",
-        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
         "type": "github"
       }
     },
@@ -522,15 +522,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1751421193,
-        "narHash": "sha256-rklXDo12dfukaSqcEyiYbze3ffRtTl2/WAAQCWfkGiw=",
+        "lastModified": 1755030560,
+        "narHash": "sha256-iEKngfkifsqAvi8g2cwV2W0IK/3LopgFhA3SXz4r5m0=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "64ca6f4c0c6db283e2ec457c775bce75173fb319",
+        "rev": "f1da9c88be417237608580bab7fe24ee433bc585",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "jl/10.6.0-pre-updates",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -342,11 +342,11 @@
         "utils": "utils"
       },
       "locked": {
-        "lastModified": 1761324192,
-        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "lastModified": 1761827211,
+        "narHash": "sha256-butMOynyTKhLUrjocKuBnbAkDYhbnRKGEGdbTS773KQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "rev": "9a132bb72045e9462f0612e5df5af07c7206635a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1209,11 +1209,11 @@
         "sodium": "sodium_3"
       },
       "locked": {
-        "lastModified": 1761066415,
-        "narHash": "sha256-jx83bMiZGw3ulkouzjLTcx6xtVI9GLoG6qBy/Oo3DPM=",
+        "lastModified": 1762808561,
+        "narHash": "sha256-SPa6PSCbYjAaIfS/1B0dIYYegML4bH9fUfaUGNBsHng=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "338ae551e1d1ae5dae72bbb335f8c3cd623fefee",
+        "rev": "5558bf878ae4d7ede1f2bd3c19582d5a3c388167",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -215,11 +215,11 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1757635285,
-        "narHash": "sha256-dVYhbEYpl1G5hnQYz42DWFsYzrJ0DmSYhTQ1hIL0co8=",
+        "lastModified": 1760975377,
+        "narHash": "sha256-HJE5R51LyGCGQQJoldWONbr501Ww/juEUOqEIC1yOfY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "edae9912ff7569a48d531be6088470718f73e2cd",
+        "rev": "7697209cab6072598f9dc5f7bc1bf75979199ee9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -43,6 +43,26 @@
         "type": "github"
       }
     },
+    "blockperf": {
+      "inputs": {
+        "flake-parts": "flake-parts",
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "lastModified": 1758832274,
+        "narHash": "sha256-na9CqAbZKVQLgxAwyxLOi2hlbQcRln3wgo5qTlBPefo=",
+        "owner": "johnalotoski",
+        "repo": "blockperf",
+        "rev": "80c13b6b3cb6a3a17309851659909bd246e999c8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "johnalotoski",
+        "ref": "jl/fix-detail",
+        "repo": "blockperf",
+        "type": "github"
+      }
+    },
     "blst": {
       "flake": false,
       "locked": {
@@ -372,6 +392,24 @@
         "nixpkgs-lib": "nixpkgs-lib"
       },
       "locked": {
+        "lastModified": 1704982712,
+        "narHash": "sha256-2Ptt+9h8dczgle2Oo6z5ni5rt/uLMG47UFTR1ry/wgg=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "07f6395285469419cf9d078f59b5b49993198c00",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_2": {
+      "inputs": {
+        "nixpkgs-lib": "nixpkgs-lib_2"
+      },
+      "locked": {
         "lastModified": 1743550720,
         "narHash": "sha256-hIshGgKZCgWh6AYJpJmRgFdR3WUbkY04o82X05xqQiY=",
         "owner": "hercules-ci",
@@ -385,7 +423,7 @@
         "type": "github"
       }
     },
-    "flake-parts_2": {
+    "flake-parts_3": {
       "inputs": {
         "nixpkgs-lib": [
           "nix",
@@ -496,7 +534,7 @@
     "iohk-nix": {
       "inputs": {
         "blst": "blst",
-        "nixpkgs": "nixpkgs",
+        "nixpkgs": "nixpkgs_2",
         "secp256k1": "secp256k1",
         "sodium": "sodium"
       },
@@ -517,7 +555,7 @@
     "iohk-nix-ng": {
       "inputs": {
         "blst": "blst_2",
-        "nixpkgs": "nixpkgs_2",
+        "nixpkgs": "nixpkgs_3",
         "secp256k1": "secp256k1_2",
         "sodium": "sodium_2"
       },
@@ -539,9 +577,9 @@
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat_2",
-        "flake-parts": "flake-parts_2",
+        "flake-parts": "flake-parts_3",
         "git-hooks-nix": "git-hooks-nix",
-        "nixpkgs": "nixpkgs_3",
+        "nixpkgs": "nixpkgs_4",
         "nixpkgs-23-11": "nixpkgs-23-11",
         "nixpkgs-regression": "nixpkgs-regression"
       },
@@ -583,16 +621,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1751071626,
-        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
-        "owner": "nixos",
+        "lastModified": 1705458851,
+        "narHash": "sha256-uQvEhiv33Zj/Pv364dTvnpPwFSptRZgVedDzoM+HqVg=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
+        "rev": "8bf65f17d8070a0a490daf5f1c784b87ee73982c",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
-        "ref": "release-25.05",
+        "owner": "NixOS",
+        "ref": "nixos-23.11",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -614,6 +652,24 @@
       }
     },
     "nixpkgs-lib": {
+      "locked": {
+        "dir": "lib",
+        "lastModified": 1703961334,
+        "narHash": "sha256-M1mV/Cq+pgjk0rt6VxoyyD+O8cOUiai8t9Q6Yyq4noY=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b0d36bd0a420ecee3bc916c91886caca87c894e9",
+        "type": "github"
+      },
+      "original": {
+        "dir": "lib",
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-lib_2": {
       "locked": {
         "lastModified": 1743296961,
         "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
@@ -678,6 +734,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1751071626,
+        "narHash": "sha256-/uHE/AD2qGq4QLigWAnBHiVvpVXB04XAfrOtw8JMv+Y=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a47938d89bdf8e279ad432bd6a473cf4c430f48c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "release-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1747179050,
         "narHash": "sha256-qhFMmDkeJX9KJwr5H32f1r7Prs7XbQWtO0h3V0a0rFY=",
         "owner": "NixOS",
@@ -692,7 +764,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1748162331,
         "narHash": "sha256-rqc2RKYTxP3tbjA+PB3VMRQNnjesrT0pEofXQTrMsS8=",
@@ -743,6 +815,7 @@
       "inputs": {
         "auth-keys-hub": "auth-keys-hub",
         "blockfrost-platform-service": "blockfrost-platform-service",
+        "blockperf": "blockperf",
         "capkgs": "capkgs",
         "cardano-db-sync-schema": "cardano-db-sync-schema",
         "cardano-db-sync-schema-ng": "cardano-db-sync-schema-ng",
@@ -758,12 +831,12 @@
         "cardano-tracer-service-ng": "cardano-tracer-service-ng",
         "cardano-wallet-service": "cardano-wallet-service",
         "colmena": "colmena",
-        "flake-parts": "flake-parts",
+        "flake-parts": "flake-parts_2",
         "inputs-check": "inputs-check",
         "iohk-nix": "iohk-nix",
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nixpkgs-unstable": "nixpkgs-unstable",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",

--- a/flake.lock
+++ b/flake.lock
@@ -99,11 +99,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1755190706,
-        "narHash": "sha256-/+6TQESSFiqoyT6LfBbcij0HeyCAMD9+AndDJHGKSFM=",
+        "lastModified": 1760451894,
+        "narHash": "sha256-GXy1zMjD73bmBpmK3f6V+rWCKQgfjQXzYUk9Dky+qso=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "b2cd2938011557e0c7e767dc112510acdaed2b16",
+        "rev": "36068d0908d770da0498f9dcc254d17b17524e03",
         "type": "github"
       },
       "original": {
@@ -560,11 +560,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1755030560,
-        "narHash": "sha256-iEKngfkifsqAvi8g2cwV2W0IK/3LopgFhA3SXz4r5m0=",
+        "lastModified": 1760465963,
+        "narHash": "sha256-EZYi51N2LmKBE9+/lmB9M0wqCCfuBflyGH+aoXezwnM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f1da9c88be417237608580bab7fe24ee433bc585",
+        "rev": "f3f554529ca86e337e9ab921d01d6d62643c3f53",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,38 +1,5 @@
 {
   "nodes": {
-    "CHaP": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1761315163,
-        "narHash": "sha256-h+JPIMflNAOpY3XhZNcS5sUAOyO06499uWATj2j6P5Q=",
-        "owner": "intersectmbo",
-        "repo": "cardano-haskell-packages",
-        "rev": "131bcd51c4869b191e8c3afbb9f3fd326cd6e5e1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "intersectmbo",
-        "ref": "repo",
-        "repo": "cardano-haskell-packages",
-        "type": "github"
-      }
-    },
-    "HTTP": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1451647621,
-        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
-        "owner": "phadej",
-        "repo": "HTTP",
-        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
-        "type": "github"
-      },
-      "original": {
-        "owner": "phadej",
-        "repo": "HTTP",
-        "type": "github"
-      }
-    },
     "auth-keys-hub": {
       "inputs": {
         "flake-parts": [
@@ -130,112 +97,18 @@
         "type": "github"
       }
     },
-    "blst_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1739372843,
-        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
-        "owner": "supranational",
-        "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
-        "type": "github"
-      },
-      "original": {
-        "owner": "supranational",
-        "ref": "v0.3.14",
-        "repo": "blst",
-        "type": "github"
-      }
-    },
-    "cabal-32": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1603716527,
-        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.2",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-34": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1645834128,
-        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.4",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
-    "cabal-36": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1669081697,
-        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
-        "owner": "haskell",
-        "repo": "cabal",
-        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "3.6",
-        "repo": "cabal",
-        "type": "github"
-      }
-    },
     "capkgs": {
       "locked": {
-        "lastModified": 1760451894,
-        "narHash": "sha256-GXy1zMjD73bmBpmK3f6V+rWCKQgfjQXzYUk9Dky+qso=",
+        "lastModified": 1763153457,
+        "narHash": "sha256-2orZuWq9ewAs8RT+kvSeqcbTul4mGaxLCFHYRIUvLvA=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "36068d0908d770da0498f9dcc254d17b17524e03",
+        "rev": "4146aa28984f63ef9cd8fbda904ce345958e23f9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "type": "github"
-      }
-    },
-    "cardano-automation": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "haskellNix": [
-          "cardano-node-10-6-0",
-          "haskellNix"
-        ],
-        "nixpkgs": [
-          "cardano-node-10-6-0",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1750923974,
-        "narHash": "sha256-PXB1aro2KalRw6OZkcbICl6Ge7HB4yEl5O3epm9VZl8=",
-        "owner": "input-output-hk",
-        "repo": "cardano-automation",
-        "rev": "64bf80a78102787790bac96075ef4109ff7de36e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-automation",
         "type": "github"
       }
     },
@@ -322,40 +195,6 @@
         "type": "github"
       }
     },
-    "cardano-node-10-6-0": {
-      "inputs": {
-        "CHaP": "CHaP",
-        "cardano-automation": "cardano-automation",
-        "customConfig": "customConfig",
-        "em": "em",
-        "empty-flake": "empty-flake",
-        "flake-compat": "flake-compat",
-        "hackageNix": "hackageNix",
-        "haskellNix": "haskellNix",
-        "incl": "incl",
-        "iohkNix": "iohkNix",
-        "nixpkgs": [
-          "cardano-node-10-6-0",
-          "haskellNix",
-          "nixpkgs-unstable"
-        ],
-        "utils": "utils"
-      },
-      "locked": {
-        "lastModified": 1761827211,
-        "narHash": "sha256-butMOynyTKhLUrjocKuBnbAkDYhbnRKGEGdbTS773KQ=",
-        "owner": "IntersectMBO",
-        "repo": "cardano-node",
-        "rev": "9a132bb72045e9462f0612e5df5af07c7206635a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "IntersectMBO",
-        "ref": "ana/10.6-final-integration-mix",
-        "repo": "cardano-node",
-        "type": "github"
-      }
-    },
     "cardano-node-service": {
       "flake": false,
       "locked": {
@@ -376,16 +215,16 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1761324192,
-        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "lastModified": 1763122005,
+        "narHash": "sha256-pm+lbEiRdQesnkaXmzn58aWlBhD29l7QHGNtJiDlzuA=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "rev": "f5ac0eb01b56af80e8d430828ff6000b6abb92e9",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "ana/10.6-final-integration-mix",
+        "ref": "10.6.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -404,22 +243,6 @@
         "owner": "input-output-hk",
         "ref": "ogmios-6-3-0",
         "repo": "cardano-ogmios",
-        "type": "github"
-      }
-    },
-    "cardano-shell": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1608537748,
-        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
-        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "cardano-shell",
         "type": "github"
       }
     },
@@ -443,16 +266,16 @@
     "cardano-submit-api-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1761324192,
-        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "lastModified": 1763122005,
+        "narHash": "sha256-pm+lbEiRdQesnkaXmzn58aWlBhD29l7QHGNtJiDlzuA=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "rev": "f5ac0eb01b56af80e8d430828ff6000b6abb92e9",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "ana/10.6-final-integration-mix",
+        "ref": "10.6.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -477,16 +300,16 @@
     "cardano-tracer-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1761324192,
-        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "lastModified": 1763122005,
+        "narHash": "sha256-pm+lbEiRdQesnkaXmzn58aWlBhD29l7QHGNtJiDlzuA=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "rev": "f5ac0eb01b56af80e8d430828ff6000b6abb92e9",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "ana/10.6-final-integration-mix",
+        "ref": "10.6.0",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -510,8 +333,8 @@
     },
     "colmena": {
       "inputs": {
-        "flake-compat": "flake-compat_3",
-        "flake-utils": "flake-utils_2",
+        "flake-compat": "flake-compat",
+        "flake-utils": "flake-utils",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "nixpkgs"
@@ -532,87 +355,7 @@
         "type": "github"
       }
     },
-    "customConfig": {
-      "locked": {
-        "lastModified": 1630400035,
-        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
-        "owner": "input-output-hk",
-        "repo": "empty-flake",
-        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "empty-flake",
-        "type": "github"
-      }
-    },
-    "em": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750940090,
-        "narHash": "sha256-DmDtgq8ipHCm2/Hq6e9xeJ2u8WLQFN1gXYSWM1bZNCU=",
-        "owner": "mgmeier",
-        "repo": "em",
-        "rev": "e3dde1952fcbe550055fb065590fdffd6f6f9710",
-        "type": "github"
-      },
-      "original": {
-        "owner": "mgmeier",
-        "repo": "em",
-        "type": "github"
-      }
-    },
-    "empty-flake": {
-      "locked": {
-        "lastModified": 1630400035,
-        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
-        "owner": "input-output-hk",
-        "repo": "empty-flake",
-        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "empty-flake",
-        "type": "github"
-      }
-    },
     "flake-compat": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1647532380,
-        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "fixes",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1672831974,
-        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
-        "owner": "input-output-hk",
-        "repo": "flake-compat",
-        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "hkm/gitlab-fix",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -628,7 +371,7 @@
         "type": "github"
       }
     },
-    "flake-compat_4": {
+    "flake-compat_2": {
       "flake": false,
       "locked": {
         "lastModified": 1733328505,
@@ -703,21 +446,6 @@
     },
     "flake-utils": {
       "locked": {
-        "lastModified": 1667395993,
-        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "flake-utils_2": {
-      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -728,23 +456,6 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "ghc-8.6.5-iohk": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1600920045,
-        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
-        "owner": "input-output-hk",
-        "repo": "ghc",
-        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "release/8.6.5-iohk",
-        "repo": "ghc",
         "type": "github"
       }
     },
@@ -776,366 +487,6 @@
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
-        "type": "github"
-      }
-    },
-    "hackage-for-stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755649550,
-        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "for-stackage",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackage-internal": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1750307553,
-        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "hackageNix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1761265459,
-        "narHash": "sha256-7tsC/ZcNBJR1pXWdKsRoh/qlVDhCxb1Ukr7PVd2zieE=",
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "rev": "eb8e4d02528b4973cd09450bb62cf34997777226",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "hackage.nix",
-        "type": "github"
-      }
-    },
-    "haskellNix": {
-      "inputs": {
-        "HTTP": "HTTP",
-        "cabal-32": "cabal-32",
-        "cabal-34": "cabal-34",
-        "cabal-36": "cabal-36",
-        "cardano-shell": "cardano-shell",
-        "flake-compat": "flake-compat_2",
-        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
-        "hackage": [
-          "cardano-node-10-6-0",
-          "hackageNix"
-        ],
-        "hackage-for-stackage": "hackage-for-stackage",
-        "hackage-internal": "hackage-internal",
-        "hls": "hls",
-        "hls-1.10": "hls-1.10",
-        "hls-2.0": "hls-2.0",
-        "hls-2.10": "hls-2.10",
-        "hls-2.11": "hls-2.11",
-        "hls-2.2": "hls-2.2",
-        "hls-2.3": "hls-2.3",
-        "hls-2.4": "hls-2.4",
-        "hls-2.5": "hls-2.5",
-        "hls-2.6": "hls-2.6",
-        "hls-2.7": "hls-2.7",
-        "hls-2.8": "hls-2.8",
-        "hls-2.9": "hls-2.9",
-        "hpc-coveralls": "hpc-coveralls",
-        "iserv-proxy": "iserv-proxy",
-        "nixpkgs": [
-          "cardano-node-10-6-0",
-          "nixpkgs"
-        ],
-        "nixpkgs-2305": "nixpkgs-2305",
-        "nixpkgs-2311": "nixpkgs-2311",
-        "nixpkgs-2405": "nixpkgs-2405",
-        "nixpkgs-2411": "nixpkgs-2411",
-        "nixpkgs-2505": "nixpkgs-2505",
-        "nixpkgs-unstable": "nixpkgs-unstable",
-        "old-ghc-nix": "old-ghc-nix",
-        "stackage": "stackage"
-      },
-      "locked": {
-        "lastModified": 1755663895,
-        "narHash": "sha256-76Ns29GQsO5S5gPRcic+vagcJicOSvhA+oKQ9r9kjFE=",
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "rev": "71fcc9f531993aada52173fceb4ff4ce2148207d",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "haskell.nix",
-        "type": "github"
-      }
-    },
-    "hls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1741604408,
-        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "682d6894c94087da5e566771f25311c47e145359",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-1.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1680000865,
-        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "1.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1687698105,
-        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "783905f211ac63edf982dd1889c671653327e441",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.0.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.10": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1743069404,
-        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.10.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.11": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1747306193,
-        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.11.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1693064058,
-        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.2.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1695910642,
-        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.3.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.4": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1699862708,
-        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.4.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.5": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1701080174,
-        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.5.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.6": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1705325287,
-        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.6.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.7": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1708965829,
-        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.7.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.8": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1715153580,
-        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.8.0.0",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hls-2.9": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1719993701,
-        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
-        "owner": "haskell",
-        "repo": "haskell-language-server",
-        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "haskell",
-        "ref": "2.9.0.1",
-        "repo": "haskell-language-server",
-        "type": "github"
-      }
-    },
-    "hpc-coveralls": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1607498076,
-        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
-        "type": "github"
-      },
-      "original": {
-        "owner": "sevanspowell",
-        "repo": "hpc-coveralls",
-        "type": "github"
-      }
-    },
-    "incl": {
-      "inputs": {
-        "nixlib": "nixlib"
-      },
-      "locked": {
-        "lastModified": 1693483555,
-        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
-        "owner": "divnix",
-        "repo": "incl",
-        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "divnix",
-        "repo": "incl",
         "type": "github"
       }
     },
@@ -1182,10 +533,10 @@
     },
     "iohk-nix": {
       "inputs": {
-        "blst": "blst_2",
+        "blst": "blst",
         "nixpkgs": "nixpkgs_2",
-        "secp256k1": "secp256k1_2",
-        "sodium": "sodium_2"
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
       },
       "locked": {
         "lastModified": 1751421193,
@@ -1203,71 +554,28 @@
     },
     "iohk-nix-ng": {
       "inputs": {
-        "blst": "blst_3",
+        "blst": "blst_2",
         "nixpkgs": "nixpkgs_3",
-        "secp256k1": "secp256k1_3",
-        "sodium": "sodium_3"
+        "secp256k1": "secp256k1_2",
+        "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1762808561,
-        "narHash": "sha256-SPa6PSCbYjAaIfS/1B0dIYYegML4bH9fUfaUGNBsHng=",
+        "lastModified": 1762970280,
+        "narHash": "sha256-1OZsxij29cBXBFK2NtexgBXbkt2a2sqnRq1HB8RejxE=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5558bf878ae4d7ede1f2bd3c19582d5a3c388167",
+        "rev": "a704b93ea51ee1a8a7e456659e0b28ddba280a95",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "jl/10.6.0-pre-updates",
         "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
-    "iohkNix": {
-      "inputs": {
-        "blst": "blst",
-        "nixpkgs": [
-          "cardano-node-10-6-0",
-          "nixpkgs"
-        ],
-        "secp256k1": "secp256k1",
-        "sodium": "sodium"
-      },
-      "locked": {
-        "lastModified": 1761066415,
-        "narHash": "sha256-jx83bMiZGw3ulkouzjLTcx6xtVI9GLoG6qBy/Oo3DPM=",
-        "owner": "input-output-hk",
-        "repo": "iohk-nix",
-        "rev": "338ae551e1d1ae5dae72bbb335f8c3cd623fefee",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "ref": "jl/10.6.0-pre-updates",
-        "repo": "iohk-nix",
-        "type": "github"
-      }
-    },
-    "iserv-proxy": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755040634,
-        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
-        "owner": "stable-haskell",
-        "repo": "iserv-proxy",
-        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
-        "type": "github"
-      },
-      "original": {
-        "owner": "stable-haskell",
-        "ref": "iserv-syms",
-        "repo": "iserv-proxy",
         "type": "github"
       }
     },
     "nix": {
       "inputs": {
-        "flake-compat": "flake-compat_4",
+        "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_3",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs_4",
@@ -1310,21 +618,6 @@
         "type": "github"
       }
     },
-    "nixlib": {
-      "locked": {
-        "lastModified": 1667696192,
-        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1705458851,
@@ -1354,86 +647,6 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2305": {
-      "locked": {
-        "lastModified": 1705033721,
-        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2311": {
-      "locked": {
-        "lastModified": 1719957072,
-        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-23.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2405": {
-      "locked": {
-        "lastModified": 1735564410,
-        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-24.05-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2411": {
-      "locked": {
-        "lastModified": 1748037224,
-        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-24.11-darwin",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-2505": {
-      "locked": {
-        "lastModified": 1748852332,
-        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-25.05-darwin",
-        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -1487,22 +700,6 @@
       }
     },
     "nixpkgs-unstable": {
-      "locked": {
-        "lastModified": 1748856973,
-        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs-unstable_2": {
       "locked": {
         "lastModified": 1748248602,
         "narHash": "sha256-LanRAm0IRpL36KpCKSknEwkBFvTLc9mDHKeAmfTrHwg=",
@@ -1582,23 +779,6 @@
         "type": "github"
       }
     },
-    "old-ghc-nix": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1631092763,
-        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
-        "owner": "angerman",
-        "repo": "old-ghc-nix",
-        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
-        "type": "github"
-      },
-      "original": {
-        "owner": "angerman",
-        "ref": "master",
-        "repo": "old-ghc-nix",
-        "type": "github"
-      }
-    },
     "opentofu-registry": {
       "flake": false,
       "locked": {
@@ -1641,7 +821,6 @@
         "cardano-db-sync-service": "cardano-db-sync-service",
         "cardano-db-sync-service-ng": "cardano-db-sync-service-ng",
         "cardano-metadata-service": "cardano-metadata-service",
-        "cardano-node-10-6-0": "cardano-node-10-6-0",
         "cardano-node-service": "cardano-node-service",
         "cardano-node-service-ng": "cardano-node-service-ng",
         "cardano-ogmios-service": "cardano-ogmios-service",
@@ -1657,7 +836,7 @@
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix",
         "nixpkgs": "nixpkgs_5",
-        "nixpkgs-unstable": "nixpkgs-unstable_2",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
@@ -1684,23 +863,6 @@
       }
     },
     "secp256k1_2": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1683999695,
-        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
-        "owner": "bitcoin-core",
-        "repo": "secp256k1",
-        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
-        "type": "github"
-      },
-      "original": {
-        "owner": "bitcoin-core",
-        "ref": "v0.3.2",
-        "repo": "secp256k1",
-        "type": "github"
-      }
-    },
-    "secp256k1_3": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -1766,23 +928,6 @@
         "type": "github"
       }
     },
-    "sodium_3": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1675156279,
-        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
-        "owner": "input-output-hk",
-        "repo": "libsodium",
-        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "libsodium",
-        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
-        "type": "github"
-      }
-    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -1819,22 +964,6 @@
         "type": "github"
       }
     },
-    "stackage": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1755648773,
-        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
-        "type": "github"
-      },
-      "original": {
-        "owner": "input-output-hk",
-        "repo": "stackage.nix",
-        "type": "github"
-      }
-    },
     "stdlib": {
       "locked": {
         "lastModified": 1590026685,
@@ -1865,21 +994,6 @@
         "type": "github"
       }
     },
-    "systems_2": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "terranix": {
       "inputs": {
         "flake-parts": [
@@ -1888,7 +1002,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1747386897,
@@ -1921,24 +1035,6 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,38 @@
 {
   "nodes": {
+    "CHaP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761315163,
+        "narHash": "sha256-h+JPIMflNAOpY3XhZNcS5sUAOyO06499uWATj2j6P5Q=",
+        "owner": "intersectmbo",
+        "repo": "cardano-haskell-packages",
+        "rev": "131bcd51c4869b191e8c3afbb9f3fd326cd6e5e1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "intersectmbo",
+        "ref": "repo",
+        "repo": "cardano-haskell-packages",
+        "type": "github"
+      }
+    },
+    "HTTP": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1451647621,
+        "narHash": "sha256-oHIyw3x0iKBexEo49YeUDV1k74ZtyYKGR2gNJXXRxts=",
+        "owner": "phadej",
+        "repo": "HTTP",
+        "rev": "9bc0996d412fef1787449d841277ef663ad9a915",
+        "type": "github"
+      },
+      "original": {
+        "owner": "phadej",
+        "repo": "HTTP",
+        "type": "github"
+      }
+    },
     "auth-keys-hub": {
       "inputs": {
         "flake-parts": [
@@ -97,6 +130,74 @@
         "type": "github"
       }
     },
+    "blst_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739372843,
+        "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
+        "owner": "supranational",
+        "repo": "blst",
+        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "type": "github"
+      },
+      "original": {
+        "owner": "supranational",
+        "ref": "v0.3.14",
+        "repo": "blst",
+        "type": "github"
+      }
+    },
+    "cabal-32": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1603716527,
+        "narHash": "sha256-X0TFfdD4KZpwl0Zr6x+PLxUt/VyKQfX7ylXHdmZIL+w=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "48bf10787e27364730dd37a42b603cee8d6af7ee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.2",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-34": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1645834128,
+        "narHash": "sha256-wG3d+dOt14z8+ydz4SL7pwGfe7SiimxcD/LOuPCV6xM=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "5ff598c67f53f7c4f48e31d722ba37172230c462",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.4",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
+    "cabal-36": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1669081697,
+        "narHash": "sha256-I5or+V7LZvMxfbYgZATU4awzkicBwwok4mVoje+sGmU=",
+        "owner": "haskell",
+        "repo": "cabal",
+        "rev": "8fd619e33d34924a94e691c5fea2c42f0fc7f144",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "3.6",
+        "repo": "cabal",
+        "type": "github"
+      }
+    },
     "capkgs": {
       "locked": {
         "lastModified": 1760451894,
@@ -109,6 +210,32 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "capkgs",
+        "type": "github"
+      }
+    },
+    "cardano-automation": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "haskellNix": [
+          "cardano-node-10-6-0",
+          "haskellNix"
+        ],
+        "nixpkgs": [
+          "cardano-node-10-6-0",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750923974,
+        "narHash": "sha256-PXB1aro2KalRw6OZkcbICl6Ge7HB4yEl5O3epm9VZl8=",
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
+        "rev": "64bf80a78102787790bac96075ef4109ff7de36e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-automation",
         "type": "github"
       }
     },
@@ -195,6 +322,40 @@
         "type": "github"
       }
     },
+    "cardano-node-10-6-0": {
+      "inputs": {
+        "CHaP": "CHaP",
+        "cardano-automation": "cardano-automation",
+        "customConfig": "customConfig",
+        "em": "em",
+        "empty-flake": "empty-flake",
+        "flake-compat": "flake-compat",
+        "hackageNix": "hackageNix",
+        "haskellNix": "haskellNix",
+        "incl": "incl",
+        "iohkNix": "iohkNix",
+        "nixpkgs": [
+          "cardano-node-10-6-0",
+          "haskellNix",
+          "nixpkgs-unstable"
+        ],
+        "utils": "utils"
+      },
+      "locked": {
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
+        "owner": "IntersectMBO",
+        "repo": "cardano-node",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
+        "type": "github"
+      },
+      "original": {
+        "owner": "IntersectMBO",
+        "ref": "ana/10.6-final-integration-mix",
+        "repo": "cardano-node",
+        "type": "github"
+      }
+    },
     "cardano-node-service": {
       "flake": false,
       "locked": {
@@ -215,16 +376,16 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1760975377,
-        "narHash": "sha256-HJE5R51LyGCGQQJoldWONbr501Ww/juEUOqEIC1yOfY=",
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "7697209cab6072598f9dc5f7bc1bf75979199ee9",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/10.6.0-pre-nix-cfg-updates",
+        "ref": "ana/10.6-final-integration-mix",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -243,6 +404,22 @@
         "owner": "input-output-hk",
         "ref": "ogmios-6-3-0",
         "repo": "cardano-ogmios",
+        "type": "github"
+      }
+    },
+    "cardano-shell": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1608537748,
+        "narHash": "sha256-PulY1GfiMgKVnBci3ex4ptk2UNYMXqGjJOxcPy2KYT4=",
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
+        "rev": "9392c75087cb9a3d453998f4230930dea3a95725",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "cardano-shell",
         "type": "github"
       }
     },
@@ -266,17 +443,17 @@
     "cardano-submit-api-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1753292803,
-        "narHash": "sha256-uP5B+vu/DsqknOAG9EutRSgZW5aAuMV9+NVY+tGJJCk=",
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
+        "ref": "ana/10.6-final-integration-mix",
         "repo": "cardano-node",
-        "rev": "f11e0f303ddf3e5b8975daf72ceaa522ddb98426",
         "type": "github"
       }
     },
@@ -300,16 +477,16 @@
     "cardano-tracer-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1757635285,
-        "narHash": "sha256-dVYhbEYpl1G5hnQYz42DWFsYzrJ0DmSYhTQ1hIL0co8=",
+        "lastModified": 1761324192,
+        "narHash": "sha256-jch/4TeqzR3VcO6yfaWAOgw1lm1U4ZZf2WEjJE9iSXQ=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "edae9912ff7569a48d531be6088470718f73e2cd",
+        "rev": "10b1a67b39ca3fdd45c3966defa0fbb454bd5320",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "jl/10.6.0-pre-nix-cfg-updates",
+        "ref": "ana/10.6-final-integration-mix",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -333,8 +510,8 @@
     },
     "colmena": {
       "inputs": {
-        "flake-compat": "flake-compat",
-        "flake-utils": "flake-utils",
+        "flake-compat": "flake-compat_3",
+        "flake-utils": "flake-utils_2",
         "nix-github-actions": "nix-github-actions",
         "nixpkgs": [
           "nixpkgs"
@@ -355,7 +532,87 @@
         "type": "github"
       }
     },
+    "customConfig": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
+    "em": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750940090,
+        "narHash": "sha256-DmDtgq8ipHCm2/Hq6e9xeJ2u8WLQFN1gXYSWM1bZNCU=",
+        "owner": "mgmeier",
+        "repo": "em",
+        "rev": "e3dde1952fcbe550055fb065590fdffd6f6f9710",
+        "type": "github"
+      },
+      "original": {
+        "owner": "mgmeier",
+        "repo": "em",
+        "type": "github"
+      }
+    },
+    "empty-flake": {
+      "locked": {
+        "lastModified": 1630400035,
+        "narHash": "sha256-MWaVOCzuFwp09wZIW9iHq5wWen5C69I940N1swZLEQ0=",
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "rev": "2040a05b67bf9a669ce17eca56beb14b4206a99a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "empty-flake",
+        "type": "github"
+      }
+    },
     "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1647532380,
+        "narHash": "sha256-wswAxyO8AJTH7d5oU8VK82yBCpqwA+p6kLgpb1f1PAY=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "7da118186435255a30b5ffeabba9629c344c0bec",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "fixes",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1672831974,
+        "narHash": "sha256-z9k3MfslLjWQfnjBtEtJZdq3H7kyi2kQtUThfTgdRk0=",
+        "owner": "input-output-hk",
+        "repo": "flake-compat",
+        "rev": "45f2638735f8cdc40fe302742b79f248d23eb368",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "hkm/gitlab-fix",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-compat_3": {
       "flake": false,
       "locked": {
         "lastModified": 1650374568,
@@ -371,7 +628,7 @@
         "type": "github"
       }
     },
-    "flake-compat_2": {
+    "flake-compat_4": {
       "flake": false,
       "locked": {
         "lastModified": 1733328505,
@@ -446,6 +703,21 @@
     },
     "flake-utils": {
       "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "locked": {
         "lastModified": 1659877975,
         "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
@@ -456,6 +728,23 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "ghc-8.6.5-iohk": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1600920045,
+        "narHash": "sha256-DO6kxJz248djebZLpSzTGD6s8WRpNI9BTwUeOf5RwY8=",
+        "owner": "input-output-hk",
+        "repo": "ghc",
+        "rev": "95713a6ecce4551240da7c96b6176f980af75cae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "release/8.6.5-iohk",
+        "repo": "ghc",
         "type": "github"
       }
     },
@@ -487,6 +776,366 @@
       "original": {
         "owner": "cachix",
         "repo": "git-hooks.nix",
+        "type": "github"
+      }
+    },
+    "hackage-for-stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755649550,
+        "narHash": "sha256-YNKeqYIezur2MvPmfVI/aHjcVRwOdBW7Du3jg6iXjKs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "5e56db8bc478dfb7466ea83744c3ab928aff0329",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "for-stackage",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackage-internal": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1750307553,
+        "narHash": "sha256-iiafNoeLHwlSLQTyvy8nPe2t6g5AV4PPcpMeH/2/DLs=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "f7867baa8817fab296528f4a4ec39d1c7c4da4f3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "hackageNix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1761265459,
+        "narHash": "sha256-7tsC/ZcNBJR1pXWdKsRoh/qlVDhCxb1Ukr7PVd2zieE=",
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "rev": "eb8e4d02528b4973cd09450bb62cf34997777226",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "hackage.nix",
+        "type": "github"
+      }
+    },
+    "haskellNix": {
+      "inputs": {
+        "HTTP": "HTTP",
+        "cabal-32": "cabal-32",
+        "cabal-34": "cabal-34",
+        "cabal-36": "cabal-36",
+        "cardano-shell": "cardano-shell",
+        "flake-compat": "flake-compat_2",
+        "ghc-8.6.5-iohk": "ghc-8.6.5-iohk",
+        "hackage": [
+          "cardano-node-10-6-0",
+          "hackageNix"
+        ],
+        "hackage-for-stackage": "hackage-for-stackage",
+        "hackage-internal": "hackage-internal",
+        "hls": "hls",
+        "hls-1.10": "hls-1.10",
+        "hls-2.0": "hls-2.0",
+        "hls-2.10": "hls-2.10",
+        "hls-2.11": "hls-2.11",
+        "hls-2.2": "hls-2.2",
+        "hls-2.3": "hls-2.3",
+        "hls-2.4": "hls-2.4",
+        "hls-2.5": "hls-2.5",
+        "hls-2.6": "hls-2.6",
+        "hls-2.7": "hls-2.7",
+        "hls-2.8": "hls-2.8",
+        "hls-2.9": "hls-2.9",
+        "hpc-coveralls": "hpc-coveralls",
+        "iserv-proxy": "iserv-proxy",
+        "nixpkgs": [
+          "cardano-node-10-6-0",
+          "nixpkgs"
+        ],
+        "nixpkgs-2305": "nixpkgs-2305",
+        "nixpkgs-2311": "nixpkgs-2311",
+        "nixpkgs-2405": "nixpkgs-2405",
+        "nixpkgs-2411": "nixpkgs-2411",
+        "nixpkgs-2505": "nixpkgs-2505",
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "old-ghc-nix": "old-ghc-nix",
+        "stackage": "stackage"
+      },
+      "locked": {
+        "lastModified": 1755663895,
+        "narHash": "sha256-76Ns29GQsO5S5gPRcic+vagcJicOSvhA+oKQ9r9kjFE=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "71fcc9f531993aada52173fceb4ff4ce2148207d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "hls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1741604408,
+        "narHash": "sha256-tuq3+Ip70yu89GswZ7DSINBpwRprnWnl6xDYnS4GOsc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "682d6894c94087da5e566771f25311c47e145359",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-1.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1680000865,
+        "narHash": "sha256-rc7iiUAcrHxwRM/s0ErEsSPxOR3u8t7DvFeWlMycWgo=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b08691db779f7a35ff322b71e72a12f6e3376fd9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "1.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1687698105,
+        "narHash": "sha256-OHXlgRzs/kuJH8q7Sxh507H+0Rb8b7VOiPAjcY9sM1k=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "783905f211ac63edf982dd1889c671653327e441",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.0.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.10": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1743069404,
+        "narHash": "sha256-q4kDFyJDDeoGqfEtrZRx4iqMVEC2MOzCToWsFY+TOzY=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "2318c61db3a01e03700bd4b05665662929b7fe8b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.10.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.11": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1747306193,
+        "narHash": "sha256-/MmtpF8+FyQlwfKHqHK05BdsxC9LHV70d/FiMM7pzBM=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "46ef4523ea4949f47f6d2752476239f1c6d806fe",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.11.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1693064058,
+        "narHash": "sha256-8DGIyz5GjuCFmohY6Fa79hHA/p1iIqubfJUTGQElbNk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "b30f4b6cf5822f3112c35d14a0cba51f3fe23b85",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.2.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1695910642,
+        "narHash": "sha256-tR58doOs3DncFehHwCLczJgntyG/zlsSd7DgDgMPOkI=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "458ccdb55c9ea22cd5d13ec3051aaefb295321be",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.3.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1699862708,
+        "narHash": "sha256-YHXSkdz53zd0fYGIYOgLt6HrA0eaRJi9mXVqDgmvrjk=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "54507ef7e85fa8e9d0eb9a669832a3287ffccd57",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.4.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.5": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1701080174,
+        "narHash": "sha256-fyiR9TaHGJIIR0UmcCb73Xv9TJq3ht2ioxQ2mT7kVdc=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "27f8c3d3892e38edaef5bea3870161815c4d014c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.5.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.6": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1705325287,
+        "narHash": "sha256-+P87oLdlPyMw8Mgoul7HMWdEvWP/fNlo8jyNtwME8E8=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "6e0b342fa0327e628610f2711f8c3e4eaaa08b1e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.6.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.7": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1708965829,
+        "narHash": "sha256-LfJ+TBcBFq/XKoiNI7pc4VoHg4WmuzsFxYJ3Fu+Jf+M=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "50322b0a4aefb27adc5ec42f5055aaa8f8e38001",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.7.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.8": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1715153580,
+        "narHash": "sha256-Vi/iUt2pWyUJlo9VrYgTcbRviWE0cFO6rmGi9rmALw0=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "dd1be1beb16700de59e0d6801957290bcf956a0a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.8.0.0",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hls-2.9": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1719993701,
+        "narHash": "sha256-wy348++MiMm/xwtI9M3vVpqj2qfGgnDcZIGXw8sF1sA=",
+        "owner": "haskell",
+        "repo": "haskell-language-server",
+        "rev": "90319a7e62ab93ab65a95f8f2bcf537e34dae76a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "haskell",
+        "ref": "2.9.0.1",
+        "repo": "haskell-language-server",
+        "type": "github"
+      }
+    },
+    "hpc-coveralls": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1607498076,
+        "narHash": "sha256-8uqsEtivphgZWYeUo5RDUhp6bO9j2vaaProQxHBltQk=",
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "rev": "14df0f7d229f4cd2e79f8eabb1a740097fdfa430",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sevanspowell",
+        "repo": "hpc-coveralls",
+        "type": "github"
+      }
+    },
+    "incl": {
+      "inputs": {
+        "nixlib": "nixlib"
+      },
+      "locked": {
+        "lastModified": 1693483555,
+        "narHash": "sha256-Beq4WhSeH3jRTZgC1XopTSU10yLpK1nmMcnGoXO0XYo=",
+        "owner": "divnix",
+        "repo": "incl",
+        "rev": "526751ad3d1e23b07944b14e3f6b7a5948d3007b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "divnix",
+        "repo": "incl",
         "type": "github"
       }
     },
@@ -533,10 +1182,10 @@
     },
     "iohk-nix": {
       "inputs": {
-        "blst": "blst",
+        "blst": "blst_2",
         "nixpkgs": "nixpkgs_2",
-        "secp256k1": "secp256k1",
-        "sodium": "sodium"
+        "secp256k1": "secp256k1_2",
+        "sodium": "sodium_2"
       },
       "locked": {
         "lastModified": 1751421193,
@@ -554,17 +1203,17 @@
     },
     "iohk-nix-ng": {
       "inputs": {
-        "blst": "blst_2",
+        "blst": "blst_3",
         "nixpkgs": "nixpkgs_3",
-        "secp256k1": "secp256k1_2",
-        "sodium": "sodium_2"
+        "secp256k1": "secp256k1_3",
+        "sodium": "sodium_3"
       },
       "locked": {
-        "lastModified": 1760465963,
-        "narHash": "sha256-EZYi51N2LmKBE9+/lmB9M0wqCCfuBflyGH+aoXezwnM=",
+        "lastModified": 1761066415,
+        "narHash": "sha256-jx83bMiZGw3ulkouzjLTcx6xtVI9GLoG6qBy/Oo3DPM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f3f554529ca86e337e9ab921d01d6d62643c3f53",
+        "rev": "338ae551e1d1ae5dae72bbb335f8c3cd623fefee",
         "type": "github"
       },
       "original": {
@@ -574,9 +1223,51 @@
         "type": "github"
       }
     },
+    "iohkNix": {
+      "inputs": {
+        "blst": "blst",
+        "nixpkgs": [
+          "cardano-node-10-6-0",
+          "nixpkgs"
+        ],
+        "secp256k1": "secp256k1",
+        "sodium": "sodium"
+      },
+      "locked": {
+        "lastModified": 1761066415,
+        "narHash": "sha256-jx83bMiZGw3ulkouzjLTcx6xtVI9GLoG6qBy/Oo3DPM=",
+        "owner": "input-output-hk",
+        "repo": "iohk-nix",
+        "rev": "338ae551e1d1ae5dae72bbb335f8c3cd623fefee",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "jl/10.6.0-pre-updates",
+        "repo": "iohk-nix",
+        "type": "github"
+      }
+    },
+    "iserv-proxy": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755040634,
+        "narHash": "sha256-8W7uHpAIG8HhO3ig5OGHqvwduoye6q6dlrea1IrP2eI=",
+        "owner": "stable-haskell",
+        "repo": "iserv-proxy",
+        "rev": "1383d199a2c64f522979005d112b4fbdee38dd92",
+        "type": "github"
+      },
+      "original": {
+        "owner": "stable-haskell",
+        "ref": "iserv-syms",
+        "repo": "iserv-proxy",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_4",
         "flake-parts": "flake-parts_3",
         "git-hooks-nix": "git-hooks-nix",
         "nixpkgs": "nixpkgs_4",
@@ -619,6 +1310,21 @@
         "type": "github"
       }
     },
+    "nixlib": {
+      "locked": {
+        "lastModified": 1667696192,
+        "narHash": "sha256-hOdbIhnpWvtmVynKcsj10nxz9WROjZja+1wRAJ/C9+s=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "babd9cd2ca6e413372ed59fbb1ecc3c3a5fd3e5b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1705458851,
@@ -648,6 +1354,86 @@
         "owner": "NixOS",
         "repo": "nixpkgs",
         "rev": "a62e6edd6d5e1fa0329b8653c801147986f8d446",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2305": {
+      "locked": {
+        "lastModified": 1705033721,
+        "narHash": "sha256-K5eJHmL1/kev6WuqyqqbS1cdNnSidIZ3jeqJ7GbrYnQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a1982c92d8980a0114372973cbdfe0a307f1bdea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2311": {
+      "locked": {
+        "lastModified": 1719957072,
+        "narHash": "sha256-gvFhEf5nszouwLAkT9nWsDzocUTqLWHuL++dvNjMp9I=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "7144d6241f02d171d25fba3edeaf15e0f2592105",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-23.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2405": {
+      "locked": {
+        "lastModified": 1735564410,
+        "narHash": "sha256-HB/FA0+1gpSs8+/boEavrGJH+Eq08/R2wWNph1sM1Dg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1e7a8f391f1a490460760065fa0630b5520f9cf8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.05-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2411": {
+      "locked": {
+        "lastModified": 1748037224,
+        "narHash": "sha256-92vihpZr6dwEMV6g98M5kHZIttrWahb9iRPBm1atcPk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f09dede81861f3a83f7f06641ead34f02f37597f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-24.11-darwin",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-2505": {
+      "locked": {
+        "lastModified": 1748852332,
+        "narHash": "sha256-r/wVJWmLYEqvrJKnL48r90Wn9HWX9SHFt6s4LhuTh7k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "a8167f3cc2f991dd4d0055746df53dae5fd0c953",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-25.05-darwin",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },
@@ -701,6 +1487,22 @@
       }
     },
     "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1748856973,
+        "narHash": "sha256-RlTsJUvvr8ErjPBsiwrGbbHYW8XbB/oek0Gi78XdWKg=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e4b09e47ace7d87de083786b404bf232eb6c89d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-unstable_2": {
       "locked": {
         "lastModified": 1748248602,
         "narHash": "sha256-LanRAm0IRpL36KpCKSknEwkBFvTLc9mDHKeAmfTrHwg=",
@@ -780,6 +1582,23 @@
         "type": "github"
       }
     },
+    "old-ghc-nix": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1631092763,
+        "narHash": "sha256-sIKgO+z7tj4lw3u6oBZxqIhDrzSkvpHtv0Kki+lh9Fg=",
+        "owner": "angerman",
+        "repo": "old-ghc-nix",
+        "rev": "af48a7a7353e418119b6dfe3cd1463a657f342b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "angerman",
+        "ref": "master",
+        "repo": "old-ghc-nix",
+        "type": "github"
+      }
+    },
     "opentofu-registry": {
       "flake": false,
       "locked": {
@@ -822,6 +1641,7 @@
         "cardano-db-sync-service": "cardano-db-sync-service",
         "cardano-db-sync-service-ng": "cardano-db-sync-service-ng",
         "cardano-metadata-service": "cardano-metadata-service",
+        "cardano-node-10-6-0": "cardano-node-10-6-0",
         "cardano-node-service": "cardano-node-service",
         "cardano-node-service-ng": "cardano-node-service-ng",
         "cardano-ogmios-service": "cardano-ogmios-service",
@@ -837,7 +1657,7 @@
         "iohk-nix-ng": "iohk-nix-ng",
         "nix": "nix",
         "nixpkgs": "nixpkgs_5",
-        "nixpkgs-unstable": "nixpkgs-unstable",
+        "nixpkgs-unstable": "nixpkgs-unstable_2",
         "opentofu-registry": "opentofu-registry",
         "process-compose-flake": "process-compose-flake",
         "services-flake": "services-flake",
@@ -864,6 +1684,23 @@
       }
     },
     "secp256k1_2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1683999695,
+        "narHash": "sha256-9nJJVENMXjXEJZzw8DHzin1DkFkF8h9m/c6PuM7Uk4s=",
+        "owner": "bitcoin-core",
+        "repo": "secp256k1",
+        "rev": "acf5c55ae6a94e5ca847e07def40427547876101",
+        "type": "github"
+      },
+      "original": {
+        "owner": "bitcoin-core",
+        "ref": "v0.3.2",
+        "repo": "secp256k1",
+        "type": "github"
+      }
+    },
+    "secp256k1_3": {
       "flake": false,
       "locked": {
         "lastModified": 1683999695,
@@ -929,6 +1766,23 @@
         "type": "github"
       }
     },
+    "sodium_3": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675156279,
+        "narHash": "sha256-0uRcN5gvMwO7MCXVYnoqG/OmeBFi8qRVnDWJLnBb9+Y=",
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "libsodium",
+        "rev": "dbb48cce5429cb6585c9034f002568964f1ce567",
+        "type": "github"
+      }
+    },
     "sops-nix": {
       "inputs": {
         "nixpkgs": [
@@ -965,6 +1819,22 @@
         "type": "github"
       }
     },
+    "stackage": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755648773,
+        "narHash": "sha256-NhcOu6GwYal+awBQLoMT4vf7L7Ar1DectDjK2mF653I=",
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "rev": "1a0ea16d99761b93456460c255a8b723647b2c77",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "stackage.nix",
+        "type": "github"
+      }
+    },
     "stdlib": {
       "locked": {
         "lastModified": 1590026685,
@@ -995,6 +1865,21 @@
         "type": "github"
       }
     },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
     "terranix": {
       "inputs": {
         "flake-parts": [
@@ -1003,7 +1888,7 @@
         "nixpkgs": [
           "nixpkgs"
         ],
-        "systems": "systems"
+        "systems": "systems_2"
       },
       "locked": {
         "lastModified": 1747386897,
@@ -1036,6 +1921,24 @@
       "original": {
         "owner": "numtide",
         "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1710146030,
+        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,9 @@
     iohk-nix-ng.url = "github:input-output-hk/iohk-nix/jl/10.6.0-pre-updates";
     # iohk-nix-ng.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/iohk-nix";
 
+    # Until blockperf detail fix is merged to master upstream
+    blockperf.url = "github:johnalotoski/blockperf/jl/fix-detail";
+
     # For tmp local testing pins
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";
     # cardano-faucet.url = "path:/home/jlotoski/work/iohk/cardano-faucet-wt/jl/node-9.2";

--- a/flake.nix
+++ b/flake.nix
@@ -60,14 +60,14 @@
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/jl/10.6.0-pre-updates";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
     # iohk-nix-ng.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/jl/10.6.0-pre-updates";
 
     # Until blockperf detail fix is merged to master upstream
     blockperf.url = "github:johnalotoski/blockperf/jl/fix-detail";
 
     # Until cardano-node 10.6.0 is tagged
-    cardano-node-10-6-0.url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
+    # cardano-node-10-6-0.url = "github:IntersectMBO/cardano-node";
 
     # For tmp local testing pins
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";
@@ -101,15 +101,12 @@
     };
 
     cardano-node-service = {
-      # Until 10.6.0 tag is available
       url = "github:IntersectMBO/cardano-node/f11e0f303ddf3e5b8975daf72ceaa522ddb98426";
       flake = false;
     };
 
     cardano-node-service-ng = {
-      # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
-      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/ana/10.6-final-integration-mix";
+      url = "github:IntersectMBO/cardano-node/10.6.0";
       flake = false;
     };
 
@@ -129,27 +126,22 @@
     };
 
     cardano-submit-api-service = {
-      # Until 10.6.0 tag is available
       url = "github:IntersectMBO/cardano-node/f11e0f303ddf3e5b8975daf72ceaa522ddb98426";
       flake = false;
     };
 
     cardano-submit-api-service-ng = {
-      # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
+      url = "github:IntersectMBO/cardano-node/10.6.0";
       flake = false;
     };
 
     cardano-tracer-service = {
-      # Until 10.6.0 tag is available
       url = "github:IntersectMBO/cardano-node/f11e0f303ddf3e5b8975daf72ceaa522ddb98426";
       flake = false;
     };
 
     cardano-tracer-service-ng = {
-      # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
-      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/ana/10.6-final-integration-mix";
+      url = "github:IntersectMBO/cardano-node/10.6.0";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
     capkgs.url = "github:input-output-hk/capkgs";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
     # iohk-nix.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/jl/10.6.0-pre-updates";
     # iohk-nix-ng.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/iohk-nix";
 
     # For tmp local testing pins
@@ -103,7 +103,8 @@
 
     cardano-node-service-ng = {
       # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/f11e0f303ddf3e5b8975daf72ceaa522ddb98426";
+      url = "github:IntersectMBO/cardano-node/jl/10.6.0-pre-nix-cfg-updates";
+      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/jl/10.6.0-pre-nix-cfg-updates";
       flake = false;
     };
 
@@ -142,7 +143,8 @@
 
     cardano-tracer-service-ng = {
       # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/f11e0f303ddf3e5b8975daf72ceaa522ddb98426";
+      url = "github:IntersectMBO/cardano-node/jl/10.6.0-pre-nix-cfg-updates";
+      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/jl/10.6.0-pre-nix-cfg-updates";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -67,6 +67,9 @@
     # Until blockperf detail fix is merged to master upstream
     blockperf.url = "github:johnalotoski/blockperf/jl/fix-detail";
 
+    # Until cardano-node 10.6.0 is tagged
+    cardano-node-10-6-0.url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
+
     # For tmp local testing pins
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/jl/node-9.2";
     # cardano-faucet.url = "path:/home/jlotoski/work/iohk/cardano-faucet-wt/jl/node-9.2";
@@ -106,8 +109,8 @@
 
     cardano-node-service-ng = {
       # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/jl/10.6.0-pre-nix-cfg-updates";
-      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/jl/10.6.0-pre-nix-cfg-updates";
+      url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
+      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/ana/10.6-final-integration-mix";
       flake = false;
     };
 
@@ -134,7 +137,7 @@
 
     cardano-submit-api-service-ng = {
       # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/f11e0f303ddf3e5b8975daf72ceaa522ddb98426";
+      url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
       flake = false;
     };
 
@@ -146,8 +149,8 @@
 
     cardano-tracer-service-ng = {
       # Until 10.6.0 tag is available
-      url = "github:IntersectMBO/cardano-node/jl/10.6.0-pre-nix-cfg-updates";
-      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/jl/10.6.0-pre-nix-cfg-updates";
+      url = "github:IntersectMBO/cardano-node/ana/10.6-final-integration-mix";
+      # url = "path:/home/jlotoski/work/iohk/cardano-node-wt/ana/10.6-final-integration-mix";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -60,9 +60,8 @@
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    # iohk-nix.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/iohk-nix";
     iohk-nix-ng.url = "github:input-output-hk/iohk-nix/jl/10.6.0-pre-updates";
-    # iohk-nix-ng.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/iohk-nix";
+    # iohk-nix-ng.url = "path:/home/jlotoski/work/iohk/iohk-nix-wt/jl/10.6.0-pre-updates";
 
     # Until blockperf detail fix is merged to master upstream
     blockperf.url = "github:johnalotoski/blockperf/jl/fix-detail";

--- a/flake/nixosModules/profile-blockperf.nix
+++ b/flake/nixosModules/profile-blockperf.nix
@@ -275,27 +275,27 @@ flake: {
               else {
                 TraceOptions = {
                   "BlockFetch.Client.CompletedBlockFetch" = {
-                    details = "DNormal";
+                    detail = "DNormal";
                     maxFrequency = 0.0;
                     severity = "Info";
                   };
                   "BlockFetch.Client.SendFetchRequest" = {
-                    details = "DNormal";
+                    detail = "DNormal";
                     maxFrequency = 0.0;
                     severity = "Info";
                   };
                   "ChainDB.AddBlockEvent.AddedToCurrentChain" = {
-                    details = "DNormal";
+                    detail = "DNormal";
                     maxFrequency = 0.0;
                     severity = "Info";
                   };
                   "ChainDB.AddBlockEvent.SwitchedToAFork" = {
-                    details = "DNormal";
+                    detail = "DNormal";
                     maxFrequency = 0.0;
                     severity = "Info";
                   };
                   "ChainSync.Client.DownloadedHeader" = {
-                    details = "DNormal";
+                    detail = "DNormal";
                     maxFrequency = 0.0;
                     severity = "Info";
                   };

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -47,10 +47,16 @@
     inherit (nixos.config.cardano-parts.perNode.meta) cardanoNodePort cardanoNodePrometheusExporterPort hostAddr hostAddrIpv6 nodeId;
     inherit (nixos.config.cardano-parts.perNode.pkgs) cardano-cli cardano-node cardano-node-pkgs cardano-tracer mithril-client-cli;
     inherit (cardanoLib) mkEdgeTopology mkEdgeTopologyP2P;
-    inherit (cardanoLib.environments.${environmentName}.nodeConfig) ByronGenesisFile ShelleyGenesisFile;
+    inherit (cardanoLib.environments.${environmentName}.${nodeConfigGenesis}) ByronGenesisFile ShelleyGenesisFile;
     inherit (opsLib) mithrilAllowedAncillaryNetworks mithrilAllowedNetworks mithrilVerifyingPools;
     inherit ((fromJSON (readFile ByronGenesisFile)).protocolConsts) protocolMagic;
     inherit (fromJSON (readFile ShelleyGenesisFile)) slotsPerKESPeriod;
+
+    # Remove this usage once legacy tracing is dropped from node
+    nodeConfigGenesis =
+      if cardanoLib.environments.${environmentName} ? nodeConfig
+      then "nodeConfig"
+      else "nodeConfigLegacy";
 
     opsLib = self.cardano-parts.lib.opsLib pkgs;
 

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -37,8 +37,8 @@
     nodeResources,
     ...
   }: let
-    inherit (builtins) elem fromJSON readFile;
-    inherit (lib) boolToString concatStringsSep flatten foldl' getExe min mkDefault mkForce mkIf mkOption optional optionalAttrs optionalString range recursiveUpdate types;
+    inherit (builtins) elem fromJSON isString readFile;
+    inherit (lib) boolToString concatStringsSep flatten foldl' getExe min mkDefault mkForce mkIf mkOption optional optionalAttrs optionalString range recursiveUpdate types versionAtLeast;
     inherit (types) bool float ints listOf oneOf str;
     inherit (nodeResources) cpuCount memMiB;
 
@@ -345,6 +345,14 @@
               ];
 
               defaultScribes = [["JournalSK" "cardano"]];
+            }
+            # Remove this optionalAttrs block once 10.6.0 is the latest full release
+            // optionalAttrs (
+              !(versionAtLeast cfgNode.nodeConfig.MinNodeVersion "10.6.0") && (isString cfgNode.operationalCertificate)
+            ) {
+              PeerSharing = false;
+              TargetNumberOfKnownPeers = 100;
+              TargetNumberOfRootPeers = 100;
             };
 
           extraNodeInstanceConfig = i:

--- a/flake/nixosModules/profile-cardano-node-group.nix
+++ b/flake/nixosModules/profile-cardano-node-group.nix
@@ -91,7 +91,7 @@
         inherit (env) edgeNodes useLedgerAfterSlot;
       };
     in
-      if (cfgNode.useNewTopology or true)
+      if (elem cfgNode.useNewTopology [null true])
       then p2pTopology
       else legacyTopology;
 
@@ -292,8 +292,7 @@
             if optNode.useNewTopology.type.description == "boolean"
             then mkDefault true
             # When ouroboros-network >= 0.22.2 is in use:
-            # else mkDefault null;
-            else mkDefault true;
+            else mkDefault null;
 
           useSystemdReload = mkDefault true;
 

--- a/flake/nixosModules/profile-cardano-node-topology.nix
+++ b/flake/nixosModules/profile-cardano-node-topology.nix
@@ -95,11 +95,6 @@
           };
 
           # These are also set from the role-block-producer nixos module
-          extraNodeConfig = {
-            PeerSharing = false;
-            TargetNumberOfKnownPeers = 100;
-            TargetNumberOfRootPeers = 100;
-          };
           publicProducers = mkForce (extraNodeListPublicProducers ++ extraPublicProducers);
           useLedgerAfterSlot = -1;
         };
@@ -376,8 +371,6 @@
 
       config = {
         services.cardano-node = {
-          extraNodeConfig = mkIf (cfg.role == "bp") roles.${cfg.role}.extraNodeConfig;
-
           bootstrapPeers = mkIf (cfg.role == "bp") null;
 
           producers = mkIf (cfg.role != null || cfg.enableProducers) (

--- a/flake/nixosModules/role-block-producer.nix
+++ b/flake/nixosModules/role-block-producer.nix
@@ -59,9 +59,9 @@ flake: {
         inherit groupOutPath groupName name secretName keyName pathPrefix;
         fileOwner = "cardano-node";
         fileGroup = "cardano-node";
-        reloadUnits = optionals (nodeCfg.useSystemdReload && nodeCfg.useNewTopology) ["cardano-node.service"];
+        reloadUnits = optionals (nodeCfg.useSystemdReload && (nodeCfg.useNewTopology or true)) ["cardano-node.service"];
         restartUnits =
-          optionals (!nodeCfg.useSystemdReload || !nodeCfg.useNewTopology) ["cardano-node.service"]
+          optionals (!nodeCfg.useSystemdReload || !(nodeCfg.useNewTopology or true)) ["cardano-node.service"]
           ++ optionals mithrilCfg.enable ["mithril-signer.service"];
       };
 

--- a/flake/nixosModules/role-block-producer.nix
+++ b/flake/nixosModules/role-block-producer.nix
@@ -193,8 +193,6 @@ flake: {
           serviceCfg.${Protocol}
           // {
             # These are also set from the profile-cardano-node-topology nixos module when role == "bp"
-            extraNodeConfig.PeerSharing = false;
-            extraNodeConfig.TargetNumberOfRootPeers = 100;
             publicProducers = mkForce [];
             useLedgerAfterSlot = -1;
           };

--- a/flake/nixosModules/role-block-producer.nix
+++ b/flake/nixosModules/role-block-producer.nix
@@ -59,9 +59,9 @@ flake: {
         inherit groupOutPath groupName name secretName keyName pathPrefix;
         fileOwner = "cardano-node";
         fileGroup = "cardano-node";
-        reloadUnits = optionals (nodeCfg.useSystemdReload && (nodeCfg.useNewTopology or true)) ["cardano-node.service"];
+        reloadUnits = optionals (nodeCfg.useSystemdReload && (elem nodeCfg.useNewTopology [null true])) ["cardano-node.service"];
         restartUnits =
-          optionals (!nodeCfg.useSystemdReload || !(nodeCfg.useNewTopology or true)) ["cardano-node.service"]
+          optionals (!nodeCfg.useSystemdReload || !(elem nodeCfg.useNewTopology [null true])) ["cardano-node.service"]
           ++ optionals mithrilCfg.enable ["mithril-signer.service"];
       };
 

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -11,8 +11,12 @@
 #   flake.cardano-parts.cluster.infra.aws.region
 #   flake.cardano-parts.cluster.infra.aws.regions
 #   flake.cardano-parts.cluster.infra.generic.abortOnMissingIpModule
+#   flake.cardano-parts.cluster.infra.generic.costCenter
+#   flake.cardano-parts.cluster.infra.generic.environment
 #   flake.cardano-parts.cluster.infra.generic.function
 #   flake.cardano-parts.cluster.infra.generic.organization
+#   flake.cardano-parts.cluster.infra.generic.owner
+#   flake.cardano-parts.cluster.infra.generic.project
 #   flake.cardano-parts.cluster.infra.generic.repo
 #   flake.cardano-parts.cluster.infra.generic.tribe
 #   flake.cardano-parts.cluster.infra.generic.warnOnMissingIpModule
@@ -223,6 +227,35 @@ flake @ {
         default = true;
       };
 
+      costCenter = mkOption {
+        type = optionCheck "string" "infra.generic.costCenter" "str";
+        description = mdDoc ''
+          The cardano-parts cluster infra generic costCenter.
+
+          By default, the costCenter string for tagging cloud resources is
+          treated as a secret and must be added to the
+          secrets/tf/cluster.tfvars file.
+
+          The string declared for this option should be the name of the secret
+          var stored in the cluster.tfvars file.
+
+          This option is required by IOG IT/Finance.
+        '';
+        example = "tag_costCenter";
+        default = null;
+      };
+
+      environment = mkOption {
+        type = optionCheck "string" "infra.generic.environment" "str";
+        description = mdDoc ''
+          The cardano-parts cluster infra generic environment.
+
+          This option is required by IOG IT/Finance.
+        '';
+        example = "testnets";
+        default = null;
+      };
+
       function = mkOption {
         type = optionCheck "string" "infra.generic.function" "str";
         description = mdDoc "The cardano-parts cluster infra generic function.";
@@ -234,6 +267,28 @@ flake @ {
         type = optionCheck "string" "infra.generic.organization" "str";
         description = mdDoc "The cardano-parts cluster infra generic organization.";
         example = "iog";
+        default = null;
+      };
+
+      owner = mkOption {
+        type = optionCheck "string" "infra.generic.owner" "str";
+        description = mdDoc ''
+          The cardano-parts cluster infra generic owner.
+
+          This option is required by IOG IT/Finance.
+        '';
+        example = "ioe";
+        default = null;
+      };
+
+      project = mkOption {
+        type = optionCheck "string" "infra.generic.project" "str";
+        description = mdDoc ''
+          The cardano-parts cluster infra generic project.
+
+          This option is required by IOG IT/Finance.
+        '';
+        example = "cardano-playground";
         default = null;
       };
 

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -41,6 +41,10 @@ in {
           cp -r "${envCfgs}/config/$ENV" "$DATA_DIR/config/"
         done
 
+        # Required for direct entrypoint access.
+        # Can be removed once the find command below is removed
+        chmod -R +w "$DATA_DIR"
+
         # Until https://github.com/IntersectMBO/cardano-node/pull/6282 is merged and released,
         # remove PrometheusSimple from configs so multiple instances can be started without fatal error.
         find "$DATA_DIR" -name 'config*.json' -type f -exec sed -i '/PrometheusSimple/d' {} +

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -43,7 +43,7 @@ in {
 
         # Until https://github.com/IntersectMBO/cardano-node/pull/6282 is merged and released,
         # remove PrometheusSimple from configs so multiple instances can be started without fatal error.
-        find "$DATA_DIR/config" -type f -exec sed -i '/PrometheusSimple/d' {} +
+        find "$DATA_DIR" -name 'config*.json' -type f -exec sed -i '/PrometheusSimple/d' {} +
 
         # Prepare mithril client env configs
         ${
@@ -88,6 +88,7 @@ in {
             [ -z "''${DATA_DIR:-}" ] && echo "DATA_DIR env var must be set -- aborting" && exit 1
 
             mkdir -p "$DATA_DIR/config/custom"
+            chmod -R +w "$DATA_DIR/config"
 
             # The menu of environments that we ship as built-in envs
             if [ "''${UNSTABLE_LIB:-}" = "true" ]; then
@@ -98,7 +99,7 @@ in {
               ${copyEnvsTemplate cardanoLib}
             fi
 
-            chmod -R +w "$DATA_DIR/config" "$DATA_DIR/config/custom"
+            chmod -R +w "$DATA_DIR/config"
 
             if [ -n "''${ENVIRONMENT:-}" ]; then
               echo "Using the preset environment $ENVIRONMENT ..." >&2

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -258,6 +258,7 @@ in {
             #   [$TEMPLATE_DIR]
             #   [$TESTNET_MAGIC]
             #   [$UNSTABLE]
+            #   [$UNSTABLE_LIB]
             #   [$USE_ENCRYPTION]
             #   [$USE_SHELL_BINS]
 
@@ -275,6 +276,7 @@ in {
 
             if [ "''${UNSTABLE_LIB:-}" = "true" ]; then
               export TEMPLATE_DIR=''${TEMPLATE_DIR:-"${localFlake.inputs.iohk-nix-ng}/cardano-lib/testnet-template"}
+              echo "$TEMPLATE_DIR"
             else
               export TEMPLATE_DIR=''${TEMPLATE_DIR:-"${localFlake.inputs.iohk-nix}/cardano-lib/testnet-template"}
             fi
@@ -285,7 +287,7 @@ in {
             ENV="''${ENV:-custom}"
 
             mkdir -p "$GENESIS_DIR"
-            "''${CARDANO_CLI_NO_ERA[@]}" legacy genesis create-cardano \
+            "''${CARDANO_CLI_NO_ERA[@]}" legacy genesis create-cardano --conway-era \
               --genesis-dir "$GENESIS_DIR" \
               --gen-genesis-keys "$NUM_GENESIS_KEYS" \
               --gen-utxo-keys 1 \

--- a/flakeModules/lib.nix
+++ b/flakeModules/lib.nix
@@ -3,15 +3,12 @@
 # TODO: Move this to a docs generator
 #
 # Attributes available on flakeModule import:
+#   flake.cardano-parts.lib.opsLib
 #   flake.cardano-parts.lib.topologyLib
 #
 # Tips:
 #   * flake level attrs are accessed from flake level at [config.]flake.cardano-parts.lib.<...>
-{
-  config,
-  lib,
-  ...
-}: let
+{lib, ...}: let
   inherit (lib) mdDoc mkDefault mkOption types;
   inherit (types) attrsOf anything functionTo submodule;
 

--- a/flakeModules/lib/ops.nix
+++ b/flakeModules/lib/ops.nix
@@ -21,12 +21,16 @@ with lib; rec {
           cp -v "${cardano-deployment}/$i" "$out/config/$ENV/''${i#"$ENV-"}"
         done
 
-        # Adjust genesis file, config and config-bp refs
-        for i in config config-bp db-sync-config; do
+        # Adjust genesis file, config refs
+        for i in config config-legacy db-sync-config; do
           if [ -f "$out/config/$ENV/$i.json" ]; then
             sed -i "s|\"$ENV-|\"|g" "$out/config/$ENV/$i.json"
           fi
         done
+
+        # Normalize the topology file peer snapshot ref for per ENV dir placement
+        ${jq}/bin/jq '.peerSnapshotFile = "peer-snapshot.json"' < "$out/config/$ENV/topology.json" > "$ENV-topology.json"
+        mv -v "$ENV-topology.json" "$out/config/$ENV/topology.json"
 
         # Adjust index.html file refs
         sed -i "s|$ENV-|config/$ENV/|g" "$out/index.html"

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -467,7 +467,7 @@ in
           mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
           mithril-pre-release = "input-output-hk-mithril-unstable-effe078";
           node-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
-          node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
+          # node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
         in
           submodule {
             options = foldl' recursiveUpdate {} [
@@ -481,7 +481,8 @@ in
 
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
               (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.11.0.0";}))
-              (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))
+              # (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))
+              (mkPkg "cardano-cli-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-cli)
               (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-release}")
               (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-pre-release}")
               (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-release}")
@@ -494,17 +495,21 @@ in
               (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
 
               (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.5.1";}))
-              (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.1";}))
+              # (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.1";}))
+              (mkPkg "cardano-node-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-node)
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-29-0-2ef95e1)
               (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")
               (mkPkg "cardano-smash-ng" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-pre-release}")
               (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-${node-release}")
-              (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-${node-pre-release}")
+              # (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-${node-pre-release}")
+              (mkPkg "cardano-submit-api-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-submit-api)
               (mkPkg "cardano-testnet" caPkgs."cardano-testnet-${node-release}")
-              (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-${node-pre-release}")
+              # (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-${node-pre-release}")
+              (mkPkg "cardano-testnet-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-testnet)
               (mkPkg "cardano-tracer" caPkgs."cardano-tracer-${node-release}")
-              (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-${node-pre-release}")
+              # (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-${node-pre-release}")
+              (mkPkg "cardano-tracer-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-tracer)
               (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2025-03-31-1649791
                 // {
                   pname = "cardano-wallet";
@@ -513,11 +518,14 @@ in
               (mkPkg "cc-sign" caPkgs."cc-sign-${credential-manager-release}")
               (mkPkg "colmena" localFlake.inputs.colmena.packages.${system}.colmena)
               (mkPkg "db-analyser" caPkgs."db-analyser-${node-release}")
-              (mkPkg "db-analyser-ng" caPkgs."db-analyser-${node-pre-release}")
+              # (mkPkg "db-analyser-ng" caPkgs."db-analyser-${node-pre-release}")
+              (mkPkg "db-analyser-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-analyser)
               (mkPkg "db-synthesizer" caPkgs."db-synthesizer-${node-release}")
-              (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-${node-pre-release}")
+              # (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-${node-pre-release}")
+              (mkPkg "db-synthesizer-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-synthesizer)
               (mkPkg "db-truncater" caPkgs."db-truncater-${node-release}")
-              (mkPkg "db-truncater-ng" caPkgs."db-truncater-${node-pre-release}")
+              # (mkPkg "db-truncater-ng" caPkgs."db-truncater-${node-pre-release}")
+              (mkPkg "db-truncater-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-truncater)
               (mkPkg "isd" caPkgs.isd-isd-project-isd-v0-5-1-51d52a2)
               (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v1-46-0-6a1799e)
               (mkPkg "metadata-server" caPkgs."metadata-server-${metadata-server-release}")
@@ -530,7 +538,8 @@ in
               (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs."mithril-signer-${mithril-pre-release}" {meta.mainProgram = "mithril-signer";}))
               (mkPkg "orchestrator-cli" caPkgs."orchestrator-cli-${credential-manager-release}")
               (mkPkg "snapshot-converter" caPkgs."snapshot-converter-${node-release}")
-              (mkPkg "snapshot-converter-ng" caPkgs."snapshot-converter-${node-pre-release}")
+              # (mkPkg "snapshot-converter-ng" caPkgs."snapshot-converter-${node-pre-release}")
+              (mkPkg "snapshot-converter-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.snapshot-converter)
               (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs."token-metadata-creator-${metadata-server-release}" {meta.mainProgram = "token-metadata-creator";}))
               (mkPkg "tx-bundle" caPkgs."tx-bundle-${credential-manager-release}")
             ];

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -464,10 +464,10 @@ in
           dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           dbsync-pre-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
-          mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
-          mithril-pre-release = "input-output-hk-mithril-unstable-effe078";
+          mithril-release = "input-output-hk-mithril-2543-1-hotfix-5d5571e";
+          mithril-pre-release = "input-output-hk-mithril-unstable-59bf453";
           node-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
-          # node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
+          node-pre-release = "input-output-hk-cardano-node-10-6-0-f5ac0eb";
         in
           submodule {
             options = foldl' recursiveUpdate {} [
@@ -481,8 +481,8 @@ in
 
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
               (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.11.0.0";}))
-              # (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))
-              (mkPkg "cardano-cli-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-cli)
+              (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.13.1.0";}))
+              # (mkPkg "cardano-cli-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-cli)
               (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-release}")
               (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-pre-release}")
               (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-release}")
@@ -495,21 +495,21 @@ in
               (mkPkg "cardano-faucet-ng" caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-1-2cccf6d")
 
               (mkPkg "cardano-node" (caPkgs."cardano-node-${node-release}" // {version = "10.5.1";}))
-              # (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.5.1";}))
-              (mkPkg "cardano-node-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-node)
+              (mkPkg "cardano-node-ng" (caPkgs."cardano-node-${node-pre-release}" // {version = "10.6.0";}))
+              # (mkPkg "cardano-node-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-node)
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-11-2-df5971a)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-29-0-2ef95e1)
               (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")
               (mkPkg "cardano-smash-ng" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-pre-release}")
               (mkPkg "cardano-submit-api" caPkgs."cardano-submit-api-${node-release}")
-              # (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-${node-pre-release}")
-              (mkPkg "cardano-submit-api-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-submit-api)
+              (mkPkg "cardano-submit-api-ng" caPkgs."cardano-submit-api-${node-pre-release}")
+              # (mkPkg "cardano-submit-api-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-submit-api)
               (mkPkg "cardano-testnet" caPkgs."cardano-testnet-${node-release}")
-              # (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-${node-pre-release}")
-              (mkPkg "cardano-testnet-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-testnet)
+              (mkPkg "cardano-testnet-ng" caPkgs."cardano-testnet-${node-pre-release}")
+              # (mkPkg "cardano-testnet-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-testnet)
               (mkPkg "cardano-tracer" caPkgs."cardano-tracer-${node-release}")
-              # (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-${node-pre-release}")
-              (mkPkg "cardano-tracer-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-tracer)
+              (mkPkg "cardano-tracer-ng" caPkgs."cardano-tracer-${node-pre-release}")
+              # (mkPkg "cardano-tracer-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.cardano-tracer)
               (mkPkg "cardano-wallet" (caPkgs.cardano-wallet-cardano-foundation-cardano-wallet-v2025-03-31-1649791
                 // {
                   pname = "cardano-wallet";
@@ -518,14 +518,14 @@ in
               (mkPkg "cc-sign" caPkgs."cc-sign-${credential-manager-release}")
               (mkPkg "colmena" localFlake.inputs.colmena.packages.${system}.colmena)
               (mkPkg "db-analyser" caPkgs."db-analyser-${node-release}")
-              # (mkPkg "db-analyser-ng" caPkgs."db-analyser-${node-pre-release}")
-              (mkPkg "db-analyser-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-analyser)
+              (mkPkg "db-analyser-ng" caPkgs."db-analyser-${node-pre-release}")
+              # (mkPkg "db-analyser-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-analyser)
               (mkPkg "db-synthesizer" caPkgs."db-synthesizer-${node-release}")
-              # (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-${node-pre-release}")
-              (mkPkg "db-synthesizer-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-synthesizer)
+              (mkPkg "db-synthesizer-ng" caPkgs."db-synthesizer-${node-pre-release}")
+              # (mkPkg "db-synthesizer-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-synthesizer)
               (mkPkg "db-truncater" caPkgs."db-truncater-${node-release}")
-              # (mkPkg "db-truncater-ng" caPkgs."db-truncater-${node-pre-release}")
-              (mkPkg "db-truncater-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-truncater)
+              (mkPkg "db-truncater-ng" caPkgs."db-truncater-${node-pre-release}")
+              # (mkPkg "db-truncater-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.db-truncater)
               (mkPkg "isd" caPkgs.isd-isd-project-isd-v0-5-1-51d52a2)
               (mkPkg "process-compose" caPkgs.process-compose-F1bonacc1-process-compose-v1-46-0-6a1799e)
               (mkPkg "metadata-server" caPkgs."metadata-server-${metadata-server-release}")
@@ -538,8 +538,8 @@ in
               (mkPkg "mithril-signer-ng" (recursiveUpdate caPkgs."mithril-signer-${mithril-pre-release}" {meta.mainProgram = "mithril-signer";}))
               (mkPkg "orchestrator-cli" caPkgs."orchestrator-cli-${credential-manager-release}")
               (mkPkg "snapshot-converter" caPkgs."snapshot-converter-${node-release}")
-              # (mkPkg "snapshot-converter-ng" caPkgs."snapshot-converter-${node-pre-release}")
-              (mkPkg "snapshot-converter-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.snapshot-converter)
+              (mkPkg "snapshot-converter-ng" caPkgs."snapshot-converter-${node-pre-release}")
+              # (mkPkg "snapshot-converter-ng" localFlake.inputs.cardano-node-10-6-0.packages.x86_64-linux.snapshot-converter)
               (mkPkg "token-metadata-creator" (recursiveUpdate caPkgs."token-metadata-creator-${metadata-server-release}" {meta.mainProgram = "token-metadata-creator";}))
               (mkPkg "tx-bundle" caPkgs."tx-bundle-${credential-manager-release}")
             ];

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -465,7 +465,7 @@ in
           dbsync-pre-release = "input-output-hk-cardano-db-sync-13-6-0-5-cb61094";
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2524-0-pre-7bf7033";
-          mithril-pre-release = "input-output-hk-mithril-unstable-de4de82";
+          mithril-pre-release = "input-output-hk-mithril-unstable-effe078";
           node-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
           node-pre-release = "input-output-hk-cardano-node-10-5-1-ca1ec27";
         in

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -474,7 +474,11 @@ in
               # TODO: Fix the missing meta/version info upstream
               (mkPkg "bech32" caPkgs."bech32-${node-release}")
               (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-2-e06029b)
-              (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-d757f38)
+
+              # Until blockperf detail fix is merged to master upstream
+              # (mkPkg "blockperf" caPkgs.blockperf-cardano-foundation-blockperf-main-d757f38)
+              (mkPkg "blockperf" localFlake.inputs.blockperf.packages.x86_64-linux.blockperf)
+
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-0-3749045")
               (mkPkg "cardano-cli" (caPkgs."cardano-cli-${node-release}" // {version = "10.11.0.0";}))
               (mkPkg "cardano-cli-ng" (caPkgs."cardano-cli-${node-pre-release}" // {version = "10.11.0.0";}))

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -241,6 +241,12 @@ in
                 description = mdDoc "Minimal devShell";
                 extraCfg.pkgs = mkOption {
                   default = with pkgs; [
+                    # Bash interactive needs to be included, otherwise, the
+                    # default devShell uses a bash without progcomp compiled
+                    # and devShell bins will fail to auto-complete on file
+                    # completions.
+                    bashInteractive
+
                     alejandra
                     bc
                     curl

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -359,7 +359,7 @@ in
 
                         gdb
                         process-compose
-                        token-metadata-creator
+                        # token-metadata-creator
                       ]);
                 };
               }

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -359,7 +359,7 @@ in
 
                         gdb
                         process-compose
-                        # token-metadata-creator
+                        token-metadata-creator
                       ]);
                 };
               }

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -157,6 +157,11 @@ in
             defaultZshCompFpathLoading = mkOption {
               description = mdDoc "The cardano-parts default zsh completion fpath loading hook.";
               default = globalDefault isGlobal (packages: ''
+                  # Direnv use prevents the dynamic loading of zsh completions,
+                  # requiring a zsh "reentry" upon arriving in the devShell.
+                  # (ie: `zsh` or `exec zsh -l`, etc.
+                  #
+                  # If using plain nix develop, zsh "reentry" is not required.
                   export ZDOTDIR=$PWD/.direnv-zsh
                   mkdir -p "$ZDOTDIR"
                   rm -f "$ZDOTDIR/.zcompdump"*
@@ -184,6 +189,8 @@ in
                 echo
                 echo "To return to your normal zsh without devShell fpath modifications, run \"zsh-base\" before leaving the repo directory,"
                 echo "otherwise, close and open a new zsh shell to avoid lingering devShell command completions."
+                echo
+                echo "To re-enter the completions in this devShell with direnv, run \"zsh\" or similar."
                 echo
                 EOF
               '');

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -43,7 +43,7 @@
   ...
 }: let
   inherit (flake-parts-lib) mkPerSystemOption;
-  inherit (lib.types) anything attrs attrsOf bool enum nullOr listOf package str submodule;
+  inherit (lib.types) anything attrs attrsOf bool enum nullOr listOf package str lines submodule;
 in
   with builtins;
   with lib; {
@@ -114,7 +114,7 @@ in
             };
 
             defaultHooks = mkOption {
-              type = globalType isGlobal str;
+              type = globalType isGlobal lines;
               description = mdDoc "The cardano-parts default git and shell hooks.";
               default = globalDefault isGlobal ''
                 if ${isPartsRepo} && [ -d .git/hooks ]; then

--- a/templates/cardano-parts-project/.gitignore
+++ b/templates/cardano-parts-project/.gitignore
@@ -1,6 +1,6 @@
 /*.cert
 /cloudFormation/
-/.direnv
+/.direnv*
 /.envrc.local
 /.gcroots
 /*.log

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -284,8 +284,17 @@ cardano-testnet isNg *ARGS:
 cf STACKNAME:
   #!/usr/bin/env nu
   mkdir cloudFormation
+  let secretName = (nix eval --raw '.#cardano-parts.cluster.infra.generic.costCenter')
+  let costCenter = (
+    just sops-decrypt-binary secrets/tf/cluster.tfvars
+    | lines
+    | where { |it| $it =~ $secretName }
+    | parse $"($secretName) = \"{secret}\""
+    | get 0.secret
+    | to text
+  )
   nix eval --json '.#cloudFormation.{{STACKNAME}}' | from json | save --force 'cloudFormation/{{STACKNAME}}.json'
-  rain deploy --debug --termination-protection --yes ./cloudFormation/{{STACKNAME}}.json
+  rain deploy --debug --params costCenter=($costCenter) --termination-protection ./cloudFormation/{{STACKNAME}}.json
 
 # Prep dbsync for delegation analysis
 dbsync-prep ENV HOST ACCTS="501":
@@ -401,11 +410,11 @@ dedelegate-pools ENV *IDXS=null:
       --wallet-mnemonic <(just sops-decrypt-binary secrets/envs/{{ENV}}/utxo-keys/faucet.mnemonic) \
       --delegation-index "$i"
 
-    TXID=$(eval "$CARDANO_CLI" latest transaction txid --tx-file tx-deleg-account-$i-restore.txsigned)
+    TXID=$(eval "$CARDANO_CLI" latest transaction txid --tx-file tx-deleg-account-$i-restore.txsigned | jq -r .txhash)
     EXISTS="true"
 
     while [ "$EXISTS" = "true" ]; do
-      EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists)
+      EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists || true)
       if [ "$EXISTS" = "true" ]; then
         echo "Pool de-delegation index $i tx still exists in the mempool, sleeping 5s: $TXID"
       else

--- a/templates/cardano-parts-project/flake/cloudFormation/terraformState.nix
+++ b/templates/cardano-parts-project/flake/cloudFormation/terraformState.nix
@@ -12,23 +12,45 @@ with lib; {
           Key = n;
           Value = v;
         }) {
-          inherit (config.flake.cardano-parts.cluster.infra.generic) organization tribe function repo;
-          environment = "generic";
+          inherit
+            (config.flake.cardano-parts.cluster.infra.generic)
+            environment
+            function
+            organization
+            owner
+            project
+            repo
+            tribe
+            ;
         })
       ++ [
         {
           Key = "Name";
           Value = name;
         }
+        {
+          Key = "costCenter";
+          Value = {
+            Ref = "costCenter";
+          };
+        }
       ];
   in {
     AWSTemplateFormatVersion = "2010-09-09";
     Description = "Terraform state handling";
 
+    # The costCenter parameter will be passed to the configuration via a secrets file.
+    # For details, see the just recipe: cf
+    Parameters = {
+      costCenter = {
+        Type = "String";
+        Description = "The costCenter tag";
+      };
+    };
+
     # Resources here will be created in the AWS_REGION and AWS_PROFILE from your
     # environment variables.
     # Execute this using: `just cf terraformState`
-
     Resources = {
       kmsKey = {
         Type = "AWS::KMS::Key";

--- a/templates/cardano-parts-project/flake/cluster.nix
+++ b/templates/cardano-parts-project/flake/cluster.nix
@@ -35,6 +35,13 @@
       # function = "cardano-parts";
       # repo = "https://github.com/input-output-hk/UPDATE_ME";
 
+      # owner = "ioe";
+      # environment = "testnets";
+      # project = "cardano-playground";
+
+      # This is the tf var secrets name located in secrets/tf/cluster.tfvars
+      # costCenter = "tag_costCenter";
+
       # By default abort and warn if the ip-module is missing:
       # abortOnMissingIpModule = true;
       # warnOnMissingIpModule = true;

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -7,8 +7,6 @@
 }: let
   inherit (config.flake) nixosModules nixosConfigurations;
   # inherit (config.flake.cardano-parts.cluster.infra.aws) domain regions;
-
-  cfgGeneric = config.flake.cardano-parts.cluster.infra.generic;
 in
   with builtins;
   with lib; {
@@ -39,7 +37,8 @@ in
 
         # Since all machines are assigned a group, this is a good place to include default aws instance tags
         aws.instance.tags = {
-          inherit (cfgGeneric) organization tribe function repo;
+          # This group environment name will override the
+          # flake.cluster.infra.generic environment name for aws instances.
           environment = config.flake.cardano-parts.cluster.groups.${name}.meta.environmentName;
           group = name;
         };

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -138,6 +138,28 @@ with lib; let
   groupMultivalueDnsAttrs = mkMultivalueDnsAttrs "groupRelayMultivalueDns" groupMultivalueDnsList;
 
   mkCustomRoute53Records = import ./cluster/route53.nix-import;
+
+  sensitiveString = {
+    type = "string";
+    sensitive = true;
+    nullable = false;
+  };
+
+  defaultTags = {
+    inherit
+      (infra.generic)
+      environment
+      function
+      organization
+      owner
+      project
+      repo
+      tribe
+      ;
+
+    # costCenter is saved as a secret
+    costCenter = "\${var.${infra.generic.costCenter}}";
+  };
 in {
   flake.opentofu.cluster = inputs.cardano-parts.inputs.terranix.lib.terranixConfiguration {
     inherit system;
@@ -161,13 +183,19 @@ in {
           };
         };
 
+        variable = {
+          # costCenter tag should remain secret in public repos
+          "${infra.generic.costCenter}" = sensitiveString;
+        };
+
         provider.aws = forEach (attrNames cluster.regions) (region: {
           inherit region;
           alias = underscore region;
-          default_tags.tags = {
-            inherit (infra.generic) organization tribe function repo;
-            environment = "generic";
-          };
+
+          # Default tagging is inconsistent across aws resources, but including
+          # it may help tag some resources that might have otherwise been
+          # missed.
+          default_tags.tags = defaultTags;
         });
 
         # Common parameters:
@@ -324,6 +352,8 @@ in {
                         gateway_id = "\${data.aws_internet_gateway.${region}.id}";
                       }
                     ];
+
+                  tags = defaultTags;
                 };
               }
           );
@@ -346,6 +376,7 @@ in {
                   + " cidrsubnet(${ipv6CidrBlock}, ${toString ipv6SubnetCidrBits} - parseint(tolist(regex(\"/([0-9]+)$\", ${ipv6CidrBlock}))[0], 10), each.key)}";
 
                 availability_zone = "\${each.value.availability_zone}";
+                tags = defaultTags;
               };
             });
 
@@ -358,6 +389,7 @@ in {
                 ${region} = {
                   provider = awsProviderFor region;
                   assign_generated_ipv6_cidr_block = true;
+                  tags = defaultTags;
                 };
               }
           );
@@ -378,6 +410,10 @@ in {
                 vpc_security_group_ids = [
                   "\${aws_security_group.common_${underscore region}[0].id}"
                 ];
+
+                # Provider level `default_tags` are automatically inherited at
+                # the instance level.  Instance specific tags defined in
+                # flake/colmena.nix are merged.
                 tags = {Name = name;} // node.aws.instance.tags or {};
 
                 root_block_device = {
@@ -386,14 +422,9 @@ in {
                   iops = node.aws.instance.root_block_device.iops or 3000;
                   throughput = node.aws.instance.root_block_device.throughput or 125;
                   delete_on_termination = true;
-                  tags =
-                    # Root block device tags aren't applied like the other
-                    # resources since terraform-aws-provider v5.39.0.
-                    #
-                    # We need to strip the following tag attrs or tofu
-                    # constantly tries to re-apply them.
-                    {Name = name;}
-                    // removeAttrs (node.aws.instance.tags or {}) ["organization" "tribe" "function" "repo"];
+
+                  # Default tags are not inherited to the volume level automatically.
+                  tags = defaultTags // {Name = name;} // node.aws.instance.tags or {};
                 };
 
                 metadata_options = {
@@ -433,6 +464,7 @@ in {
           aws_iam_instance_profile.ec2_profile = {
             name = "ec2Profile";
             role = "\${aws_iam_role.ec2_role.name}";
+            tags = defaultTags;
           };
 
           aws_iam_role.ec2_role = {
@@ -447,6 +479,8 @@ in {
                 }
               ];
             };
+
+            tags = defaultTags;
           };
 
           aws_iam_role_policy_attachment = let
@@ -495,6 +529,8 @@ in {
                 }
               ];
             };
+
+            tags = defaultTags;
           };
 
           tls_private_key.bootstrap.algorithm = "ED25519";
@@ -508,6 +544,7 @@ in {
               provider = awsProviderFor region;
               key_name = "bootstrap";
               public_key = "\${tls_private_key.bootstrap.public_key_openssh}";
+              tags = defaultTags;
             };
           });
 
@@ -515,6 +552,8 @@ in {
             inherit (node.aws.instance) count;
             provider = awsProviderFor node.aws.region;
             instance = "\${aws_instance.${name}[0].id}";
+
+            # Provider level `default_tags` are automatically inherited.
             tags = {Name = name;} // node.aws.instance.tags or {};
           });
 
@@ -592,6 +631,8 @@ in {
                     protocol = "-1";
                   })
                 ];
+
+                tags = defaultTags;
               };
             });
 

--- a/templates/cardano-parts-project/scripts/bash-fns.sh
+++ b/templates/cardano-parts-project/scripts/bash-fns.sh
@@ -2,13 +2,6 @@
 #
 # Various bash helper fns which aren't used enough to move to just recipes.
 
-# This can be used to simplify ssh sessions, rsync, ex:
-#   ssh -o "$(ssm-proxy-cmd "$REGION")" "$INSTANCE_ID"
-ssm-proxy-cmd() {
-  echo "ProxyCommand=sh -c 'aws --region $1 ssm start-session --target %h --document-name AWS-StartSSHSession --parameters portNumber=%p'"
-}
-
-
 # A handy transaction submission function with mempool monitoring.
 # CARDANO_NODE_{NETWORK_ID,SOCKET_PATH}, TESTNET_MAGIC should already be exported.
 submit() (

--- a/templates/cardano-parts-project/scripts/bash-fns.sh
+++ b/templates/cardano-parts-project/scripts/bash-fns.sh
@@ -15,7 +15,7 @@ submit() (
 
   EXISTS="true"
   while [ "$EXISTS" = "true" ]; do
-    EXISTS=$(cardano-cli latest query tx-mempool tx-exists "$TXID" | jq -re .exists)
+    EXISTS=$(cardano-cli latest query tx-mempool tx-exists "$TXID" | jq -re .exists || true)
     if [ "$EXISTS" = "true" ]; then
       echo "The transaction still exists in the mempool, sleeping 5s: $TXID"
     else
@@ -198,4 +198,31 @@ return-utxo() (
   PROMPT
 
   submit "$BASENAME.signed"
+)
+
+# A handy faucet submission function with mempool monitoring, usable on custom networks.
+# CARDANO_NODE_{NETWORK_ID,SOCKET_PATH}, TESTNET_MAGIC should already be exported.
+# SEND_ADDR, LOVELACE, RICH_ADDR and RICH vars need to be provided.
+faucet() (
+  SEND_ADDR="$1"
+  LOVELACE="$2"
+
+  UTXOS=$(cardano-cli query utxo --address "$RICH_ADDR")
+  UTXO=$(jq -r 'to_entries | max_by(.value.value.lovelace) | { (.key): .value }' <<< "$UTXOS")
+  UTXO_TX=$(jq -r 'keys[0]' <<< "$UTXO")
+
+  cardano-cli latest transaction build \
+    --tx-in "$UTXO_TX" \
+    --tx-out "$SEND_ADDR+$LOVELACE" \
+    --change-address "$RICH_ADDR" \
+    --testnet-magic "$TESTNET_MAGIC" \
+    --out-file faucet.txbody
+
+  cardano-cli latest transaction sign \
+    --tx-body-file faucet.txbody \
+    --signing-key-file "$RICH.skey" \
+    --testnet-magic "$TESTNET_MAGIC" \
+    --out-file faucet.txsigned
+
+  submit faucet.txsigned
 )

--- a/templates/cardano-parts-project/scripts/lib/cli.py
+++ b/templates/cardano-parts-project/scripts/lib/cli.py
@@ -53,7 +53,7 @@ def createTransaction(start, end, txin, payments_txouts, utxo_address, utxo_sign
 
     signed_tx = signTx(tx_prefix, utxo_signing_key_str)
 
-    p = subprocess.run([cardanoCliStr(), "latest", "transaction", "txid", "--tx-file", signed_tx], capture_output=True, text=True)
+    p = subprocess.run([cardanoCliStr(), "latest", "transaction", "txid", "--output-text", "--tx-file", signed_tx], capture_output=True, text=True)
     new_txin = p.stdout.rstrip()
     return (f"{new_txin}#0", tx_out_amount, fee)
 
@@ -66,6 +66,7 @@ def estimateFeeTx(txbody, txin_count, txout_count, pparams) -> int:
         "--tx-out-count", str(txout_count),
         "--witness-count", "1",
         "--protocol-params-file", pparams,
+        "--output-text",
         "--tx-body-file", txbody]
 
     p = subprocess.run(cmd, capture_output=True, text=True)

--- a/templates/cardano-parts-project/scripts/recipes/governance.just
+++ b/templates/cardano-parts-project/scripts/recipes/governance.just
@@ -992,7 +992,7 @@ vote-with-pool ENV POOL ACTION_ID ACTION_IDX VOTE:
   EXISTS="true"
 
   while [ "$EXISTS" = "true" ]; do
-    EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists)
+    EXISTS=$(eval "$CARDANO_CLI" latest query tx-mempool tx-exists $TXID | jq -r .exists || true)
     if [ "$EXISTS" = "true" ]; then
       echo "Vote transaction still exists in the mempool, sleeping 5s: $TXID"
     else

--- a/templates/cardano-parts-project/scripts/restore-delegation-accounts.py
+++ b/templates/cardano-parts-project/scripts/restore-delegation-accounts.py
@@ -261,7 +261,7 @@ def signTx(tx_body, utxo_signing_key_str, stake_signing_key, out_file):
     if p.returncode != 0:
         print(p.stderr)
         raise Exception("Unknown error signing transaction")
-    cli_args = ["cardano-cli", "latest", "transaction", "txid", "--tx-file", out_file]
+    cli_args = ["cardano-cli", "latest", "transaction", "txid", "--output-text", "--tx-file", out_file]
     p = subprocess.run(cli_args, input=None, capture_output=True, text=True)
     if p.returncode != 0:
         print(p.stderr)

--- a/templates/cardano-parts-project/secrets/tf/cluster.tfvars
+++ b/templates/cardano-parts-project/secrets/tf/cluster.tfvars
@@ -1,0 +1,9 @@
+# To enable terraform and cloudFormation cluster secrets usage:
+#   * update the following with the appropriate cluster secrets
+#   * remove these comments
+#   * encrypt this file with sops as a binary type using an age sre/admin secret key
+#
+# Expect this file to generate a pre-push error until it is either encrypted or deleted
+
+# Set this to the finance billing code
+tag_costCenter = "UPDATE_ME"


### PR DESCRIPTION
## Overview:

This release contains node `10.6.0` pre-release and adds zsh devShell command completion.  New required flakeModule `cluster.nix` tags were added for better cloud resource tagging.  Other miscellaneous improvements and fixes were added, see details below.

## Details:

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
| :---: | :---: | :---: |
| blockperf | <ins>***2.0.2-fix-detail***</ins> | N/A |
| cardano-address | 4.0.0 | N/A |
| cardano-cli | 10.11.0.0 | <ins>***10.13.1.0***</ins> |
| cardano-db-sync | 13.6.0.5 | 13.6.0.5 |
| cardano-node | 10.5.1 | <ins>***10.6.0***</ins> |
| cardano-ogmios | 6.11.2 | N/A |
| cardano-signer | 1.29.0 | N/A |
| credential-manager | 0.1.5.0 | N/A |
| mithril | <ins>***2543.1-hotfix***</ins> | <ins>***59bf453***</ins> |
| nix* | 2.29.2 | N/A |
| nixpkgs* | 25.05 | N/A |

\* = For nixos machine deployments

* Bumps cardano-node pre-release to `10.6.0`, mithril to `2543.1-hotfix` and blockperf to a fix branch which includes a patch for the new tracing system proper blockperf configuration
* Adds new flakeModule `cluster.nix` options for required resource tagging:
```
flake.cardano-parts.cluster.infra.generic.costCenter
flake.cardano-parts.cluster.infra.generic.environment
flake.cardano-parts.cluster.infra.generic.owner
flake.cardano-parts.cluster.infra.generic.project
```
* Added rsync ssm help bash function and alias to the common machine profile
* Added peer snapshot files to the ops library function `generateStaticHTMLConfigs`
* Added new flakeModule `cluster.nix` options of infra.generic `costCenter`, `owner` and `project`
* Added zsh devShell command completion
* Updated a number of nixosModules to support both new and legacy tracing systems as well as `10.6.0` and `10.5.1` configuration differences
* Updated template CloudFormation terraform state and opentofu cluster resource definitions for corresponding tagging updates
* Fixed template script breakages caused by cardano-cli breaking changes included in the `10.6.0` pre-release
* Fixed the `profile-blockperf.nix` nixosModule new tracing system configuration

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* To the `flake/cluster.nix` file, the following new tags need to be declared: `costCenter`, `environment`, `owner`, `project`.  The `costCenter` tag is treated as a secret -- see the comments in the `secrets/tf/cluster.tfvars` file in the "Action Items" section below for implementation.

### Recommended Updates:
* Update the cardano-parts pin to this release version `v2025-11-18`.
* Apply the template Justfile diff and patch or clone recipes on files described below.

### Action Items:
Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`.  Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the `just template-clone "$FILE"` recipe.
```
.gitignore                               # Zsh devShell command completion
Justfile                                 # For new tag updates and costCenter secret and breaking change fixes
flake/cluster.nix                        # For new tag updates and costCenter secret
flake/cloudFormation/terraformState.nix  # For new tag updates and costCenter secret
flake/colmena.nix                        # For new tag updates and costCenter secret
flake/opentofu/cluster.nix               # For new tag updates and costCenter secret
scripts/bash-fns.sh                      # For breaking change fixes
scripts/lib/cli.py                       # For breaking change fixes
scripts/recipes/governance.just          # For breaking change fixes
scripts/restore-delegation-accounts.py   # For breaking change fixes
secrets/tf/cluster.tfvars                # For new costCenter tag secret
```

## Known Issues:
* N/A
