### PR TITLE
Add process-compose CI tests for cardano-node and db-sync startup validation

### DIFF
--- a/.github/workflows/nix-jobs-test.yaml
+++ b/.github/workflows/nix-jobs-test.yaml
@@ -1,3 +1,4 @@
+name: Nix Jobs Tests
 on:
   workflow_dispatch:
     inputs:
@@ -16,26 +17,43 @@ permissions:
   pull-requests: read
 
 jobs:
+  # This job allows for maintainer workflow dispatch of forked PRs with a
+  # declared PR input number.
+  detect-pr:
+    name: Detect PR context
+    runs-on: ubuntu-latest
+    outputs:
+      is_trusted: ${{ steps.detect-pr.outputs.is_trusted }}
+      base_ref: ${{ steps.detect-pr.outputs.base_ref }}
+      head_ref: ${{ steps.detect-pr.outputs.head_ref }}
+      pr_number: ${{ steps.detect-pr.outputs.pr_number }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Checkout base branch to ensure detect-pr runs trusted action code.
+          # The || github.sha fallback handles non-PR events (push, workflow_dispatch).
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+
+      - name: Detect PR context
+        id: detect-pr
+        uses: ./.github/actions/detect-pr
+
   nix-jobs-test:
-    name: "Test nix jobs"
+    name: Test nix jobs
+    needs: detect-pr
+    if: needs.detect-pr.outputs.is_trusted == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      # This step allows for maintainer workflow dispatch of forked PRs with a
-      # declared PR input number.
-      - name: Detect PR context
-        id: detect-pr
-        uses: ./.github/actions/detect-pr
-
-      # For PRs, checkout a merge base, including for forked PRs.
       - name: Checkout and merge PR
         uses: ./.github/actions/checkout-merge
         with:
-          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
-          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
-          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
+          base_ref: ${{ needs.detect-pr.outputs.base_ref }}
+          head_ref: ${{ needs.detect-pr.outputs.head_ref }}
+          pr_number: ${{ needs.detect-pr.outputs.pr_number }}
 
       - name: Install Nix
         uses: cachix/install-nix-action@v27

--- a/.github/workflows/process-compose-test.yaml
+++ b/.github/workflows/process-compose-test.yaml
@@ -1,0 +1,110 @@
+name: Process Compose Tests
+on:
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Optional PR number, for maintainer use
+        required: false
+  push:
+    branches:
+      - main
+  pull_request:
+permissions:
+  contents: read
+  pull-requests: read
+jobs:
+  # Node Startup Tests (all environments, no Mithril)
+  test-node:
+    name: "Test: cardano-node startup"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Detect PR context
+        id: detect-pr
+        uses: ./.github/actions/detect-pr
+      - name: Checkout and merge PR
+        uses: ./.github/actions/checkout-merge
+        with:
+          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
+          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
+          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+            experimental-features = fetch-closure flakes nix-command
+            substituters = https://cache.iog.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - name: Test node startup (mainnet)
+        run: nix run .#test-process-compose-node-mainnet
+      - name: Test node startup (preprod)
+        run: nix run .#test-process-compose-node-preprod
+      - name: Test node startup (preview)
+        run: nix run .#test-process-compose-node-preview
+
+  # DB-Sync Integration Tests (all environments, no Mithril)
+  test-dbsync:
+    name: "Test: db-sync integration"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Detect PR context
+        id: detect-pr
+        uses: ./.github/actions/detect-pr
+      - name: Checkout and merge PR
+        uses: ./.github/actions/checkout-merge
+        with:
+          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
+          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
+          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+            experimental-features = fetch-closure flakes nix-command
+            substituters = https://cache.iog.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - name: Test db-sync integration (mainnet)
+        run: nix run .#test-process-compose-dbsync-mainnet
+      - name: Test db-sync integration (preprod)
+        run: nix run .#test-process-compose-dbsync-preprod
+      - name: Test db-sync integration (preview)
+        run: nix run .#test-process-compose-dbsync-preview
+
+  # Mithril Bootstrap Tests (all environments, watches for download to start)
+  test-mithril:
+    name: "Test: Mithril bootstrap"
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Detect PR context
+        id: detect-pr
+        uses: ./.github/actions/detect-pr
+      - name: Checkout and merge PR
+        uses: ./.github/actions/checkout-merge
+        with:
+          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
+          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
+          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
+      - name: Install Nix
+        uses: cachix/install-nix-action@v27
+        with:
+          extra_nix_config: |
+            accept-flake-config = true
+            experimental-features = fetch-closure flakes nix-command
+            substituters = https://cache.iog.io https://cache.nixos.org/
+            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      - name: Test Mithril bootstrap (mainnet)
+        run: nix run .#test-process-compose-node-mithril-mainnet
+      - name: Test Mithril bootstrap (preprod)
+        run: nix run .#test-process-compose-node-mithril-preprod
+      - name: Test Mithril bootstrap (preview)
+        run: nix run .#test-process-compose-node-mithril-preview

--- a/.github/workflows/process-compose-test.yaml
+++ b/.github/workflows/process-compose-test.yaml
@@ -13,23 +13,44 @@ permissions:
   contents: read
   pull-requests: read
 jobs:
-  # Node Startup Tests (all environments, no Mithril)
-  test-node:
-    name: "Test: cardano-node startup"
+  # This job allows for maintainer workflow dispatch of forked PRs with a
+  # declared PR input number.
+  detect-pr:
+    name: Detect PR context
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    outputs:
+      is_trusted: ${{ steps.detect-pr.outputs.is_trusted }}
+      base_ref: ${{ steps.detect-pr.outputs.base_ref }}
+      head_ref: ${{ steps.detect-pr.outputs.head_ref }}
+      pr_number: ${{ steps.detect-pr.outputs.pr_number }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          # Checkout base branch to ensure detect-pr runs trusted action code.
+          # The || github.sha fallback handles non-PR events (push, workflow_dispatch).
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
       - name: Detect PR context
         id: detect-pr
         uses: ./.github/actions/detect-pr
+
+  test:
+    name: Process Compose Tests
+    needs: detect-pr
+    if: needs.detect-pr.outputs.is_trusted == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Checkout and merge PR
         uses: ./.github/actions/checkout-merge
         with:
-          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
-          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
-          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
+          base_ref: ${{ needs.detect-pr.outputs.base_ref }}
+          head_ref: ${{ needs.detect-pr.outputs.head_ref }}
+          pr_number: ${{ needs.detect-pr.outputs.pr_number }}
+
       - name: Install Nix
         uses: cachix/install-nix-action@v27
         with:
@@ -38,70 +59,22 @@ jobs:
             experimental-features = fetch-closure flakes nix-command
             substituters = https://cache.iog.io https://cache.nixos.org/
             trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+
+      # Node startup tests
       - name: Test node startup (mainnet)
         run: nix run .#test-process-compose-node-mainnet
       - name: Test node startup (preprod)
         run: nix run .#test-process-compose-node-preprod
       - name: Test node startup (preview)
         run: nix run .#test-process-compose-node-preview
-
-  # DB-Sync Integration Tests (all environments, no Mithril)
-  test-dbsync:
-    name: "Test: db-sync integration"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Detect PR context
-        id: detect-pr
-        uses: ./.github/actions/detect-pr
-      - name: Checkout and merge PR
-        uses: ./.github/actions/checkout-merge
-        with:
-          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
-          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
-          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-            experimental-features = fetch-closure flakes nix-command
-            substituters = https://cache.iog.io https://cache.nixos.org/
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      # DB-sync integration tests
       - name: Test db-sync integration (mainnet)
         run: nix run .#test-process-compose-dbsync-mainnet
       - name: Test db-sync integration (preprod)
         run: nix run .#test-process-compose-dbsync-preprod
       - name: Test db-sync integration (preview)
         run: nix run .#test-process-compose-dbsync-preview
-
-  # Mithril Bootstrap Tests (all environments, watches for download to start)
-  test-mithril:
-    name: "Test: Mithril bootstrap"
-    runs-on: ubuntu-latest
-    timeout-minutes: 5
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Detect PR context
-        id: detect-pr
-        uses: ./.github/actions/detect-pr
-      - name: Checkout and merge PR
-        uses: ./.github/actions/checkout-merge
-        with:
-          base_ref: ${{ steps.detect-pr.outputs.base_ref }}
-          head_ref: ${{ steps.detect-pr.outputs.head_ref }}
-          pr_number: ${{ steps.detect-pr.outputs.pr_number }}
-      - name: Install Nix
-        uses: cachix/install-nix-action@v27
-        with:
-          extra_nix_config: |
-            accept-flake-config = true
-            experimental-features = fetch-closure flakes nix-command
-            substituters = https://cache.iog.io https://cache.nixos.org/
-            trusted-public-keys = hydra.iohk.io:f/Ea+s+dFdN+3Y/G+FDgSq+a5NEWhJGzdjvKNGv0/EQ= cache.nixos.org-1:6NCHdD59X431o0gWypbMrAURkbJ16ZPMQFGspcDShjY=
+      # Mithril bootstrap tests
       - name: Test Mithril bootstrap (mainnet)
         run: nix run .#test-process-compose-node-mithril-mainnet
       - name: Test Mithril bootstrap (preprod)

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 /.envrc.local
 result*
 /.run/
+/.run-test/
 /treefmt.toml

--- a/flake.lock
+++ b/flake.lock
@@ -799,11 +799,11 @@
     },
     "process-compose-flake": {
       "locked": {
-        "lastModified": 1705650762,
-        "narHash": "sha256-kSLMsz0tXc1N5Jx8ghEXhLmK4X3Bktt3S4ttXJXCzCo=",
+        "lastModified": 1767863885,
+        "narHash": "sha256-XXekPAxzbv1DmHFo3Elmj/vDnvWc1V0jdDUvM0/Wf7k=",
         "owner": "Platonic-systems",
         "repo": "process-compose-flake",
-        "rev": "c8942208e7c7122aef4811a606f7c12ad0753a98",
+        "rev": "99bea96cf269cfd235833ebdf645b567069fd398",
         "type": "github"
       },
       "original": {

--- a/perSystem/process-compose/default.nix
+++ b/perSystem/process-compose/default.nix
@@ -681,6 +681,7 @@ flake @ {inputs, ...}: {
           "cardano-node-${env}${envVer env "isNodeNg"}" = {
             ready_log_line = mithrilLogPatterns.${env};
             depends_on."cleanup-db-${env}".condition = "process_completed_successfully";
+            environment."MITHRIL_VERIFY_SNAPSHOT_${env}" = "false";
           };
           "test-mithril-success" = mkTestMithrilSuccess env;
         };


### PR DESCRIPTION
Add CI tests for process-compose validation.

The first commit works on it's own, but the second commit upgrades process-compose-flake (and process-compose itself), which enables a simpler testing approach with less code to maintain.

I tested the upgrade version manually, starting up all the networks, and it's also being tested through this new CI.