### PR TITLE
Node 10.6.4, Dbsync 13.6.0.8/13.7.0.2, zfs ARC cache

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1775686001,
-        "narHash": "sha256-k0OYXR/I8lm0c9k2kzmmoXVVlAkBpi5IekLfmtt4iOQ=",
+        "lastModified": 1775853349,
+        "narHash": "sha256-YLRcOZL1e0sy047jcmmbiVP+S/1IZ1NGAeKXxTtHM4g=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "00cbd5d683eac63f66a70b7fb336b09a4fbd6f82",
+        "rev": "e2278cddb37c4863e95e58c4a6b6ef08e824d6a4",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1774412398,
-        "narHash": "sha256-oimh+P7vHgf2gunCt/w96R6rwmtxHmlToP0EZxlczS8=",
+        "lastModified": 1775070525,
+        "narHash": "sha256-JEYS+aa/SD+WJmmQqFc5EjIi9oK/57D4rOnu1NezLqA=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "6ae1c9b2e1d7c079efde344cde496e742e7f612e",
+        "rev": "3814de4b0610c9d3077aabe1ee7bf42e9b218b8b",
         "type": "github"
       },
       "original": {
@@ -181,16 +181,16 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1770822424,
-        "narHash": "sha256-zyrBw3yn69y3n0c6U0MDvezYC3GHbjJ3yJmhM4vMtUk=",
+        "lastModified": 1774886169,
+        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0d697f14ee10a775f08c60e3839becc9131dca75",
+        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.2",
+        "ref": "10.6.3",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -232,16 +232,16 @@
     "cardano-submit-api-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1770822424,
-        "narHash": "sha256-zyrBw3yn69y3n0c6U0MDvezYC3GHbjJ3yJmhM4vMtUk=",
+        "lastModified": 1774886169,
+        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0d697f14ee10a775f08c60e3839becc9131dca75",
+        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.2",
+        "ref": "10.6.3",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -266,16 +266,16 @@
     "cardano-tracer-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1770822424,
-        "narHash": "sha256-zyrBw3yn69y3n0c6U0MDvezYC3GHbjJ3yJmhM4vMtUk=",
+        "lastModified": 1774886169,
+        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "0d697f14ee10a775f08c60e3839becc9131dca75",
+        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.2",
+        "ref": "10.6.3",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1775070525,
-        "narHash": "sha256-JEYS+aa/SD+WJmmQqFc5EjIi9oK/57D4rOnu1NezLqA=",
+        "lastModified": 1775686001,
+        "narHash": "sha256-k0OYXR/I8lm0c9k2kzmmoXVVlAkBpi5IekLfmtt4iOQ=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "3814de4b0610c9d3077aabe1ee7bf42e9b218b8b",
+        "rev": "00cbd5d683eac63f66a70b7fb336b09a4fbd6f82",
         "type": "github"
       },
       "original": {
@@ -96,16 +96,16 @@
     "cardano-db-sync-schema": {
       "flake": false,
       "locked": {
-        "lastModified": 1774307814,
-        "narHash": "sha256-9qxk1wJNJV8XufuQsUL9drEYZ4DXUotd4dcQLcEmmQw=",
+        "lastModified": 1775295721,
+        "narHash": "sha256-oI4+/xzOxwKUO4EgfGQjqe3/skpV9P1QuAnDFi7ztxk=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "39c66dbebb3f303da2a3a716a61e187fa91f097e",
+        "rev": "2017bdaa25a01ce0e5e3838fab28cf0710ad14aa",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.6.0.7",
+        "ref": "13.6.0.8",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -113,16 +113,16 @@
     "cardano-db-sync-schema-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1771212271,
-        "narHash": "sha256-9wrlypHCKjC6biJa0Ip2Mfwvfm7Uc3Ex6GUZQa1Tstk=",
+        "lastModified": 1774635451,
+        "narHash": "sha256-mnaBzFHOcBJKF4e4zyDxFiBvzE2lWtrNqmg7rw+FYU8=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "3c8724b10ccea570bec282633d15e71160aa8344",
+        "rev": "0acc69f273488abe06a717999260811d2c6a83a6",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.7.0.1",
+        "ref": "13.7.0.2",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -130,16 +130,16 @@
     "cardano-db-sync-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1742316958,
-        "narHash": "sha256-8dADl0Y5mu8rHGADDC56KYV/kQlDFITTpgRiSTHwUc8=",
+        "lastModified": 1775295721,
+        "narHash": "sha256-oI4+/xzOxwKUO4EgfGQjqe3/skpV9P1QuAnDFi7ztxk=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "cb61094c82254464fc9de777225e04d154d9c782",
+        "rev": "2017bdaa25a01ce0e5e3838fab28cf0710ad14aa",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.6.0.5",
+        "ref": "13.6.0.8",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -147,16 +147,16 @@
     "cardano-db-sync-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1771212271,
-        "narHash": "sha256-9wrlypHCKjC6biJa0Ip2Mfwvfm7Uc3Ex6GUZQa1Tstk=",
+        "lastModified": 1774635451,
+        "narHash": "sha256-mnaBzFHOcBJKF4e4zyDxFiBvzE2lWtrNqmg7rw+FYU8=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "3c8724b10ccea570bec282633d15e71160aa8344",
+        "rev": "0acc69f273488abe06a717999260811d2c6a83a6",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.7.0.1",
+        "ref": "13.7.0.2",
         "repo": "cardano-db-sync",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -549,11 +549,11 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1770968833,
-        "narHash": "sha256-Q4zfM7aGr7FnhV0UAu0hCS+bG3I/U1YAVRJY+ep8a1I=",
+        "lastModified": 1775592560,
+        "narHash": "sha256-DEAAkrgoLARJyn+9/rnAjaZDRmJR6gbQQSoSTiBTn80=",
         "owner": "nixos",
         "repo": "nix",
-        "rev": "eef8a1a5ff03aad775ec4df66ff98e980cc458bc",
+        "rev": "9fe879916bc47e620773003a553e767f35a71a55",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -181,16 +181,16 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1774886169,
-        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
+        "lastModified": 1775833532,
+        "narHash": "sha256-V5NYiZb0JZPWcxE0ndnd7BOK1zvauUYDE/6DwIIVQ4M=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
+        "rev": "5a4dcd1b410ba78f9faab7acd48f606496909935",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.3",
+        "ref": "10.6.4",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -232,16 +232,16 @@
     "cardano-submit-api-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1774886169,
-        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
+        "lastModified": 1775833532,
+        "narHash": "sha256-V5NYiZb0JZPWcxE0ndnd7BOK1zvauUYDE/6DwIIVQ4M=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
+        "rev": "5a4dcd1b410ba78f9faab7acd48f606496909935",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.3",
+        "ref": "10.6.4",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -266,16 +266,16 @@
     "cardano-tracer-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1774886169,
-        "narHash": "sha256-TQHJmtgV33DhEeiOLokDS7BGTUX/4wdQt9DIP62SEuw=",
+        "lastModified": 1775833532,
+        "narHash": "sha256-V5NYiZb0JZPWcxE0ndnd7BOK1zvauUYDE/6DwIIVQ4M=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "e252edef4dfcd28ba8987e0c1368c6db0404beac",
+        "rev": "5a4dcd1b410ba78f9faab7acd48f606496909935",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.3",
+        "ref": "10.6.4",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
     };
 
     cardano-node-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.3";
+      url = "github:IntersectMBO/cardano-node/10.6.4";
       flake = false;
     };
 
@@ -119,7 +119,7 @@
     };
 
     cardano-submit-api-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.3";
