### PR TITLE
docs: add module-docs auto-generator for NixOS and flake module options

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -617,16 +617,19 @@
     },
     "nixpkgs-lib": {
       "locked": {
-        "lastModified": 1743296961,
-        "narHash": "sha256-b1EdN3cULCqtorQ4QeWgLMrd5ZGOjLSLemfa00heasc=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "e4822aea2a6d1cdd36653c134cacfd64c97ff4fa",
+        "dir": "lib",
+        "lastModified": 1767313136,
+        "narHash": "sha256-16KkgfdYqjaeRGBaYsNrhPRRENs0qzkQVUooNHtoy2w=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "ac62194c3917d5f474c1a844b6fd6da2db95077d",
         "type": "github"
       },
       "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
+        "dir": "lib",
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
         "type": "github"
       }
     },

--- a/flake/nixosModules/profile-cardano-parts.nix
+++ b/flake/nixosModules/profile-cardano-parts.nix
@@ -55,7 +55,7 @@ flake @ {moduleWithSystem, ...}: {
     ...
   }: let
     inherit (builtins) attrNames deepSeq elem head stringLength;
-    inherit (lib) count filterAttrs foldl' isList mapAttrsToList mdDoc mapAttrs' mkIf mkOption nameValuePair optional optionalString pipe recursiveUpdate types;
+    inherit (lib) count filterAttrs foldl' isList mapAttrsToList mapAttrs' mkIf mkOption nameValuePair optional optionalString pipe recursiveUpdate types;
     inherit (types) anything attrsOf bool enum ints listOf oneOf package port nullOr str submodule;
     inherit (cfg.group) groupFlake;
     inherit (cfgPerNode.lib) topologyLib;
