### PR TITLE
`just ssh` check: ignore machines without IPv4

### DIFF
--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -112,6 +112,7 @@ checkSshConfig := '''
       | where ($it.machine | str ends-with ".ipv4")
       | rename machine pubIpv4
       | update machine { $in | str replace ".ipv4" "" }
+      | update pubIpv4 { $in | if $in == "unavailable.ipv4" { null } else { $in } }
       | sort-by machine
     )
 


### PR DESCRIPTION
The equivalent to IPv6. In some projects, the machines don't even have public IPv4s, and are only connected to via SSM.