+      url = "github:IntersectMBO/cardano-node/10.6.4";
       flake = false;
     };
 
@@ -129,7 +129,7 @@
     };
 
     cardano-tracer-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.3";
+      url = "github:IntersectMBO/cardano-node/10.6.4";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,12 +70,12 @@
     # versioning of the release and pre-release (-ng) dbsync
     # definitions found in flakeModule/pkgs.nix.
     cardano-db-sync-schema = {
-      url = "github:IntersectMBO/cardano-db-sync/13.6.0.7";
+      url = "github:IntersectMBO/cardano-db-sync/13.6.0.8";
       flake = false;
     };
 
     cardano-db-sync-schema-ng = {
-      url = "github:IntersectMBO/cardano-db-sync/13.7.0.1";
+      url = "github:IntersectMBO/cardano-db-sync/13.7.0.2";
       flake = false;
     };
 
@@ -84,12 +84,12 @@
     # flakeModule options and do not necessarily reflect the software
     # versions running on those nixos services.
     cardano-db-sync-service = {
-      url = "github:IntersectMBO/cardano-db-sync/13.6.0.5";
+      url = "github:IntersectMBO/cardano-db-sync/13.6.0.8";
       flake = false;
     };
 
     cardano-db-sync-service-ng = {
-      url = "github:IntersectMBO/cardano-db-sync/13.7.0.1";
+      url = "github:IntersectMBO/cardano-db-sync/13.7.0.2";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -94,7 +94,7 @@
     };
 
     cardano-node-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.2";
+      url = "github:IntersectMBO/cardano-node/10.6.3";
       flake = false;
     };
 
@@ -119,7 +119,7 @@
     };
 
     cardano-submit-api-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.2";
+      url = "github:IntersectMBO/cardano-node/10.6.3";
       flake = false;
     };
 
@@ -129,7 +129,7 @@
     };
 
     cardano-tracer-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.2";
+      url = "github:IntersectMBO/cardano-node/10.6.3";
       flake = false;
     };
 

--- a/flake/nixosModules/profile-aws-ec2-ephemeral.nix
+++ b/flake/nixosModules/profile-aws-ec2-ephemeral.nix
@@ -157,7 +157,7 @@
           if (config.services ? cardano-node && config.services.cardano-node.enable)
           then ''
             mkdir -p ${cfg.mountPoint}/cardano-node
-            chown -R cardano-node:cardano-node ${cfg.mountPoint}/cardano-node
+            chown -R cardano-node:cardano-node ${cfg.mountPoint}/cardano-node || true
           ''
           else ''
             echo "Cardano node module not detected, exiting."

--- a/flakeModules/aws/ec2-spec.json
+++ b/flakeModules/aws/ec2-spec.json
@@ -1893,6 +1893,138 @@
       }
     },
     {
+      "InstanceType": "c8a.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.large",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 2048
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8a.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
       "InstanceType": "c8g.12xlarge",
       "MemoryInfo": {
         "SizeInMiB": 98304
@@ -2022,6 +2154,611 @@
         "DefaultVCpus": 4,
         "DefaultCores": 4,
         "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.large",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 2048
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gd.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.large",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 2048
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8gn.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.large",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i-flex.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.large",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8i.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.large",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "c8id.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
       }
     },
     {
@@ -2208,6 +2945,39 @@
       "VCpuInfo": {
         "DefaultVCpus": 16,
         "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "f2.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "f2.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 2097152
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "f2.6xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 24,
+        "DefaultCores": 12,
         "DefaultThreadsPerCore": 2
       }
     },
@@ -2674,6 +3444,50 @@
       }
     },
     {
+      "InstanceType": "g6f.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "g6f.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "g6f.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "g6f.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
       "InstanceType": "gr6.4xlarge",
       "MemoryInfo": {
         "SizeInMiB": 131072
@@ -2692,6 +3506,17 @@
       "VCpuInfo": {
         "DefaultVCpus": 32,
         "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "gr6f.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
         "DefaultThreadsPerCore": 2
       }
     },
@@ -2791,17 +3616,6 @@
       "VCpuInfo": {
         "DefaultVCpus": 2,
         "DefaultCores": 1,
-        "DefaultThreadsPerCore": 2
-      }
-    },
-    {
-      "InstanceType": "i3.metal",
-      "MemoryInfo": {
-        "SizeInMiB": 524288
-      },
-      "VCpuInfo": {
-        "DefaultVCpus": 72,
-        "DefaultCores": 36,
         "DefaultThreadsPerCore": 2
       }
     },