@@ -71,7 +71,7 @@ flake @ {moduleWithSystem, ...}: {
     mkPkgOpt = name: pkg: {
       ${name} = mkOption {
         type = package;
-        description = mdDoc "The cardano-parts nixos default package for ${name}.";
+        description = "The cardano-parts nixos default package for ${name}.";
         default = pkg;
       };
     };
@@ -79,7 +79,7 @@ flake @ {moduleWithSystem, ...}: {
     mkSpecialOpt = name: type: specialPkg: {
       ${name} = mkOption {
         inherit type;
-        description = mdDoc "The cardano-parts nixos default special package for ${name}.";
+        description = "The cardano-parts nixos default special package for ${name}.";
         default = specialPkg;
       };
     };
@@ -88,13 +88,13 @@ flake @ {moduleWithSystem, ...}: {
       options = {
         cluster = mkOption {
           type = clusterSubmodule;
-          description = mdDoc "Cardano-parts nixos cluster submodule";
+          description = "Cardano-parts nixos cluster submodule";
           default = {};
         };
 
         perNode = mkOption {
           type = perNodeSubmodule;
-          description = mdDoc "Cardano-parts nixos perNode submodule";
+          description = "Cardano-parts nixos perNode submodule";
           default = {};
         };
       };
@@ -105,7 +105,7 @@ flake @ {moduleWithSystem, ...}: {
         group = mkOption {
           type = attrsOf anything;
           inherit (flake.config.flake.cardano-parts.cluster.groups) default;
-          description = mdDoc "The cardano group to associate with the nixos node.";
+          description = "The cardano group to associate with the nixos node.";
         };
       };
     };
@@ -114,31 +114,31 @@ flake @ {moduleWithSystem, ...}: {
       options = {
         generic = mkOption {
           type = genericSubmodule;
-          description = mdDoc "Cardano-parts nixos perNode generic submodule";
+          description = "Cardano-parts nixos perNode generic submodule";
           default = {};
         };
 
         lib = mkOption {
           type = libSubmodule;
-          description = mdDoc "Cardano-parts nixos perNode lib submodule";
+          description = "Cardano-parts nixos perNode lib submodule";
           default = {};
         };
 
         meta = mkOption {
           type = metaSubmodule;
-          description = mdDoc "Cardano-parts nixos perNode meta submodule";
+          description = "Cardano-parts nixos perNode meta submodule";
           default = {};
         };
 
         pkgs = mkOption {
           type = pkgsSubmodule;
-          description = mdDoc "Cardano-parts nixos perNode pkgs submodule";
+          description = "Cardano-parts nixos perNode pkgs submodule";
           default = {};
         };
 
         roles = mkOption {
           type = rolesSubmodule;
-          description = mdDoc "Cardano-parts nixos perNode roles submodule";
+          description = "Cardano-parts nixos perNode roles submodule";
           default = {};
         };
       };
@@ -148,7 +148,7 @@ flake @ {moduleWithSystem, ...}: {
       options = {
         abortOnMissingIpModule = mkOption {
           type = bool;
-          description = mdDoc ''
+          description = ''
             The option to abort on missing downstream provided "ip-module" nixosModule.
           '';
           default = cfg.group.generic.abortOnMissingIpModule;
@@ -156,7 +156,7 @@ flake @ {moduleWithSystem, ...}: {
 
         warnOnMissingIpModule = mkOption {
           type = bool;
-          description = mdDoc ''
+          description = ''
             The option to warn on missing downstream provided "ip-module" nixosModule.
           '';
           default = cfg.group.generic.warnOnMissingIpModule;
@@ -176,91 +176,91 @@ flake @ {moduleWithSystem, ...}: {
       options = {
         addressType = mkOption {
           type = enum ["fqdn" "namePrivateIpv4" "namePublicIpv4" "namePublicIpv6" "privateIpv4" "publicIpv4" "publicIpv6"];
-          description = mdDoc "The default addressType for topologyLib mkProducer function.";
+          description = "The default addressType for topologyLib mkProducer function.";
           default = cfg.group.meta.addressType;
         };
 
         blockfrost-platform-service = mkOption {
           type = str;
-          description = mdDoc "The blockfrost-platform-service import path string.";
+          description = "The blockfrost-platform-service import path string.";
           default = cfg.group.meta.blockfrost-platform-service;
         };
 
         cardanoDbSyncPrometheusExporterPort = mkOption {
           type = port;
-          description = mdDoc "The port to associate with the nixos cardano-db-sync prometheus exporter.";
+          description = "The port to associate with the nixos cardano-db-sync prometheus exporter.";
           default = cfg.group.meta.cardanoDbSyncPrometheusExporterPort;
         };
 
         cardanoNodePort = mkOption {
           type = port;
-          description = mdDoc "The port to associate with the nixos cardano-node.";
+          description = "The port to associate with the nixos cardano-node.";
           default = cfg.group.meta.cardanoNodePort;
         };
 
         cardanoNodePrometheusExporterPort = mkOption {
           type = port;
-          description = mdDoc "The port to associate with the nixos cardano-node prometheus exporter.";
+          description = "The port to associate with the nixos cardano-node prometheus exporter.";
           default = cfg.group.meta.cardanoNodePrometheusExporterPort;
         };
 
         cardanoSmashDelistedPools = mkOption {
           type = listOf str;
-          description = mdDoc "The cardano-smash delisted pools.";
+          description = "The cardano-smash delisted pools.";
           default = cfg.group.meta.cardanoSmashDelistedPools;
         };
 
         cardano-db-sync-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-db-sync-service import path string.";
+          description = "The cardano-db-sync-service import path string.";
           default = cfg.group.meta.cardano-db-sync-service;
         };
 
         cardano-faucet-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-faucet-service import path string.";
+          description = "The cardano-faucet-service import path string.";
           default = cfg.group.meta.cardano-faucet-service;
         };
 
         cardano-metadata-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-metadata-service import path string.";
+          description = "The cardano-metadata-service import path string.";
           default = cfg.group.meta.cardano-metadata-service;
         };
 
         cardano-node-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-node-service import path string.";
+          description = "The cardano-node-service import path string.";
           default = cfg.group.meta.cardano-node-service;
         };
 
         cardano-ogmios-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-ogmios-service import path string.";
+          description = "The cardano-ogmios-service import path string.";
           default = cfg.group.meta.cardano-ogmios-service;
         };
 
         cardano-smash-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-smash-service import path string.";
+          description = "The cardano-smash-service import path string.";
           default = cfg.group.meta.cardano-smash-service;
         };
 
         cardano-submit-api-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-submit-api-service import path string.";
+          description = "The cardano-submit-api-service import path string.";
           default = cfg.group.meta.cardano-submit-api-service;
         };
 
         cardano-tracer-service = mkOption {
           type = str;
-          description = mdDoc "The cardano-tracer-service import path string.";
+          description = "The cardano-tracer-service import path string.";
           default = cfg.group.meta.cardano-tracer-service;
         };
 
         enableAlertCount = mkOption {
           type = bool;
-          description = mdDoc ''
+          description = ''
             Whether to count this machine as an expected machine to appear in grafana/prometheus metrics.
 
             In cases where this machine may be created, but mostly kept in a stopped state such that it will
@@ -275,7 +275,7 @@ flake @ {moduleWithSystem, ...}: {
 
         enableDns = mkOption {
           type = bool;
-          description = mdDoc ''
+          description = ''
             Whether to create a DNS for this machine when running `just tofu apply`.
 
             Typically, only block producers or other sensitive machines would want to set this to false.
@@ -285,19 +285,19 @@ flake @ {moduleWithSystem, ...}: {
 
         hostAddr = mkOption {
           type = str;
-          description = mdDoc "The hostAddr to associate with the nixos cardano-node for ipv4 binding.";
+          description = "The hostAddr to associate with the nixos cardano-node for ipv4 binding.";
           default = "0.0.0.0";
         };
 
         hostAddrIpv6 = mkOption {
           type = str;
-          description = mdDoc "The hostAddr to associate with the nixos cardano-node for ipv6 binding.";
+          description = "The hostAddr to associate with the nixos cardano-node for ipv6 binding.";
           default = "::0";
         };
 
         hostsList = mkOption {
           type = oneOf [(enum ["all" "group"]) (listOf str)];
-          description = mdDoc ''
+          description = ''
             A list of Colmena machine names for which /etc/hosts will be configured for if
             nixosModule.ip-module is available in the downstream repo and profile-cardano-parts
             nixosModule is imported.
@@ -313,7 +313,7 @@ flake @ {moduleWithSystem, ...}: {
 
         nodeId = mkOption {
           type = nullOr ints.unsigned;
-          description = mdDoc "The hostAddr to associate with the nixos cardano-node.";
+          description = "The hostAddr to associate with the nixos cardano-node.";
           default = 0;
         };
       };

--- a/flakeModules/aws.nix
+++ b/flakeModules/aws.nix
@@ -13,7 +13,7 @@
   lib,
   ...
 }: let
-  inherit (lib) foldl' mdDoc mkDefault mkOption recursiveUpdate types;
+  inherit (lib) foldl' mkDefault mkOption recursiveUpdate types;
   inherit (types) anything attrsOf submodule;
 
   cfg = config.flake.cardano-parts;
@@ -23,7 +23,7 @@
     options = {
       aws = mkOption {
         type = awsSubmodule;
-        description = mdDoc "Cardano-parts aws options";
+        description = "Cardano-parts aws options";
         default = {};
       };
     };
@@ -33,7 +33,7 @@
     options = {
       ec2 = mkOption {
         type = ec2Submodule;
-        description = mdDoc "Cardano-parts aws ec2 options";
+        description = "Cardano-parts aws ec2 options";
         default = {};
       };
     };
@@ -43,13 +43,18 @@
     options = {
       rawSpec = mkOption {
         type = anything;
-        description = mdDoc "The cardano-parts aws ec2 instance type raw spec reference.";
+        description = "The cardano-parts aws ec2 instance type raw spec reference.";
         default = builtins.fromJSON (builtins.readFile ./aws/ec2-spec.json);
+        defaultText = lib.literalExpression "builtins.fromJSON (builtins.readFile ./aws/ec2-spec.json)";
       };
 
       spec = mkOption {
         type = attrsOf anything;
-        description = mdDoc "The cardano-parts aws ec2 instance type spec reference.";
+        description = "The cardano-parts aws ec2 instance type spec reference.";
+        defaultText = lib.literalExpression ''
+          # Attrset of EC2 instance specs keyed by InstanceType, derived from rawSpec.
+          # Each entry has: provider, nodeType, coreCount, cpuCount, memMiB, threadsPerCore.
+        '';
         default = foldl' (acc: spec:
           recursiveUpdate acc {
             ${spec.InstanceType} = {

--- a/flakeModules/lib.nix
+++ b/flakeModules/lib.nix
@@ -9,14 +9,14 @@
 # Tips:
 #   * flake level attrs are accessed from flake level at [config.]flake.cardano-parts.lib.<...>
 {lib, ...}: let
-  inherit (lib) mdDoc mkDefault mkOption types;
+  inherit (lib) mkDefault mkOption types;
   inherit (types) attrsOf anything functionTo submodule;
 
   mainSubmodule = submodule {
     options = {
       lib = mkOption {
         type = libSubmodule;
-        description = mdDoc "Cardano-parts lib options";
+        description = "Cardano-parts lib options";
         default = {};
       };
     };
@@ -26,7 +26,7 @@
     options = {
       opsLib = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts ops library.
 
           A miscellaneous library for shared code used in various places
@@ -40,7 +40,7 @@
 
       topologyLib = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts topology library.
 
           Consumers of the default definition of this library

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -80,7 +80,7 @@
   ...
 }: let
   inherit (flake-parts-lib) mkPerSystemOption;
-  inherit (lib) filterAttrs init last mdDoc mkOption updateManyAttrsByPath;
+  inherit (lib) filterAttrs init last mkOption updateManyAttrsByPath;
   inherit (lib.types) anything attrsOf functionTo package path str submodule;
 
   removeManyByPath = listofPathLists:
@@ -108,7 +108,7 @@
     options = {
       pkgs = mkOption {
         type = mainPkgsSubmodule;
-        description = mdDoc "Cardano-parts packages options";
+        description = "Cardano-parts packages options";
         default = {};
       };
     };
@@ -118,7 +118,7 @@
     options = {
       special = mkOption {
         type = specialPkgsSubmodule;
-        description = mdDoc "Cardano-parts special package options";
+        description = "Cardano-parts special package options";
         default = {};
       };
     };
@@ -128,13 +128,13 @@
     options = {
       blockfrost-platform-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default blockfrost-platform-service import path string.";
+        description = "The cardano-parts default blockfrost-platform-service import path string.";
         default = "${localFlake.inputs.blockfrost-platform-service}/nix/nixos";
       };
 
       cardanoLib = mkOption {
         type = anything;
-        description = mdDoc ''
+        description = ''
           The cardano-parts system dependent default package for cardanoLib.
 
           Iohk-nix cardanoLib is not a proper package derivation and
@@ -147,11 +147,12 @@
           The definition must be a function of system.
         '';
         default = system: mkCardanoLib system localFlake.inputs.iohk-nix;
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardanoLibCustom = mkOption {
         type = anything;
-        description = mdDoc ''
+        description = ''
           The cardano-parts system dependent default package for cardanoLibCustom.
 
           This is the same as the cardanoLib option with the exception that a
@@ -160,11 +161,12 @@
           The definition must be a function of iohk-nix input and system.
         '';
         default = iohk-nix: system: mkCardanoLib system iohk-nix;
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardanoLibNg = mkOption {
         type = anything;
-        description = mdDoc ''
+        description = ''
           The cardano-parts system dependent default package for cardanoLibNg.
 
           This is the same as the cardanoLib option with the exception that the
@@ -173,11 +175,12 @@
           The definition must be a function of system.
         '';
         default = system: mkCardanoLib system localFlake.inputs.iohk-nix-ng;
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardano-db-sync-pkgs = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-db-sync-pkgs attrset.
 
           Used in cardano-db-sync nixos related services, such as smash and
@@ -192,11 +195,12 @@
           cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLib system;
           schema = flake.config.flake.cardano-parts.pkgs.special.cardano-db-sync-schema;
         };
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardano-db-sync-pkgs-ng = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-db-sync-pkgs-ng attrset.
 
           This is the same as the cardano-db-sync-pkgs option with the exception that the
@@ -210,11 +214,12 @@
           cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLibNg system;
           schema = flake.config.flake.cardano-parts.pkgs.special.cardano-db-sync-schema-ng;
         };
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardano-db-sync-schema = mkOption {
         type = path;
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-db-sync-schema path.
 
           Used in cardano-db-sync to provide migration schema.
@@ -226,7 +231,7 @@
 
       cardano-db-sync-schema-ng = mkOption {
         type = path;
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-db-sync-schema-ng path.
 
           This is the same as the cardano-db-sync-schema option with the exception that the
@@ -237,7 +242,7 @@
 
       cardano-metadata-pkgs = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-metadata-pkgs attrset.
 
           The definition must be a function of system.
@@ -249,11 +254,12 @@
           metadata-webhook = withSystem system ({config, ...}: config.cardano-parts.pkgs.metadata-webhook);
           token-metadata-creator = withSystem system ({config, ...}: config.cardano-parts.pkgs.token-metadata-creator);
         };
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardano-node-pkgs = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-node-pkgs attrset.
 
           Used in cardano-node nixos service as an alternative to specifying
@@ -269,11 +275,12 @@
           cardano-tracer = withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-tracer);
           cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLib system;
         };
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardano-node-pkgs-ng = mkOption {
         type = functionTo (attrsOf anything);
-        description = mdDoc ''
+        description = ''
           The cardano-parts default cardano-node-pkgs-ng attrset.
 
           This is the same as the cardano-node-pkgs option with the exception that the
@@ -288,79 +295,80 @@
           cardano-tracer = withSystem system ({config, ...}: config.cardano-parts.pkgs.cardano-tracer-ng);
           cardanoLib = flake.config.flake.cardano-parts.pkgs.special.cardanoLibNg system;
         };
+        defaultText = lib.literalMD "*see source*";
       };
 
       cardano-db-sync-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-db-sync-service import path string.";
+        description = "The cardano-parts default cardano-db-sync-service import path string.";
         default = "${localFlake.inputs.cardano-db-sync-service}/nix/nixos/cardano-db-sync-service.nix";
       };
 
       cardano-db-sync-service-ng = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-db-sync-service-ng import path string.";
+        description = "The cardano-parts default cardano-db-sync-service-ng import path string.";
         default = "${localFlake.inputs.cardano-db-sync-service-ng}/nix/nixos/cardano-db-sync-service.nix";
       };
 
       # TODO: Module import fixup for local services
       cardano-faucet-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-faucet-service import path string.";
+        description = "The cardano-parts default cardano-faucet-service import path string.";
         # default = localFlake.nixosModules.service-cardano-faucet;
         default = "${localFlake}/flake/nixosModules/service-cardano-faucet.nix";
       };
 
       cardano-metadata-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-metadata-service import path string.";
+        description = "The cardano-parts default cardano-metadata-service import path string.";
         default = "${localFlake.inputs.cardano-metadata-service}/nix/nixos/default.nix";
       };
 
       cardano-node-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-node-service import path string.";
+        description = "The cardano-parts default cardano-node-service import path string.";
         default = "${localFlake.inputs.cardano-node-service}/nix/nixos/cardano-node-service.nix";
       };
 
       cardano-node-service-ng = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-node-service-ng import path string.";
+        description = "The cardano-parts default cardano-node-service-ng import path string.";
         default = "${localFlake.inputs.cardano-node-service-ng}/nix/nixos/cardano-node-service.nix";
       };
 
       cardano-ogmios-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-ogmios-service import path string.";
+        description = "The cardano-parts default cardano-ogmios-service import path string.";
         default = "${localFlake.inputs.cardano-ogmios-service}/nix/nixos";
       };
 
       cardano-smash-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-smash-service import path string.";
+        description = "The cardano-parts default cardano-smash-service import path string.";
         default = "${localFlake.inputs.cardano-db-sync-service}/nix/nixos/smash-service.nix";
       };
 
       cardano-submit-api-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-submit-api-service import path string.";
+        description = "The cardano-parts default cardano-submit-api-service import path string.";
         default = "${localFlake.inputs.cardano-submit-api-service}/nix/nixos/cardano-submit-api-service.nix";
       };
 
       cardano-submit-api-service-ng = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-submit-api-service-ng import path string.";
+        description = "The cardano-parts default cardano-submit-api-service-ng import path string.";
         default = "${localFlake.inputs.cardano-submit-api-service-ng}/nix/nixos/cardano-submit-api-service.nix";
       };
 
       cardano-tracer-service = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-tracer-service import path string.";
+        description = "The cardano-parts default cardano-tracer-service import path string.";
         default = "${localFlake.inputs.cardano-tracer-service}/nix/nixos/cardano-tracer-service.nix";
       };
 
       cardano-tracer-service-ng = mkOption {
         type = str;
-        description = mdDoc "The cardano-parts default cardano-tracer-service-ng import path string.";
+        description = "The cardano-parts default cardano-tracer-service-ng import path string.";
         default = "${localFlake.inputs.cardano-tracer-service-ng}/nix/nixos/cardano-tracer-service.nix";
       };
     };
@@ -386,8 +394,9 @@ in
         mkPkg = name: pkg: {
           ${name} = mkOption {
             type = package;
-            description = mdDoc "The cardano-parts default package for ${name}.";
+            description = "The cardano-parts default package for ${name}.";
             default = pkg;
+            defaultText = lib.literalMD "*see source*";
           };
         };
 
@@ -454,7 +463,7 @@ in
           options = {
             pkgs = mkOption {
               type = pkgsSubmodule;
-              description = mdDoc "Cardano-parts packages options";
+              description = "Cardano-parts packages options";
               default = {};
             };
           };

--- a/flakeModules/shell.nix
+++ b/flakeModules/shell.nix
@@ -83,13 +83,14 @@ in
           {
             defaultFormatterCheck = mkOption {
               type = globalType isGlobal package;
-              description = mdDoc "The cardano-parts default formatter check package.";
+              description = "The cardano-parts default formatter check package.";
               default = globalDefault isGlobal (treefmtEval.config.build.check flake.self);
+              defaultText = lib.literalMD "*see source*";
             };
 
             defaultFormatterCfg = mkOption {
               type = globalType isGlobal (attrsOf anything);
-              description = mdDoc "The cardano-parts default formatter config.";
+              description = "The cardano-parts default formatter config.";
               default = globalDefault isGlobal {
                 projectRootFile = "flake.nix";
                 programs.alejandra.enable = true;
@@ -99,33 +100,36 @@ in
 
             defaultFormatterHook = mkOption {
               type = globalType isGlobal str;
-              description = mdDoc "The cardano-parts default formatter hook.";
+              description = "The cardano-parts default formatter hook.";
               default = globalDefault isGlobal ''
                 if ${isPartsRepo}; then
                   ln -sf ${treefmtEval.config.build.configFile} treefmt.toml
                 fi
               '';
+              defaultText = lib.literalMD "*see source*";
             };
 
             defaultFormatterPkg = mkOption {
               type = globalType isGlobal package;
-              description = mdDoc "The cardano-parts default flake formatter package.";
+              description = "The cardano-parts default flake formatter package.";
               default = globalDefault isGlobal treefmtEval.config.build.wrapper;
+              defaultText = lib.literalMD "*see source*";
             };
 
             defaultHooks = mkOption {
               type = globalType isGlobal lines;
-              description = mdDoc "The cardano-parts default git and shell hooks.";
+              description = "The cardano-parts default git and shell hooks.";
               default = globalDefault isGlobal ''
                 if ${isPartsRepo} && [ -d .git/hooks ]; then
                   ln -sf ${getExe (withLocal ({config, ...}: config.packages.pre-push))} .git/hooks/
                 fi
               '';
+              defaultText = lib.literalMD "*see source*";
             };
 
             defaultLintPkg = mkOption {
               type = globalType isGlobal package;
-              description = mdDoc "The cardano-parts default lint package.";
+              description = "The cardano-parts default lint package.";
               default = globalDefault isGlobal (
                 pkgs.runCommand "lint" {
                   nativeBuildInputs = with pkgs; [
@@ -141,21 +145,23 @@ in
                   touch $out
                 ''
               );
+              defaultText = lib.literalMD "*see source*";
             };
 
             defaultVars = mkOption {
               type = globalType isGlobal attrs;
-              description = mdDoc "The cardano-parts default devShell env vars.";
+              description = "The cardano-parts default devShell env vars.";
               default = globalDefault isGlobal {
                 AWS_PROFILE = flakeCfg.cluster.infra.aws.profile;
                 AWS_REGION = flakeCfg.cluster.infra.aws.region;
                 KMS = flakeCfg.cluster.infra.aws.kms;
                 SSH_CONFIG_FILE = ".ssh_config";
               };
+              defaultText = lib.literalMD "*see source*";
             };
 
             defaultZshCompFpathLoading = mkOption {
-              description = mdDoc "The cardano-parts default zsh completion fpath loading hook.";
+              description = "The cardano-parts default zsh completion fpath loading hook.";
               default = globalDefault isGlobal (packages: ''
                   # Direnv use prevents the dynamic loading of zsh completions,
                   # requiring a zsh "reentry" upon arriving in the devShell.
@@ -194,47 +200,48 @@ in
                 echo
                 EOF
               '');
+              defaultText = lib.literalMD "*see source*";
             };
 
             enableFormatter = mkOption {
               type = globalType isGlobal bool;
-              description = mdDoc "Enable default cardano-parts formatter in the devShells.";
+              description = "Enable default cardano-parts formatter in the devShells.";
               default = globalDefault isGlobal true;
             };
 
             enableHooks = mkOption {
               type = globalType isGlobal bool;
-              description = mdDoc "Enable default cardano-parts git and shell hooks in the devShells.";
+              description = "Enable default cardano-parts git and shell hooks in the devShells.";
               default = globalDefault isGlobal true;
             };
 
             enableLint = mkOption {
               type = globalType isGlobal bool;
-              description = mdDoc "Enable default cardano-parts lint check in the devShells.";
+              description = "Enable default cardano-parts lint check in the devShells.";
               default = globalDefault isGlobal true;
             };
 
             enableVars = mkOption {
               type = globalType isGlobal bool;
-              description = mdDoc "Enable default cardano-parts env vars in the devShells.";
+              description = "Enable default cardano-parts env vars in the devShells.";
               default = globalDefault isGlobal true;
             };
 
             enableZshCompFpathLoading = mkOption {
               type = globalType isGlobal bool;
-              description = mdDoc "Enable default cardano-parts zsh completion loading into fpath in zsh devShells.";
+              description = "Enable default cardano-parts zsh completion loading into fpath in zsh devShells.";
               default = globalDefault isGlobal true;
             };
 
             extraPkgs = mkOption {
               type = listOf package;
-              description = mdDoc "Extra packages.";
+              description = "Extra packages.";
               default = [];
             };
 
             pkgs = mkOption {
               type = listOf package;
-              description = mdDoc "Packages.";
+              description = "Packages.";
               default = [];
             };
           }
@@ -259,7 +266,7 @@ in
           options = {
             shell = mkOption {
               type = shellSubmodule;
-              description = mdDoc "Cardano-parts shell options";
+              description = "Cardano-parts shell options";
               default = {};
             };
           };
@@ -271,11 +278,11 @@ in
             mkShellSubmodule {
               isGlobal = true;
               id = "global";
-              description = mdDoc "The cardano-parts devShell global configuration options.";
+              description = "The cardano-parts devShell global configuration options.";
               extraCfg = {
                 defaultShell = mkOption {
                   type = nullOr (enum definedIds);
-                  description = mdDoc "The cardano-parts devShell to set as default, if desired.";
+                  description = "The cardano-parts devShell to set as default, if desired.";
                   default = null;
                 };
 
@@ -288,7 +295,7 @@ in
             // (foldl' (acc: shellCfg: recursiveUpdate acc (mkShellSubmodule ({isGlobal = false;} // shellCfg))) {} [
               {
                 id = "min";
-                description = mdDoc "Minimal devShell";
+                description = "Minimal devShell";
                 extraCfg.pkgs = mkOption {
                   default = with pkgs; [
                     # Bash interactive needs to be included, otherwise, the
@@ -324,7 +331,7 @@ in
               }
               {
                 id = "test";
-                description = mdDoc "Testing devShell";
+                description = "Testing devShell";
                 extraCfg.pkgs = mkOption {
                   default =
                     config.cardano-parts.shell.min.pkgs
@@ -365,7 +372,7 @@ in
               }
               {
                 id = "ops";
-                description = mdDoc "Operations devShell";
+                description = "Operations devShell";
                 extraCfg.pkgs = mkOption {
                   default =
                     config.cardano-parts.shell.test.pkgs

--- a/perSystem/packages/module-docs.nix
+++ b/perSystem/packages/module-docs.nix
@@ -1,0 +1,438 @@
+# perSystem/packages/module-docs.nix
+{
+  inputs,
+  self,
+  lib,
+  ...
+}: {
+  perSystem = {
+    pkgs,
+    system,
+    ...
+  }: let
+    inherit (pkgs) nixosOptionsDoc runCommand writeText;
+
+    # ---------------------------------------------------------------------------
+    # NixOS module docs
+    # ---------------------------------------------------------------------------
+    # One shared nixosSystem eval. The real upstream service modules are imported
+    # directly; a small stub module provides cardano-parts-specific data and stubs
+    # for the metadata service (no upstream NixOS module imported).
+    # _module.check = false suppresses "option does not exist" errors from config
+    # sections that reference options not declared by any imported module.
+
+    # Genesis file stubs — modules that unconditionally call readFile on genesis
+    # files in their let-blocks get these toFile paths instead of real store paths.
+    byronGenesisStub = builtins.toFile "byron-genesis-stub.json" (builtins.toJSON {
+      protocolConsts.protocolMagic = 764824073;
+    });
+    shelleyGenesisStub = builtins.toFile "shelley-genesis-stub.json" (builtins.toJSON {
+      slotsPerKESPeriod = 129600;
+      systemStart = "2017-09-23T21:44:51Z";
+      epochLength = 432000;
+    });
+
+    # Shared cardanoLib stub used by both cardano-parts perNode.lib and
+    # services.cardano-node.cardanoNodePackages (the real upstream module).
+    cardanoLibStub = {
+      environments.mainnet = {
+        edgeNodes = [];
+        edgePort = 3001;
+        useLedgerAfterSlot = -1;
+        nodeConfig = {
+          ByronGenesisFile = byronGenesisStub;
+          ShelleyGenesisFile = shelleyGenesisStub;
+          MinNodeVersion = "10.6.0";
+          Protocol = "Cardano";
+        };
+        nodeConfigLegacy = {
+          ByronGenesisFile = byronGenesisStub;
+          ShelleyGenesisFile = shelleyGenesisStub;
+          MinNodeVersion = "10.0.0";
+          Protocol = "Cardano";
+        };
+        dbSyncConfig = {};
+      };
+      mkEdgeTopology = _: {};
+      mkEdgeTopologyP2P = _: {};
+    };
+
+    # cardanoNodePackages stub for the real upstream cardano-node-service.nix.
+    # That module's cardanoNodePackages option defaults to
+    # `pkgs.cardanoNodePackages or (import ../. {...}).cardanoNodePackages`;
+    # setting this value in config prevents the import from ever being evaluated.
+    cardanoNodePackagesStub = {
+      cardano-node = pkgs.hello;
+      cardano-tracer = pkgs.hello;
+      cardano-submit-api = pkgs.hello;
+      cardanoLib = cardanoLibStub;
+    };
+
+    nixosDocsEval = inputs.nixpkgs.lib.nixosSystem {
+      inherit system;
+      specialArgs = {
+        nodeResources = {
+          provider = "aws";
+          coreCount = 2;
+          cpuCount = 4;
+          memMiB = 8192;
+          nodeType = "m5ad.large";
+          threadsPerCore = 2;
+        };
+        # Colmena args used by several modules
+        nodes = {};
+        name = "docs-eval";
+        # profile-grafana-alloy requests `self` as a module arg
+        inherit self;
+      };
+      modules = [
+        # Real upstream service modules — replace the hand-rolled option stubs.
+        "${inputs.cardano-node-service}/nix/nixos/cardano-node-service.nix"
+        "${inputs.cardano-tracer-service}/nix/nixos/cardano-tracer-service.nix"
+        "${inputs.cardano-db-sync-service}/nix/nixos/cardano-db-sync-service.nix"
+        "${inputs.cardano-db-sync-service}/nix/nixos/smash-service.nix"
+        # --- Tier 1: no Colmena args, simple deps ---
+        self.nixosModules.module-aws-ec2
+        self.nixosModules.module-nginx-vhost-exporter
+        self.nixosModules.profile-aws-ec2-ephemeral
+        self.nixosModules.profile-cardano-postgres
+        # --- Tier 2: needs cardano-parts.perNode stubs ---
+        self.nixosModules.profile-cardano-node-topology
+        # --- Tier 2: cluster.group + opsLib stubs ---
+        self.nixosModules.profile-mithril-relay
+        self.nixosModules.profile-cardano-custom-metrics
+        self.nixosModules.profile-tcpdump
+        self.nixosModules.profile-blockperf
+        # profile-grafana-agent is legacy (replaced by alloy) — not documented
+        self.nixosModules.profile-grafana-alloy
+        # --- Tier 3: imports other cardano-parts nixosModules ---
+        self.nixosModules.profile-cardano-node-group
+        self.nixosModules.role-block-producer
+        self.nixosModules.profile-cardano-db-sync
+        self.nixosModules.profile-cardano-db-sync-snapshots
+        self.nixosModules.service-cardano-faucet
+        self.nixosModules.profile-cardano-faucet
+        self.nixosModules.profile-cardano-webserver
+        self.nixosModules.profile-cardano-smash
+        self.nixosModules.profile-cardano-metadata
+
+        # Stub module — cardano-parts-specific data + metadata service stubs
+        ({
+          lib,
+          pkgs,
+          ...
+        }: {
+          options = {
+            # profile-cardano-node-topology deps (and others using perNode)
+            cardano-parts = lib.mkOption {
+              type = lib.types.anything;
+              default = {
+                cluster.group = {
+                  # groupName and groupFlake used by blockperf, tcpdump, grafana-agent, grafana-alloy
+                  groupName = "docs-group";
+                  groupFlake.self.outPath = "/dev/null";
+                  meta = {
+                    environmentName = "mainnet";
+                    # domain used by service-cardano-faucet, profile-cardano-webserver,
+                    # profile-cardano-smash, profile-cardano-metadata
+                    domain = "example.com";
+                  };
+                };
+                perNode = {
+                  lib = {
+                    cardanoLib = cardanoLibStub;
+                    topologyLib = {
+                      topoList = _: [];
+                      topoInfixFiltered = _: [];
+                      topoSimple = _: [];
+                      topoSimpleMax = _: [];
+                      p2pEdgeNodes = _: [];
+                    };
+                  };
+                  # Prometheus port / address metadata used by grafana-agent, grafana-alloy, custom-metrics
+                  meta = {
+                    cardanoDbSyncPrometheusExporterPort = 8080;
+                    cardanoNodePrometheusExporterPort = 12798;
+                    cardanoNodePort = 3001;
+                    hostAddr = "0.0.0.0";
+                    # hostAddrIpv6 used by profile-cardano-node-group
+                    hostAddrIpv6 = "::";
+                    # nodeId used by profile-cardano-node-group
+                    nodeId = 0;
+                    # cardanoSmashDelistedPools used by profile-cardano-smash
+                    cardanoSmashDelistedPools = [];
+                  };
+                  # Package stubs used by various modules
+                  pkgs = {
+                    blockperf = pkgs.hello;
+                    cardano-cli = pkgs.hello;
+                    cardano-node = pkgs.hello;
+                    cardano-node-pkgs = cardanoNodePackagesStub;
+                    cardano-tracer = pkgs.hello;
+                    mithril-client-cli = pkgs.hello;
+                    mithril-signer = pkgs.hello;
+                    cardano-db-sync = pkgs.hello;
+                    cardano-db-sync-pkgs = {};
+                    cardano-db-tool = pkgs.hello;
+                    cardano-faucet = pkgs.hello;
+                    cardano-smash = pkgs.hello;
+                    cardano-metadata-pkgs = {
+                      metadata-server = pkgs.hello;
+                      metadata-sync = pkgs.hello;
+                      metadata-webhook = pkgs.hello;
+                    };
+                  };
+                  # roles used by role-block-producer
+                  roles.isCardanoDensePool = false;
+                };
+              };
+            };
+
+            # metadata service stubs for profile-cardano-metadata config section
+            # (no upstream NixOS module imported for the metadata service)
+            services = {
+              metadata-server = lib.mkOption {
+                type = lib.types.anything;
+                default = {
+                  user = "metadata";
+                  postgres = {
+                    database = "metadata";
+                    user = "metadata";
+                    socketdir = "/run/postgresql";
+                    port = 5432;
+                    table = "";
+                    numConnections = 4;
+                  };
+                };
+              };
+              metadata-webhook = lib.mkOption {
+                type = lib.types.anything;
+                default.user = "metadata-webhook";
+              };
+              metadata-sync = lib.mkOption {
+                type = lib.types.anything;
+                default.user = "metadata-sync";
+              };
+            };
+
+            # sops stub: profile-tcpdump's environmentFile default reads
+            # config.sops.secrets.tcpdump.path when useSopsSecrets = true
+            sops = lib.mkOption {
+              type = lib.types.anything;
+              default = {
+                secrets.tcpdump.path = "/run/secrets/tcpdump";
+              };
+            };
+          };
+
+          config = {
+            _module.check = false;
+            system.stateVersion = "24.11";
+            fileSystems."/" = {
+              device = "/dev/null";
+              fsType = "tmpfs";
+            };
+            boot.loader.grub.device = "nodev";
+            networking.hostName = "docs-eval";
+            # profile-blockperf.enable defaults to true; its config section calls
+            # mkSopsSecret with keyName = cfg.clientCert/clientKey/amazonCa which
+            # default to null, causing "cannot coerce null to a string".
+            # Setting enable = false skips the config body, leaving option docs intact.
+            # module-aws-ec2 declares aws.{instance,region,route53} with no defaults
+            aws = {
+              instance = {
+                instance_type = "m5.large";
+                count = 1;
+              };
+              region = "eu-central-1";
+            };
+            services = {
+              # profile-blockperf.enable defaults to true; its config section calls
+              # mkSopsSecret with keyName = cfg.clientCert/clientKey/amazonCa which
+              # default to null, causing "cannot coerce null to a string".
+              # Setting enable = false skips the config body, leaving option docs intact.
+              blockperf.enable = false;
+              # profile-tcpdump.environmentFile default accesses config.sops.secrets.tcpdump.path
+              # when useSopsSecrets = true, but the anything-type sops stub doesn't reliably
+              # preserve the `path` attribute through the merge with mkSopsSecret's output.
+              # Disabling useSopsSecrets makes the default evaluate to null instead.
+              tcpdump.useSopsSecrets = false;
+              cardano-node = {
+                # role-block-producer: disable sops secrets to avoid mkSopsSecret with
+                # real paths that don't exist under /dev/null/secrets/...
+                useSopsSecrets = false;
+                # Provide cardanoNodePackages so the upstream module's default
+                # `pkgs.cardanoNodePackages or (import ../. {...}).cardanoNodePackages`
+                # is never evaluated.
+                cardanoNodePackages = cardanoNodePackagesStub;
+              };
+              # profile-cardano-db-sync-snapshots: same reason
+              cardano-db-sync-snapshots.useSopsSecrets = false;
+              # profile-cardano-metadata: same reason
+              cardano-metadata.useSopsSecrets = false;
+              # profile-cardano-webserver: vhostsDir default is
+              # "${groupFlake.self.outPath}/static" = "/dev/null/static" which doesn't
+              # exist as a directory.  Point to this file's own directory (perSystem/packages)
+              # which has only .nix files — no "directory" or "symlink" entries →
+              # vhostsDirList = [] → no nginx vhosts crash.
+              cardano-webserver.vhostsDir = toString ./.;
+            };
+          };
+        })
+      ];
+    };
+
+    # Option namespaces defined by cardano-parts NixOS modules.
+    # Extend this list as more modules are added.
+    cardanoPartsPrefixes = [
+      # Tier 1
+      "aws."
+      "services.nginx-vhost-exporter."
+      "services.aws.ec2.ephemeral."
+      "services.cardano-postgres."
+      # Tier 2
+      "services.cardano-node-topology."
+      "services.mithril-relay."
+      "services.cardano-custom-metrics."
+      "services.tcpdump."
+      "services.blockperf."
+      # services.grafana-agent is legacy; not documented
+      "services.alloy."
+      # Tier 3 — profile-cardano-node-group adds sub-options to services.cardano-node
+      # and declares the services.mithril-client namespace
+      "services.cardano-node.totalCpuCount"
+      "services.cardano-node.totalMaxHeapSizeMiB"
+      "services.cardano-node.shareNodeSocket"
+      "services.mithril-client."
+      # Tier 3 — role-block-producer adds a sub-option to services.cardano-node
+      # and declares the services.mithril-signer namespace
+      "services.cardano-node.useSopsSecrets"
+      "services.mithril-signer."
+      # Tier 3 — profile-cardano-db-sync adds sub-options to services.cardano-db-sync
+      "services.cardano-db-sync.additionalDbUsers"
+      "services.cardano-db-sync.nodeRamAvailableMiB"
+      "services.cardano-db-sync.postgresRamAvailableMiB"
+      # Tier 3 — dedicated namespaces
+      "services.cardano-db-sync-snapshots."
+      "services.cardano-faucet."
+      "services.cardano-webserver."
+      "services.cardano-smash."
+      "services.cardano-metadata."
+    ];
+
+    isDocumented = name:
+      builtins.any (prefix: lib.hasPrefix prefix name) cardanoPartsPrefixes;
+
+    nixosDoc = nixosOptionsDoc {
+      inherit (nixosDocsEval) options;
+      transformOptions = opt:
+        if isDocumented opt.name
+        then opt // {declarations = [];}
+        else
+          opt
+          // {
+            visible = false;
+            internal = true;
+          };
+      warningsAreErrors = false;
+    };
+
+    # ---------------------------------------------------------------------------
+    # Flake module docs
+    # ---------------------------------------------------------------------------
+    # Build a standalone evalModules with only the four cardano-parts flake
+    # modules. This avoids touching flake-parts internals (which would trigger
+    # perSystem package evaluation without a system context).
+    #
+    # In flake-parts, topLevel.options.flake is a single option OBJECT (not a
+    # nested attrset), so `topLevel.options.flake.cardano-parts` does not exist
+    # directly. In a plain lib.evalModules, options ARE a nested attrset, so
+    # `flakeDocEval.options.flake.cardano-parts` works correctly.
+    #
+    # Stubs:
+    #   withSystem = _: _: null   -- cluster.nix/pkgs.nix; every default that
+    #                                calls withSystem has defaultText, so the
+    #                                stub function is never actually invoked
+    #   flake-parts-lib.mkPerSystemOption -- pkgs.nix uses this; stub returns an
+    #                                        anything-typed option (not doc'd here)
+    #   flake.nixosModules = {}   -- cluster.nix `addressType` default checks
+    #                                `flake.config.flake.nixosModules ? ips`
+    # Note: self.flakeModules.pkgs is a set (importApply already applied
+    # localFlake = self); used directly without re-applying localFlake.
+    flakeDocEval = inputs.nixpkgs.lib.evalModules {
+      specialArgs = {
+        withSystem = _: _: null;
+        flake-parts-lib = {
+          mkPerSystemOption = _:
+            lib.mkOption {
+              type = lib.types.anything;
+              default = {};
+            };
+        };
+      };
+      modules = [
+        ({lib, ...}: {
+          config._module.check = false;
+          options.flake.nixosModules = lib.mkOption {
+            type = lib.types.anything;
+            default = {};
+          };
+        })
+        self.flakeModules.cluster
+        self.flakeModules.pkgs
+        self.flakeModules.lib
+        self.flakeModules.aws
+      ];
+    };
+
+    flakeCardanoPartsSubOpts = flakeDocEval.options.flake.cardano-parts.type.getSubOptions ["flake" "cardano-parts"];
+
+    flakeDoc = nixosOptionsDoc {
+      options = {
+        "flake.cardano-parts" = flakeCardanoPartsSubOpts;
+      };
+      transformOptions = opt:
+        opt
+        // {declarations = [];}
+        // lib.optionalAttrs (!(opt ? defaultText)) {defaultText = lib.literalMD "*see source*";};
+      warningsAreErrors = false;
+    };
+
+    # ---------------------------------------------------------------------------
+    # Headers
+    # ---------------------------------------------------------------------------
+    flakeHeader = writeText "flake-header.md" ''
+      # Flake Module Options
+
+      Options defined by cardano-parts flakeModules, configured in the
+      consuming repository's flake-parts modules.
+
+    '';
+
+    nixosHeader = writeText "nixos-header.md" ''
+      # NixOS Module Options
+
+      Options defined by cardano-parts NixOS modules, configured
+      per-machine in NixOS configurations.
+
+    '';
+  in {
+    packages = {
+      module-docs-nixos = runCommand "module-docs-nixos" {} ''
+        mkdir -p $out
+        cat ${nixosHeader} ${nixosDoc.optionsCommonMark} > $out/nixos-options.md
+      '';
+
+      module-docs-flake = runCommand "module-docs-flake" {} ''
+        mkdir -p $out
+        cat ${flakeHeader} ${flakeDoc.optionsCommonMark} > $out/flake-options.md
+      '';
+
+      module-docs = runCommand "module-docs" {} ''
+        mkdir -p $out
+        cat ${nixosHeader} ${nixosDoc.optionsCommonMark} > $out/nixos-options.md
+        cat ${flakeHeader} ${flakeDoc.optionsCommonMark} > $out/flake-options.md
+      '';
+    };
+  };
+}


### PR DESCRIPTION
Adds `perSystem/packages/module-docs.nix` which builds `nixosOptionsDoc`-based Markdown for all cardano-parts options:

  nix build .#module-docs-nixos   # NixOS module options
  nix build .#module-docs-flake   # flake module options
  nix build .#module-docs         # both combined

NixOS modules (Tier 1-3 fully documented):
- profile-cardano-node-topology, module-nginx-vhost-exporter, profile-aws-ec2-ephemeral, profile-cardano-postgres, profile-mithril-relay, profile-cardano-custom-metrics, profile-tcpdump, profile-blockperf, profile-grafana-alloy, profile-cardano-node-group, role-block-producer, profile-cardano-db-sync, profile-cardano-db-sync-snapshots, profile-cardano-webserver, profile-cardano-faucet, profile-cardano-metadata, profile-cardano-smash, service-cardano-faucet

Flake modules (all four namespaces documented):
- flake.cardano-parts.cluster, flake.cardano-parts.pkgs, flake.cardano-parts.lib, flake.cardano-parts.aws

Flake docs use a standalone lib.evalModules with only the four cardano-parts flake modules rather than the full flake-parts eval (which would trigger perSystem package evaluation without a system context, causing a "process-compose option has no value" error). All complex defaults in flakeModules get defaultText to prevent stack overflow in generators.toPretty (the self-referential groupFlake = flake default was the original trigger).

Supporting changes:
- flakeModules/cluster.nix: add defaultText to all complex defaults; allow null in optionCheck; fix conditional kms/bucketName defaults; fix groupMeta.domain type to nullOr str
- flakeModules/pkgs.nix: add defaultText to mkPkg helper and all special function options
- flakeModules/shell.nix: add defaultText to complex shell defaults
- flakeModules/aws.nix: add defaultText with literalExpression to rawSpec and spec options
- flake/nixosModules/profile-cardano-parts.nix: drop deprecated lib.mdDoc wrappers (plain strings are now implicit Markdown)