@@ -3015,6 +3829,127 @@
       }
     },
     {
+      "InstanceType": "i7i.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7i.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
       "InstanceType": "i7ie.12xlarge",
       "MemoryInfo": {
         "SizeInMiB": 393216
@@ -3099,6 +4034,28 @@
       "VCpuInfo": {
         "DefaultVCpus": 2,
         "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7ie.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "i7ie.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
         "DefaultThreadsPerCore": 2
       }
     },
@@ -3202,7 +4159,139 @@
       }
     },
     {
+      "InstanceType": "i8g.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
       "InstanceType": "i8g.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.18xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 589824
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 72,
+        "DefaultCores": 72,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.3xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 12,
+        "DefaultCores": 12,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.6xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 24,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "i8ge.xlarge",
       "MemoryInfo": {
         "SizeInMiB": 32768
       },
@@ -5479,6 +6568,237 @@
       }
     },
     {
+      "InstanceType": "m8a.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8a.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.3xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 49152
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 12,
+        "DefaultCores": 12,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.6xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 98304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 24,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.metal-12xl",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8azn.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
       "InstanceType": "m8g.12xlarge",
       "MemoryInfo": {
         "SizeInMiB": 196608
@@ -5611,6 +6931,512 @@
       }
     },
     {
+      "InstanceType": "m8gd.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 4096
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8gd.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i-flex.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8i.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 196608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.large",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "m8id.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "mac-m4.metal",
+      "MemoryInfo": {
+        "SizeInMiB": 24576
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 10,
+        "DefaultCores": 10,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
       "InstanceType": "mac1.metal",
       "MemoryInfo": {
         "SizeInMiB": 32768
@@ -5630,39 +7456,6 @@
         "DefaultVCpus": 8,
         "DefaultCores": 8,
         "DefaultThreadsPerCore": 1
-      }
-    },
-    {
-      "InstanceType": "p2.16xlarge",
-      "MemoryInfo": {
-        "SizeInMiB": 749568
-      },
-      "VCpuInfo": {
-        "DefaultVCpus": 64,
-        "DefaultCores": 32,
-        "DefaultThreadsPerCore": 2
-      }
-    },
-    {
-      "InstanceType": "p2.8xlarge",
-      "MemoryInfo": {
-        "SizeInMiB": 499712
-      },
-      "VCpuInfo": {
-        "DefaultVCpus": 32,
-        "DefaultCores": 16,
-        "DefaultThreadsPerCore": 2
-      }
-    },
-    {
-      "InstanceType": "p2.xlarge",
-      "MemoryInfo": {
-        "SizeInMiB": 62464
-      },
-      "VCpuInfo": {
-        "DefaultVCpus": 4,
-        "DefaultCores": 2,
-        "DefaultThreadsPerCore": 2
       }
     },
     {
@@ -5700,6 +7493,17 @@
     },
     {
       "InstanceType": "p4d.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1179648
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "p4de.24xlarge",
       "MemoryInfo": {
         "SizeInMiB": 1179648
       },
@@ -7822,6 +9626,138 @@
       }
     },
     {
+      "InstanceType": "r8a.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8a.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
       "InstanceType": "r8g.12xlarge",
       "MemoryInfo": {
         "SizeInMiB": 393216
@@ -7951,6 +9887,501 @@
         "DefaultVCpus": 4,
         "DefaultCores": 4,
         "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.medium",
+      "MemoryInfo": {
+        "SizeInMiB": 8192
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 1,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.metal-24xl",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8gd.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i-flex.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1048576
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 3145728
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 3145728
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8i.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 393216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1048576
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 3145728
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.large",
+      "MemoryInfo": {
+        "SizeInMiB": 16384
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 3145728
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "r8id.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
       }
     },
     {
@@ -8262,28 +10693,6 @@
       }
     },
     {
-      "InstanceType": "u-12tb1.112xlarge",
-      "MemoryInfo": {
-        "SizeInMiB": 12582912
-      },
-      "VCpuInfo": {
-        "DefaultVCpus": 448,
-        "DefaultCores": 224,
-        "DefaultThreadsPerCore": 2
-      }
-    },
-    {
-      "InstanceType": "u-18tb1.112xlarge",
-      "MemoryInfo": {
-        "SizeInMiB": 18874368
-      },
-      "VCpuInfo": {
-        "DefaultVCpus": 448,
-        "DefaultCores": 224,
-        "DefaultThreadsPerCore": 2
-      }
-    },
-    {
       "InstanceType": "u-3tb1.56xlarge",
       "MemoryInfo": {
         "SizeInMiB": 3145728
@@ -8317,13 +10726,57 @@
       }
     },
     {
-      "InstanceType": "u-9tb1.112xlarge",
+      "InstanceType": "u7i-12tb.224xlarge",
       "MemoryInfo": {
-        "SizeInMiB": 9437184
+        "SizeInMiB": 12582912
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 896,
+        "DefaultCores": 448,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "u7i-6tb.112xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 6291456
       },
       "VCpuInfo": {
         "DefaultVCpus": 448,
         "DefaultCores": 224,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "u7i-8tb.112xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 8388608
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 448,
+        "DefaultCores": 224,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "u7in-16tb.224xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 16777216
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 896,
+        "DefaultCores": 448,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "u7in-24tb.224xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 25165824
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 896,
+        "DefaultCores": 448,
         "DefaultThreadsPerCore": 2
       }
     },
@@ -8677,6 +11130,160 @@
         "DefaultVCpus": 4,
         "DefaultCores": 4,
         "DefaultThreadsPerCore": 1
+      }
+    },
+    {
+      "InstanceType": "x8i.12xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 786432
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 48,
+        "DefaultCores": 24,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.16xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1048576
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 64,
+        "DefaultCores": 32,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.24xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 1572864
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 96,
+        "DefaultCores": 48,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.2xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 131072
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 8,
+        "DefaultCores": 4,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.32xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 2097152
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 128,
+        "DefaultCores": 64,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.48xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 3145728
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.4xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 262144
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 16,
+        "DefaultCores": 8,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.64xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 4194304
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 256,
+        "DefaultCores": 128,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.8xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 524288
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 32,
+        "DefaultCores": 16,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.96xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 6291456
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.large",
+      "MemoryInfo": {
+        "SizeInMiB": 32768
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 2,
+        "DefaultCores": 1,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.metal-48xl",
+      "MemoryInfo": {
+        "SizeInMiB": 3145728
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 192,
+        "DefaultCores": 96,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.metal-96xl",
+      "MemoryInfo": {
+        "SizeInMiB": 6291456
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 384,
+        "DefaultCores": 192,
+        "DefaultThreadsPerCore": 2
+      }
+    },
+    {
+      "InstanceType": "x8i.xlarge",
+      "MemoryInfo": {
+        "SizeInMiB": 65536
+      },
+      "VCpuInfo": {
+        "DefaultVCpus": 4,
+        "DefaultCores": 2,
+        "DefaultThreadsPerCore": 2
       }
     },
     {

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -465,8 +465,8 @@ in
           blockperf = caPkgs.blockperf-cardano-foundation-blockperf-main-626ad7b;
 
           credential-manager-release = "IntersectMBO-credential-manager-0-1-5-0-ba221bd";
-          dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-7-39c66db";
-          dbsync-pre-release = "input-output-hk-cardano-db-sync-13-7-0-1-3c8724b";
+          dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-8-2017bda";
+          dbsync-pre-release = "input-output-hk-cardano-db-sync-13-7-0-2-0acc69f";
 
           faucet = caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-6-762bb26";
           # faucet = localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet";

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -480,7 +480,7 @@ in
           # mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
           mithril-pre-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
 
-          node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-3-e252ede";
+          node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-4-5a4dcd1";
           # node-release = pkg: localFlake.inputs.cardano-node-10-6-3.packages.x86_64-linux.${pkg};
 
           node-pre-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-0-1e6d822";
@@ -500,7 +500,7 @@ in
               (mkPkg "cardano-db-tool-ng" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-pre-release}")
               (mkPkg "cardano-faucet" faucet)
               (mkPkg "cardano-faucet-ng" faucet-ng)
-              (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.6.3";}))
+              (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.6.4";}))
               (mkPkg "cardano-node-ng" ((node-pre-release "cardano-node") // {version = "10.7.0";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-14-0-5752501)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-34-0-4108dd3)

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -476,10 +476,10 @@ in
 
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
-          mithril-pre-release = "input-output-hk-mithril-unstable-7127c11";
+          mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
 
-          node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-2-0d697f1";
-          # node-release = pkg: localFlake.inputs.cardano-node-10-5-4.packages.x86_64-linux.${pkg};
+          node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-3-e252ede";
+          # node-release = pkg: localFlake.inputs.cardano-node-10-6-3.packages.x86_64-linux.${pkg};
 
           node-pre-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-0-1e6d822";
           # node-pre-release = pkg: localFlake.inputs.cardano-node-10-7-0.packages.x86_64-linux.${pkg};
@@ -498,7 +498,7 @@ in
               (mkPkg "cardano-db-tool-ng" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-pre-release}")
               (mkPkg "cardano-faucet" faucet)
               (mkPkg "cardano-faucet-ng" faucet-ng)
-              (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.6.2";}))
+              (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.6.3";}))
               (mkPkg "cardano-node-ng" ((node-pre-release "cardano-node") // {version = "10.7.0";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-14-0-5752501)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-34-0-4108dd3)

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -476,7 +476,9 @@ in
 
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
           mithril-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
-          mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
+          # The current mithril unstable tag has broken nix builds, so set to the current release until fixed
+          # mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
+          mithril-pre-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
 
           node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-3-e252ede";
           # node-release = pkg: localFlake.inputs.cardano-node-10-6-3.packages.x86_64-linux.${pkg};

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -13,8 +13,9 @@ null := ""
 stateDir := "STATEDIR=" + statePrefix / "$(basename $(git remote get-url origin))"
 statePrefix := "~/.local/share"
 
-# To skip ptrace permission modification prompting, env var AUTO_SET_ENV can be set to `false`
-autoSetEnv := env_var_or_default("AUTO_SET_ENV","unset")
+# Machines provisioned directly by tofu, not managed by colmena/NixOS
+# The list structure should be like: ["machine-a", "machine-b"] with optional comma delimiter
+nonNixosMachines := '[]'
 
 # Environment variables can be used to change the default template diff and path comparison sources.
 # If TEMPLATE_PATH is set, it will have precedence, otherwise git url will be used for source templates.
@@ -102,6 +103,8 @@ checkSshConfig := '''
   if $runCheck {
     print "Checking nixosCfg, sshCfg, and ipModuleCfg for consistency..."
 
+    let nonNixosMachines = ''' + nonNixosMachines + '''
+
     let nixosCfg = (nix eval --json ".#nixosConfigurations" --apply "builtins.attrNames" | from json)
 
     let sshCfg = (
@@ -138,20 +141,24 @@ checkSshConfig := '''
       | parse --regex `(?m)    (?<machine>.*) = {$\n(\s+privateIpv4 = \"(?<privIpv4>.*)";\n)?(\s+publicIpv4 = \"(?<pubIpv4>.*)";\n)?(\s+publicIpv6 = \"(?<pubIpv6>.*)";\n)?\s+};`
       | select machine privIpv4 pubIpv4 pubIpv6
       | update cells { if ($in | is-empty) { null } else { $in } }
+      | where {|r| ($nonNixosMachines | where {|m| $m == $r.machine} | is-empty) }
       | sort-by machine
     } else {
       []
     }
 
+    let ssh4NixosCfg = ($ssh4Cfg | where {|r| ($nonNixosMachines | where {|m| $m == $r.machine} | is-empty) })
+    let ssh6NixosCfg = ($ssh6Cfg | where {|r| ($nonNixosMachines | where {|m| $m == $r.machine} | is-empty) })
+
     let comparisons = [
       {
         label: "NixosConfigurations vs SSH hosts",
-        result: (list-diff $nixosCfg ($ssh4Cfg | get machine) onlyInNixosCfg onlyInSshCfg),
+        result: (list-diff $nixosCfg ($ssh4NixosCfg | get machine) onlyInNixosCfg onlyInSshCfg),
         hint: "just save-ssh-config or just tf apply"
       }
       {
         label: "SSH IPv4 vs SSH IPv6 machines",
-        result: (list-diff ($ssh4Cfg | get machine) ($ssh6Cfg | get machine) onlyInSsh4Cfg onlyInSsh6Cfg),
+        result: (list-diff ($ssh4NixosCfg | get machine) ($ssh6NixosCfg | get machine) onlyInSsh4Cfg onlyInSsh6Cfg),
         hint: "just save-ssh-config or just tf apply"
       }
       {
@@ -164,14 +171,14 @@ checkSshConfig := '''
       {
         label: "SSH public IPv4 vs IP module IPv4 values",
         result: (if $hasIpModule {
-          list-diff ($ssh4Cfg | get pubIpv4) ($moduleIps | get pubIpv4) onlyInSshCfg onlyInIpsModuleCfg
+          list-diff ($ssh4NixosCfg | get pubIpv4) ($moduleIps | get pubIpv4) onlyInSshCfg onlyInIpsModuleCfg
         } else {[]}),
         hint: "just update-ips"
       }
       {
         label: "SSH public IPv6 vs IP module IPv6 values",
         result: (if $hasIpModule {
-          list-diff ($ssh6Cfg | get pubIpv6) ($moduleIps | get pubIpv6) onlyInSshCfg onlyInIpsModuleCfg
+          list-diff ($ssh6NixosCfg | get pubIpv6) ($moduleIps | get pubIpv6) onlyInSshCfg onlyInIpsModuleCfg
         } else {[]}),
         hint: "just update-ips"
       }
@@ -1073,9 +1080,10 @@ update-ips:
   tofu init -reconfigure
   tofu workspace select -or-create cluster
 
+  let nonNixosMachines = {{nonNixosMachines}}
+
   print "\n"
-  let nodeCount = nix eval .#nixosConfigurations --raw --apply 'let f = x: toString (builtins.length (builtins.attrNames x)); in f'
-  print $"Processing ip information for ($nodeCount) nixos machine configurations..."
+  let nixosNodeCount = nix eval .#nixosConfigurations --raw --apply 'let f = x: toString (builtins.length (builtins.attrNames x)); in f'
 
   let tofuJson = (tofu show -json | from json)
 
@@ -1159,10 +1167,15 @@ update-ips:
   # The pre-push git hook will complain if this file has been committed accidently.
   git add --intent-to-add flake/nixosModules/ips-DONT-COMMIT.nix
 
-  print $"Ips were written for a machine count of: ($eipRecords | length)"
-  if $nodeCount != ($eipRecords | length | into string) {
+  let machineCount = ($ipTable | length)
+  let nonNixosMachineCount = ($nonNixosMachines | length)
+
+  print $"Processing ip information for ($nixosNodeCount) nixos machine(s) and ($nonNixosMachineCount) non-nixos machine(s)..."
+  print $"Ips were written for a machine count of: ($machineCount)"
+
+  if $nixosNodeCount != ($machineCount | $in - $nonNixosMachineCount | into string) {
     print "\n"
-    print $"(ansi bg_red)WARNING:(ansi reset) There are ($nodeCount) nixos machine configurations but ($eipRecords | length) ip record sets were written."
+    print $"(ansi bg_red)WARNING:(ansi reset) There are ($nixosNodeCount) nixos machine configurations but ($machineCount | $in - $nonNixosMachineCount) ip nixos record sets were written."
     print "\n"
   }
 

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -36,7 +36,7 @@ checkEnv := '''
 checkEnvWithoutOverride := '''
   ENV="${1:-}"
 
-  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo|^sanchonet$ ]]; then
+  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo$|^sanchonet$ ]]; then
     >&2 echo "Error: only node environments for demo, dijkstra, mainnet, preprod, preview and sanchonet are supported"
     >&2 echo "Usage: just set-default-cardano-env <env>"
     exit 1
@@ -381,7 +381,7 @@ dedelegate-pools ENV *IDXS=null:
   set -euo pipefail
   {{checkEnvWithoutOverride}}
 
-  if ! [[ "$ENV" =~ ^preprod$|^preview$|^dijkstra|^sanchonet$ ]]; then
+  if ! [[ "$ENV" =~ ^preprod$|^preview$|^dijkstra$|^sanchonet$ ]]; then
     echo "Error: only node environments for preprod, preview, dijkstra and sanchonet are supported"
     exit 1
   fi
@@ -584,7 +584,7 @@ query-tip ENV TESTNET_MAGIC=null:
     CARDANO_CLI="cardano-cli-ng"
   elif [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$ ]]; then
     CARDANO_CLI="cardano-cli"
-  elif [[ "$ENV" =~ ^dijkstra$|^demo|^sanchonet$ ]]; then
+  elif [[ "$ENV" =~ ^dijkstra$|^demo$|^sanchonet$ ]]; then
     CARDANO_CLI="cardano-cli-ng"
   fi
 
@@ -838,7 +838,7 @@ start-node ENV:
   set -euo pipefail
   {{stateDir}}
 
-  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^dijkstra|^sanchonet$ ]]; then
+  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^sanchonet$ ]]; then
     echo "Error: only node environments for mainnet, preprod, preview, dijkstra and sanchonet are supported for start-node recipe"
     exit 1
   fi
@@ -1018,7 +1018,7 @@ truncate-chain ENV SLOT:
   [ -n "${DEBUG:-}" ] && set -x
   {{stateDir}}
 
-  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^dijkstra|^sanchonet$ ]]; then
+  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^sanchonet$ ]]; then
     echo "Error: only node environments for mainnet, preprod, preview, dijkstra and sanchonet are supported for truncate-chain recipe"
     exit 1
   fi

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -151,7 +151,13 @@ in
 
             CHANGE_ROUTE "-4" "$DEFAULT_ROUTE"
 
-            DEFAULT_ROUTE=$(ip -6 route list default)
+            # Default ipv6 route output may look like:
+            #   default via fe80::8c2:6ff:feb3:c2d dev ens5 proto ra metric 1002 expires 1795sec pref medium
+            #
+            # The `1795sec` arg will not be accepted in a route change
+            # statement so must be filtered.
+            DEFAULT_ROUTE=$(ip -6 route list default | sed 's/ expires [0-9]\+sec//')
+
             if [ "$DEFAULT_ROUTE" = "" ]; then
               echo "The -6 default route is not set, skipping."
             else

--- a/templates/cardano-parts-project/flake/nixosModules/ami.nix
+++ b/templates/cardano-parts-project/flake/nixosModules/ami.nix
@@ -1,61 +1,127 @@
 {inputs, ...}: {
-  flake.nixosModules.ami = {
+  flake.nixosModules.ami = nixos @ {
     config,
     pkgs,
+    lib,
     ...
-  }: {
+  }: let
+    inherit (builtins) floor toString;
+    inherit (lib) mkIf mkOption types;
+    inherit (types) float ints nullOr oneOf;
+
+    # When building standalone AMI, nodeResources won't be in the module args
+    memMiB = nixos.nodeResources.memMiB or null;
+
+    # Calculate ARC max in bytes from percentage
+    calcArcMaxBytes = zfsArcPct:
+      if memMiB == null || zfsArcPct == null
+      then null
+      else floor (memMiB * 1024 * 1024 * zfsArcPct / 100.0);
+  in {
     imports = [
       "${inputs.nixpkgs}/nixos/maintainers/scripts/ec2/amazon-image.nix"
     ];
 
-    ec2 = {
-      efi = true;
+    options = {
+      boot.zfs.zfsArcPct = mkOption {
+        type = nullOr (oneOf [ints.positive float]);
+        default = 5.0;
+        description = ''
+          Percentage of total memory to allocate for ZFS ARC cache.
 
-      zfs = {
-        enable = true;
-        datasets = {
-          "tank/reserved".properties = {
-            canmount = "off";
-            refreserv = "1G";
-          };
-          "tank/root".mount = "/";
-          "tank/nix".mount = "/nix";
-          "tank/home".mount = "/home";
-          "tank/state".mount = "/state";
-        };
+          Default: 5.0
+
+          The ZFS ARC (Adaptive Replacement Cache) is ZFS's intelligent cache system.
+          Setting this too high may starve other applications; too low may reduce ZFS performance.
+
+          Set to null to disable setting zfs_arc_max (ZFS will use its own defaults).
+
+          Minimum enforced by ZFS: 64 MiB
+        '';
       };
     };
 
-    systemd.services = {
-      # `services.zfs.expandOnBoot` expands the partitions but does not trigger actual expansion.
-      "zpool-expand@" = {
-        path = [pkgs.jq];
-        script = ''
-          for dev in $(
-            zpool status -L --json \
-            | jq --raw-output '.pools.tank.vdevs[].vdevs[].name'
-          ); do
-            # No need for `-e` as the pool has `autoexpand=on`.
-            zpool online tank "$dev"
-          done
-        '';
+    config = let
+      arcMaxBytes = calcArcMaxBytes config.boot.zfs.zfsArcPct;
+    in {
+      # Set ZFS ARC max size via kernel parameter
+      boot.kernelParams = mkIf (config.boot.zfs.zfsArcPct != null) [
+        "zfs.zfs_arc_max=${toString arcMaxBytes}"
+      ];
+
+      ec2 = {
+        efi = true;
+
+        zfs = {
+          enable = true;
+          datasets = {
+            "tank/reserved".properties = {
+              canmount = "off";
+              refreserv = "1G";
+            };
+            "tank/root".mount = "/";
+            "tank/nix".mount = "/nix";
+            "tank/home".mount = "/home";
+            "tank/state".mount = "/state";
+          };
+        };
       };
 
-      zfs-blank = {
-        wantedBy = ["sysinit.target"];
-        before = ["sysinit.target"];
+      systemd.services = {
+        # `services.zfs.expandOnBoot` expands the partitions but does not trigger actual expansion.
+        "zpool-expand@" = {
+          path = [pkgs.jq];
+          script = ''
+            for dev in $(
+              zpool status -L --json \
+              | jq --raw-output '.pools.tank.vdevs[].vdevs[].name'
+            ); do
+              # No need for `-e` as the pool has `autoexpand=on`.
+              zpool online tank "$dev"
+            done
+          '';
+        };
 
-        path = [config.boot.zfs.package];
+        zfs-blank = {
+          wantedBy = ["sysinit.target"];
+          before = ["sysinit.target"];
 
-        script = ''
-          zfs snapshot -r tank/{root,home}@blank || :
-          zfs hold -r blank tank/{root,home}@blank || :
-        '';
+          path = [config.boot.zfs.package];
 
-        unitConfig.DefaultDependencies = false;
+          script = ''
+            zfs snapshot -r tank/{root,home}@blank || :
+            zfs hold -r blank tank/{root,home}@blank || :
+          '';
 
-        serviceConfig.Type = "oneshot";
+          unitConfig.DefaultDependencies = false;
+
+          serviceConfig.Type = "oneshot";
+        };
       };
+
+      assertions = let
+        arcMaxBytes = calcArcMaxBytes config.boot.zfs.zfsArcPct;
+      in [
+        {
+          assertion = config.boot.zfs.zfsArcPct == null || (config.boot.zfs.zfsArcPct > 0 && config.boot.zfs.zfsArcPct <= 100);
+          message = ''
+            boot.zfs.zfsArcPct must be between 0 and 100 (got ${toString config.boot.zfs.zfsArcPct}), or null to disable.
+            This represents the percentage of total memory to allocate to ZFS ARC cache.
+          '';
+        }
+        {
+          assertion = arcMaxBytes == null || arcMaxBytes >= 67108864; # 64 MiB minimum
+          message = ''
+            boot.zfs.zfsArcPct results in an ARC size that is too small.
+            Minimum: 67108864 bytes (64 MiB)
+            Current calculated value: ${toString arcMaxBytes} bytes
+            Total memory: ${toString memMiB} MiB
+            Configured percentage: ${toString config.boot.zfs.zfsArcPct}%
+
+            Consider increasing boot.zfs.zfsArcPct or ensuring the machine has sufficient memory.
+          '';
+        }
+      ];
     };
   };
 }

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -682,13 +682,6 @@ in {
             filename = "\${path.module}/.ssh_config";
             file_permission = "0600";
             content = ''
-              Host *
-                User root
-                UserKnownHostsFile /dev/null
-                StrictHostKeyChecking no
-                ServerAliveCountMax 2
-                ServerAliveInterval 60
-
               ${
                 concatStringsSep "\n" (map (name: ''
                     Host ${name}
@@ -705,6 +698,12 @@ in {
                   '')
                   (attrNames nodes))
               }
+              Host *
+                User root
+                UserKnownHostsFile /dev/null
+                StrictHostKeyChecking no
+                ServerAliveCountMax 2
+                ServerAliveInterval 60
             '';
           };
         };

--- a/templates/cardano-parts-project/flake/opentofu/grafana/dashboards/cardano-node-new-tracing.json
+++ b/templates/cardano-parts-project/flake/opentofu/grafana/dashboards/cardano-node-new-tracing.json
@@ -51,7 +51,7 @@
         "tagKeys": "revision,version",
         "target": {
           "expr": "cardano_node_metrics_cardano_build_info{environment=\"$environment\",instance=~\"$instance\"} unless (cardano_node_metrics_cardano_build_info{environment=\"$environment\",instance=~\"$instance\"} offset 4m)",
-          "interval": "",
+          "interval": "2m",
           "refId": "Anno"
         },
         "textFormat": "{{instance}}",
@@ -62,7 +62,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 38,
+  "id": 48,
   "links": [],
   "panels": [
     {
@@ -3195,104 +3195,6 @@
       "datasource": {
         "type": "prometheus"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "decbytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 84
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "rts_gc_current_bytes_used{environment=\"$environment\",instance=~\"$instance\"}",
-          "interval": "",
-          "legendFormat": "{{instance}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Node current \"residency\" (amount of live data)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus"
-      },
       "description": "The cardano-node uptime",
       "fieldConfig": {
         "defaults": {
@@ -3353,8 +3255,8 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 0,
-        "y": 92
+        "x": 16,
+        "y": 84
       },
       "id": 67,
       "options": {
@@ -3452,7 +3354,7 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 8,
+        "x": 0,
         "y": 92
       },
       "id": 34,
@@ -3484,7 +3386,105 @@
           "refId": "A"
         }
       ],
-      "title": "Node peak memory allocated (from OS)",
+      "title": "Cardano Node peak memory allocated (from OS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "decbytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 92
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rts_gc_current_bytes_used{environment=\"$environment\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cardano Node current \"residency\" (amount of live data)",
       "type": "timeseries"
     },
     {
@@ -3582,7 +3582,192 @@
           "refId": "A"
         }
       ],
-      "title": "Node max \"residency\" (amount of live data)",
+      "title": "Cardano Node max \"residency\" (amount of live data)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 100
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2+security-01",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(                                                                                     \n  sum by (instance) (                                                                 \n    rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$instance\"}[$rate_interval_mimic])\n  )                                                                                   \n/                                                                                     \n  sum by (instance) (\n    rate(node_cpu_seconds_total{instance=~\"$instance\"}[$rate_interval_mimic])             \n  )             \n) * 100\n",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Machine CPU Idle % - $rate_interval_mimic average",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 100
+      },
+      "id": 90,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2+security-01",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(\n  node_memory_MemAvailable_bytes{instance=~\"$instance\"}\n  /\n  node_memory_MemTotal_bytes{instance=~\"$instance\"}\n) * 100",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Machine Memory Available",
       "type": "timeseries"
     },
     {
@@ -3683,7 +3868,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 100
+        "y": 108
       },
       "id": 77,
       "options": {
@@ -3786,13 +3971,26 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 100
+        "y": 108
       },
       "id": 80,
       "options": {
@@ -3816,25 +4014,73 @@
           "legendFormat": "__auto",
           "range": false,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "last_over_time(instance:node_num_cpu:sum{instance=~\"$instance\"}[5m])",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "last_over_time(node_memory_MemTotal_bytes{instance=~\"$instance\"}[5m])",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
         }
       ],
-      "title": "OS Version",
+      "title": "Machine Info",
       "transformations": [
         {
-          "id": "filterFieldsByName",
+          "id": "joinByField",
           "options": {
-            "include": {
-              "names": ["instance", "pretty_name"]
-            }
+            "byField": "instance",
+            "mode": "outer"
           }
         },
         {
           "id": "organize",
           "options": {
-            "excludeByName": {},
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Value #A": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "build_id": true,
+              "id": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "name": true,
+              "version": true,
+              "version_codename": true,
+              "version_id": true
+            },
             "includeByName": {},
             "indexByName": {},
             "renameByName": {
+              "Value #B": "Total CPU",
+              "Value #C": "Total Memory",
               "instance": "Instance",
               "pretty_name": "Version"
             }
@@ -3852,8 +4098,8 @@
     "list": [
       {
         "current": {
-          "text": "preview",
-          "value": "preview"
+          "text": "mainnet",
+          "value": "mainnet"
         },
         "datasource": {
           "type": "prometheus"
@@ -3981,5 +4227,5 @@
   "timezone": "utc",
   "title": "Cardano Node: Application metrics (New Tracing)",
   "uid": "Oe0reiHea",
-  "version": 22
+  "version": 23
 }

--- a/templates/cardano-parts-project/flake/opentofu/grafana/dashboards/cardano-node.json
+++ b/templates/cardano-parts-project/flake/opentofu/grafana/dashboards/cardano-node.json
@@ -50,7 +50,7 @@
         "tagKeys": "revision,version",
         "target": {
           "expr": "cardano_node_metrics_cardano_build_info{environment=\"$environment\",instance=~\"$instance\"} unless (cardano_node_metrics_cardano_build_info{environment=\"$environment\",instance=~\"$instance\"} offset 4m)",
-          "interval": "",
+          "interval": "2m",
           "refId": "Anno"
         },
         "textFormat": "{{instance}}",
@@ -61,7 +61,7 @@
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 0,
-  "id": 41,
+  "id": 49,
   "links": [],
   "panels": [
     {
@@ -3123,104 +3123,6 @@
       "datasource": {
         "type": "prometheus"
       },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "palette-classic"
-          },
-          "custom": {
-            "axisBorderShow": false,
-            "axisCenteredZero": false,
-            "axisColorMode": "text",
-            "axisLabel": "",
-            "axisPlacement": "auto",
-            "barAlignment": 0,
-            "barWidthFactor": 0.6,
-            "drawStyle": "line",
-            "fillOpacity": 10,
-            "gradientMode": "none",
-            "hideFrom": {
-              "legend": false,
-              "tooltip": false,
-              "viz": false
-            },
-            "insertNulls": false,
-            "lineInterpolation": "linear",
-            "lineWidth": 1,
-            "pointSize": 5,
-            "scaleDistribution": {
-              "type": "linear"
-            },
-            "showPoints": "never",
-            "spanNulls": false,
-            "stacking": {
-              "group": "A",
-              "mode": "none"
-            },
-            "thresholdsStyle": {
-              "mode": "off"
-            }
-          },
-          "links": [],
-          "mappings": [],
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green"
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ]
-          },
-          "unit": "bytes"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 8,
-        "x": 16,
-        "y": 76
-      },
-      "id": 37,
-      "options": {
-        "legend": {
-          "calcs": ["lastNotNull"],
-          "displayMode": "table",
-          "placement": "right",
-          "showLegend": true
-        },
-        "tooltip": {
-          "hideZeros": false,
-          "mode": "multi",
-          "sort": "none"
-        }
-      },
-      "pluginVersion": "12.0.2+security-01",
-      "targets": [
-        {
-          "datasource": {
-            "type": "prometheus"
-          },
-          "editorMode": "code",
-          "exemplar": true,
-          "expr": "rts_gc_current_bytes_used{environment=\"$environment\",instance=~\"$instance\"}",
-          "interval": "",
-          "legendFormat": "{{instance}}",
-          "range": true,
-          "refId": "A"
-        }
-      ],
-      "title": "Node current \"residency\" (amount of live data, MBytes)",
-      "type": "timeseries"
-    },
-    {
-      "datasource": {
-        "type": "prometheus"
-      },
       "description": "The cardano-node uptime",
       "fieldConfig": {
         "defaults": {
@@ -3281,8 +3183,8 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 0,
-        "y": 84
+        "x": 16,
+        "y": 76
       },
       "id": 67,
       "options": {
@@ -3380,7 +3282,7 @@
       "gridPos": {
         "h": 8,
         "w": 8,
-        "x": 8,
+        "x": 0,
         "y": 84
       },
       "id": 34,
@@ -3412,7 +3314,105 @@
           "refId": "A"
         }
       ],
-      "title": "Node peak memory allocated (from OS)",
+      "title": "Cardano Node peak memory allocated (from OS)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "links": [],
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 84
+      },
+      "id": 37,
+      "options": {
+        "legend": {
+          "calcs": ["lastNotNull"],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2+security-01",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus"
+          },
+          "editorMode": "code",
+          "exemplar": true,
+          "expr": "rts_gc_current_bytes_used{environment=\"$environment\",instance=~\"$instance\"}",
+          "interval": "",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Cardano Node current \"residency\" (amount of live data, MBytes)",
       "type": "timeseries"
     },
     {
@@ -3510,7 +3510,192 @@
           "refId": "A"
         }
       ],
-      "title": "Node max \"residency\" (amount of live data)",
+      "title": "Cardano Node max \"residency\" (amount of live data)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 92
+      },
+      "id": 88,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2+security-01",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(                                                                                     \n  sum by (instance) (                                                                 \n    rate(node_cpu_seconds_total{mode=\"idle\", instance=~\"$instance\"}[$rate_interval_mimic])\n  )                                                                                   \n/                                                                                     \n  sum by (instance) (\n    rate(node_cpu_seconds_total{instance=~\"$instance\"}[$rate_interval_mimic])             \n  )             \n) * 100\n",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Machine CPU Idle % - $rate_interval_mimic average",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "mimir"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "barWidthFactor": 0.6,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 92
+      },
+      "id": 89,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "hideZeros": false,
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "12.0.2+security-01",
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "(\n  node_memory_MemAvailable_bytes{instance=~\"$instance\"}\n  /\n  node_memory_MemTotal_bytes{instance=~\"$instance\"}\n) * 100",
+          "legendFormat": "{{instance}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Machine Memory Available",
       "type": "timeseries"
     },
     {
@@ -3611,7 +3796,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 92
+        "y": 100
       },
       "id": 77,
       "options": {
@@ -3714,13 +3899,26 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Total Memory"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "bytes"
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 92
+        "y": 100
       },
       "id": 87,
       "options": {
@@ -3744,25 +3942,73 @@
           "legendFormat": "__auto",
           "range": false,
           "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "last_over_time(instance:node_num_cpu:sum{instance=~\"$instance\"}[5m])",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "B"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "mimir"
+          },
+          "editorMode": "code",
+          "exemplar": false,
+          "expr": "last_over_time(node_memory_MemTotal_bytes{instance=~\"$instance\"}[5m])",
+          "format": "table",
+          "hide": false,
+          "instant": true,
+          "legendFormat": "__auto",
+          "range": false,
+          "refId": "C"
         }
       ],
-      "title": "OS Version",
+      "title": "Machine Info",
       "transformations": [
         {
-          "id": "filterFieldsByName",
+          "id": "joinByField",
           "options": {
-            "include": {
-              "names": ["instance", "pretty_name"]
-            }
+            "byField": "instance",
+            "mode": "outer"
           }
         },
         {
           "id": "organize",
           "options": {
-            "excludeByName": {},
+            "excludeByName": {
+              "Time 1": true,
+              "Time 2": true,
+              "Time 3": true,
+              "Value #A": true,
+              "__name__ 1": true,
+              "__name__ 2": true,
+              "__name__ 3": true,
+              "build_id": true,
+              "id": true,
+              "job 1": true,
+              "job 2": true,
+              "job 3": true,
+              "name": true,
+              "version": true,
+              "version_codename": true,
+              "version_id": true
+            },
             "includeByName": {},
             "indexByName": {},
             "renameByName": {
+              "Value #B": "Total CPU",
+              "Value #C": "Total Memory",
               "instance": "Instance",
               "pretty_name": "Version"
             }
@@ -3911,5 +4157,5 @@
   "timezone": "utc",
   "title": "Cardano Node: Application metrics",
   "uid": "Oe0reiHez",
-  "version": 14
+  "version": 15
 }

--- a/templates/cardano-parts-project/scripts/recipes/aws.just
+++ b/templates/cardano-parts-project/scripts/recipes/aws.just
@@ -12,7 +12,7 @@ aws-ec2-describe NAME REGION:
 aws-ec2-id NAME REGION:
   #!/usr/bin/env bash
   set -e
-  ID=$(aws --region {{REGION}} ec2 describe-instances --filters "Name=tag:Name,Values={{NAME}}" --output text --query "Reservations[*].Instances[*].InstanceId")
+  ID=$(aws --region {{REGION}} ec2 describe-instances --filters "Name=tag:Name,Values={{NAME}}" "Name=instance-state-name,Values=pending,running,stopping,stopped" --output text --query "Reservations[*].Instances[*].InstanceId")
   if [ -z "${ID:-}" ]; then
     echo >&2 "ERROR: Machine {{NAME}} not found in region {{REGION}}"
     exit 1

--- a/templates/cardano-parts-project/scripts/recipes/aws.just
+++ b/templates/cardano-parts-project/scripts/recipes/aws.just
@@ -98,6 +98,7 @@ aws-sso-login-link AWS_PROFILE=null:
     echo "Logging into AWS SSO using profile \"$PROFILE\" from env var AWS_PROFILE..."
   else
     echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
+    exit 1
   fi
 
   echo
@@ -116,6 +117,7 @@ aws-sso-login-code AWS_PROFILE=null:
     echo "Logging into AWS SSO using profile \"$PROFILE\" from env var AWS_PROFILE..."
   else
     echo "ERROR: Either a recipe AWS_PROFILE arg must be given or the env var AWS_PROFILE must be set."
+    exit 1
   fi
 
   echo

--- a/templates/cardano-parts-project/scripts/recipes/governance.just
+++ b/templates/cardano-parts-project/scripts/recipes/governance.just
@@ -9,7 +9,7 @@ query-gov-action-status ENV ACTION_ID ACTION_IDX:
   set -euo pipefail
   {{checkEnvWithoutOverride}}
 
-  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo|^sanchonet$ ]]; then
+  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo$|^sanchonet$ ]]; then
     echo "Error: only node environments for mainnet, preprod, preview, dijkstra, demo and sanchonet are supported"
     exit 1
   fi
@@ -846,7 +846,7 @@ vote-with-pool ENV POOL ACTION_ID ACTION_IDX VOTE:
   set -euo pipefail
   {{checkEnvWithoutOverride}}
 
-  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo|^sanchonet$ ]]; then
+  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo$|^sanchonet$ ]]; then
     echo "Error: only node environments for mainnet, preprod, preview, dijkstra, demo and sanchonet are supported"
     exit 1
   fi

--- a/templates/cardano-parts-project/scripts/setup-delegation-accounts.py
+++ b/templates/cardano-parts-project/scripts/setup-delegation-accounts.py
@@ -8,7 +8,7 @@ Usage:
 
 Options:
     -h --help                    Show this screen
-    -p --print-only              Print sql for creation of faucet_stake_addr and faucet_deleg_addr tables only, take no other action
+    -p --print-only              Print sql for creation of faucet_stake_addr and faucet_deleg_addr tables only, submit no transactions
     -t --testnet-magic <INT>     Testnet Magic
     -s --signing-key-file <FILE> Signing Key
     -w --wallet-mnemonic <FILE>  mnemonic file cardano-address uses

--- a/templates/cardano-parts-project/scripts/setup-delegation-accounts.py
+++ b/templates/cardano-parts-project/scripts/setup-delegation-accounts.py
@@ -302,7 +302,8 @@ else:
 with open(utxo_signing_key, "r") as file:
   utxo_signing_key_str = file.read()
 payment_addr = derive_payment_address_cli_skey(utxo_signing_key_str)
-txin = getLargestUtxoForAddress(payment_addr)
+if not arguments["--print-only"]:
+  txin = getLargestUtxoForAddress(payment_addr)
 
 faucetStakeSql = ""
 faucetDelegSql = ""

--- a/templates/cardano-parts-project/secrets/tf/bootstrap.tfvars
+++ b/templates/cardano-parts-project/secrets/tf/bootstrap.tfvars
@@ -1,0 +1,9 @@
+# To enable terraform secrets usage for the bootstrap environment:
+#   * update the following with the appropriate cluster secrets
+#   * remove these comments
+#   * encrypt this file with sops as a binary type using an age sre/admin secret key
+#
+# Expect this file to generate a pre-push error until it is either encrypted or deleted
+
+# Set this to the finance billing code
+tag_costCenter = "UPDATE_ME"


### PR DESCRIPTION
## Overview:

This release updates cardano-node to `10.6.4`, cardano-db-sync to `13.6.0.8`, and cardano-db-sync pre-release to `13.7.0.2`. Nix has been bumped to address security vulnerabilities `GHSA-g3g9-5vj6-r3gj` and `CVE-2026-39860`. The ZFS AMI module gains a configurable option for percentage-based ARC cache sizing derived from the node RAM. The AWS EC2 spec is updated. Various template recipe improvements, script fixes, and Grafana dashboard enhancements are also included.

## Details:

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
| :---: | :---: | :---: |
| blockperf | 2.0.3 | N/A |
| cardano-address | 4.0.2 | N/A |
| cardano-cli | 10.15.0.0 | 10.15.1.0 |
| cardano-db-sync | <ins>***13.6.0.8***</ins> | <ins>***13.7.0.2***</ins> |
| cardano-faucet | 10.6 | 10.6 |
| cardano-node | <ins>***10.6.4***</ins> | 10.7.0 |
| cardano-ogmios | 6.14.0 | N/A |
| cardano-signer | 1.34.0 | N/A |
| cardano-wallet | v2025-12-15 | N/A |
| credential-manager | 0.1.5.0 | N/A |
| mithril | 2603.1 | 2603.1** |
| nix* | <ins>***2.33.5***</ins> | N/A |
| nixpkgs* | 25.11 | N/A |

\* = For nixos machine deployments
\*\* = The current mithril unstable tag does not nix build, so the release version is substituting

- Bumps cardano-node release to `10.6.4`, cardano-db-sync release to `13.6.0.8`, and cardano-db-sync pre-release to `13.7.0.2`
- Bumps nix to address security vulnerabilities `GHSA-g3g9-5vj6-r3gj` and `CVE-2026-39860`
- Temporarily sets mithril-pre-release to the current `2603.1` release as a workaround for broken nix builds on the upstream unstable tag; the unstable pin comment is retained for restoration when fixed
- Updates the AWS EC2 spec to include a number of new machines missing in the existing spec
- Extends the ZFS AMI `ami.nix` nixosModule with a configurable `boot.zfs.zfsArcPct` option for percentage-based ZFS ARC cache sizing
- Fixes a race condition in `profile-aws-ec2-ephemeral.nix` where chown would fail if the expected ephemeral file disappeared between mount and chown by making the failure non-fatal
- Fixes a tcpTxOpt colmena module breaking change introduced in nixpkgs `25.11`
- Adds non-nixos machine handling to the `Justfile` consistency-checking and update-ips recipes
- Adjusts generic SSH config parameters in `flake/opentofu/cluster.nix` to allow downstream override
- Adds CPU/memory usage panels and totals to `cardano-node.json` and `cardano-node-new-tracing.json` Grafana dashboards
- Fixes the AWS instance ID query in aws recipes to filter for non-terminated instances only
- Fixes the AWS SSO recipe to properly exit when the target profile is missing
- Makes environment-matching regexes consistent across just recipes
- Improves `setup-delegation-accounts.py` cli help and optimizes the `--print-only` flag usage
- Adds the `secrets/tf/bootstrap.tfvars` template file

## Breaking Changes, Recommended Updates and Action Items:

### Breaking:
* None

### Recommended Updates:
* Update your cardano-parts pin to release version `v2026-04-15`.
* Complete the Action Items below.

### Action Items:
* Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`.  Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

    * Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the `just template-clone "$FILE"` recipe.
```
Justfile                                                         # For misc recipe improvements
flake/colmena.nix                                                # For tcpTxOpt nixpkgs 25.11 breaking change
flake/nixosModules/ami.nix                                       # For configurable ZFS ARC cache size
flake/opentofu/cluster.nix                                       # For overridable generic SSH config parameters
flake/opentofu/grafana/dashboards/cardano-node.json              # For CPU/memory panels and totals
flake/opentofu/grafana/dashboards/cardano-node-new-tracing.json  # For CPU/memory panels and totals
scripts/recipes/aws.just                                         # For misc recipe improvements
scripts/setup-delegation-accounts.py                             # For --print-only txin skip fix and help text clarification
secrets/tf/bootstrap.tfvars                                      # New: if not already present from PR #79 manual creation
```
* Perform a `just tofu apply` in order to write an updated `.ssh_config` file with overridable defaults
* Perform a `just tofu grafana apply` in order to update the dashboards with improvements

## Known Issues:
* Two escape chars were missed in the `update-ips` just recipe.  To fix, add the two extra `\` characters as seen in this commit diff fix to your `Justfile`: [here](https://github.com/input-output-hk/cardano-parts/commit/4fabdf57e53f059744b4239abc1c2229aa38cdef)
* The `boot.zfs.zfsArcPct` option introduced a bug where zfs_arc_cache kernel cmdline param can be set to null in an edge case and prevent the AMI from booting properly.  This is fixed in the next release.  The patch can also be applied to this release and is found [here](https://github.com/input-output-hk/cardano-parts/commit/fd02afb7dda50b02e5e5a77f279b1d1600db9625).
