### PR TITLE
Node `10.7.1`, Dbsync `13.7.0.4`, Mithril `2617.0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Git add all new project files:
 
 Update the following files in the `<NEW_DIRECTORY>`:
 
+    # Update with your desired flake pins
+    flake.nix
+
     # Update with details of your new cluster
     flake/cluster.nix
 
@@ -55,6 +58,9 @@ Update the following files in the `<NEW_DIRECTORY>`:
     # If needed: resource customization
     flake/cloudFormation/terraformState.nix
     flake/opentofu/cluster.nix
+
+    # Update your flake.lock
+    nix flake update
 
 Continue following the [README](templates/cardano-parts-project/README.md)
 found in your <NEW_DIRECTORY> and customize it as desired.

--- a/flake.lock
+++ b/flake.lock
@@ -525,11 +525,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1776911046,
-        "narHash": "sha256-gCLi3j+FOrVEoog0UDS+fAdNHBFI2ZGBNp8X+DrEOTY=",
+        "lastModified": 1777059663,
+        "narHash": "sha256-eQAt4yPFkKJJ+80Wvr8WBIEMhOoxyHlvvg7YVJwUphg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f066a2740d520f5b9005b30b98a224dfd843c5d0",
+        "rev": "0c900d8ec6c266a946192c5cad739bb3229110ee",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1776270384,
-        "narHash": "sha256-vXuJ8meLyMgMut2UDKC+pNT58Oid3rEvsk4QVacoG60=",
+        "lastModified": 1777421127,
+        "narHash": "sha256-y3eKF6nGZpPdtXdp5YfJ2ll7H7Og8FGdbsJyxAvTQ7M=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "31572b19dbc7df57dc75c5fce98f7cf8f3ae01e1",
+        "rev": "13a31478b2386ae5da59ad82cf51fe54187d406c",
         "type": "github"
       },
       "original": {
@@ -113,16 +113,16 @@
     "cardano-db-sync-schema-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1774635451,
-        "narHash": "sha256-mnaBzFHOcBJKF4e4zyDxFiBvzE2lWtrNqmg7rw+FYU8=",
+        "lastModified": 1777403260,
+        "narHash": "sha256-HQPsVa26tiwU4cN3h0rOtnHPb8dWPXQnQ94vxdne9Y0=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "0acc69f273488abe06a717999260811d2c6a83a6",
+        "rev": "63dbf19b91d13bd31d007be0cdc329eec57e4025",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.7.0.2",
+        "ref": "13.7.0.4",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -147,16 +147,16 @@
     "cardano-db-sync-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1774635451,
-        "narHash": "sha256-mnaBzFHOcBJKF4e4zyDxFiBvzE2lWtrNqmg7rw+FYU8=",
+        "lastModified": 1777403260,
+        "narHash": "sha256-HQPsVa26tiwU4cN3h0rOtnHPb8dWPXQnQ94vxdne9Y0=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "0acc69f273488abe06a717999260811d2c6a83a6",
+        "rev": "63dbf19b91d13bd31d007be0cdc329eec57e4025",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.7.0.2",
+        "ref": "13.7.0.4",
         "repo": "cardano-db-sync",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -80,11 +80,11 @@
     },
     "capkgs": {
       "locked": {
-        "lastModified": 1775853349,
-        "narHash": "sha256-YLRcOZL1e0sy047jcmmbiVP+S/1IZ1NGAeKXxTtHM4g=",
+        "lastModified": 1776270384,
+        "narHash": "sha256-vXuJ8meLyMgMut2UDKC+pNT58Oid3rEvsk4QVacoG60=",
         "owner": "input-output-hk",
         "repo": "capkgs",
-        "rev": "e2278cddb37c4863e95e58c4a6b6ef08e824d6a4",
+        "rev": "31572b19dbc7df57dc75c5fce98f7cf8f3ae01e1",
         "type": "github"
       },
       "original": {
@@ -198,16 +198,16 @@
     "cardano-node-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1774379192,
-        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.7.0",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -249,16 +249,16 @@
     "cardano-submit-api-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1774379192,
-        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.7.0",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -283,16 +283,16 @@
     "cardano-tracer-service-ng": {
       "flake": false,
       "locked": {
-        "lastModified": 1774379192,
-        "narHash": "sha256-6b9fX1RNmHdBRpmE4WYFCf13vwZZGg1LHRhHP7GRJHE=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "1e6d8228693ab2aa4e1d7305e7bdcc57cdd278e4",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.7.0",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -51,12 +51,12 @@
         "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.14",
+        "ref": "v0.3.15",
         "repo": "blst",
         "type": "github"
       }
@@ -504,15 +504,16 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1774280402,
-        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "lastModified": 1777059663,
+        "narHash": "sha256-eQAt4yPFkKJJ+80Wvr8WBIEMhOoxyHlvvg7YVJwUphg=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
+        "rev": "0c900d8ec6c266a946192c5cad739bb3229110ee",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "leios",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
     "cardano-db-sync-schema": {
       "flake": false,
       "locked": {
-        "lastModified": 1775295721,
-        "narHash": "sha256-oI4+/xzOxwKUO4EgfGQjqe3/skpV9P1QuAnDFi7ztxk=",
+        "lastModified": 1777403260,
+        "narHash": "sha256-HQPsVa26tiwU4cN3h0rOtnHPb8dWPXQnQ94vxdne9Y0=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "2017bdaa25a01ce0e5e3838fab28cf0710ad14aa",
+        "rev": "63dbf19b91d13bd31d007be0cdc329eec57e4025",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.6.0.8",
+        "ref": "13.7.0.4",
         "repo": "cardano-db-sync",
         "type": "github"
       }
@@ -130,16 +130,16 @@
     "cardano-db-sync-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1775295721,
-        "narHash": "sha256-oI4+/xzOxwKUO4EgfGQjqe3/skpV9P1QuAnDFi7ztxk=",
+        "lastModified": 1777403260,
+        "narHash": "sha256-HQPsVa26tiwU4cN3h0rOtnHPb8dWPXQnQ94vxdne9Y0=",
         "owner": "IntersectMBO",
         "repo": "cardano-db-sync",
-        "rev": "2017bdaa25a01ce0e5e3838fab28cf0710ad14aa",
+        "rev": "63dbf19b91d13bd31d007be0cdc329eec57e4025",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "13.6.0.8",
+        "ref": "13.7.0.4",
         "repo": "cardano-db-sync",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1777059663,
-        "narHash": "sha256-eQAt4yPFkKJJ+80Wvr8WBIEMhOoxyHlvvg7YVJwUphg=",
+        "lastModified": 1777079841,
+        "narHash": "sha256-yjYY1bn3n6ehfgnoS3chrw9Aiatqzx8s0nZpKpQ8gWI=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0c900d8ec6c266a946192c5cad739bb3229110ee",
+        "rev": "ed347a6368f265587013e3241fd5f7f282f1921a",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1777059663,
-        "narHash": "sha256-eQAt4yPFkKJJ+80Wvr8WBIEMhOoxyHlvvg7YVJwUphg=",
+        "lastModified": 1777079841,
+        "narHash": "sha256-yjYY1bn3n6ehfgnoS3chrw9Aiatqzx8s0nZpKpQ8gWI=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "0c900d8ec6c266a946192c5cad739bb3229110ee",
+        "rev": "ed347a6368f265587013e3241fd5f7f282f1921a",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -68,12 +68,12 @@
         "narHash": "sha256-IlbNMLBjs/dvGogcdbWQIL+3qwy7EXJbIDpo4xBd4bY=",
         "owner": "supranational",
         "repo": "blst",
-        "rev": "8c7db7fe8d2ce6e76dc398ebd4d475c0ec564355",
+        "rev": "6d960cd05d6fe2b5bc9ba161edf0c1a131b87c4c",
         "type": "github"
       },
       "original": {
         "owner": "supranational",
-        "ref": "v0.3.14",
+        "ref": "v0.3.15",
         "repo": "blst",
         "type": "github"
       }
@@ -525,15 +525,16 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1774280402,
-        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
+        "lastModified": 1776911046,
+        "narHash": "sha256-gCLi3j+FOrVEoog0UDS+fAdNHBFI2ZGBNp8X+DrEOTY=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
+        "rev": "f066a2740d520f5b9005b30b98a224dfd843c5d0",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
+        "ref": "leios",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -181,16 +181,16 @@
     "cardano-node-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1775833532,
-        "narHash": "sha256-V5NYiZb0JZPWcxE0ndnd7BOK1zvauUYDE/6DwIIVQ4M=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "5a4dcd1b410ba78f9faab7acd48f606496909935",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.4",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -232,16 +232,16 @@
     "cardano-submit-api-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1775833532,
-        "narHash": "sha256-V5NYiZb0JZPWcxE0ndnd7BOK1zvauUYDE/6DwIIVQ4M=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "5a4dcd1b410ba78f9faab7acd48f606496909935",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.4",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -266,16 +266,16 @@
     "cardano-tracer-service": {
       "flake": false,
       "locked": {
-        "lastModified": 1775833532,
-        "narHash": "sha256-V5NYiZb0JZPWcxE0ndnd7BOK1zvauUYDE/6DwIIVQ4M=",
+        "lastModified": 1776219966,
+        "narHash": "sha256-D2HMIr65q0RM9+ZAjbtA9xNKyoKYfr3Kc4Vv4+s64uY=",
         "owner": "IntersectMBO",
         "repo": "cardano-node",
-        "rev": "5a4dcd1b410ba78f9faab7acd48f606496909935",
+        "rev": "045bc187a36ef0cbd236db902b85dd8f202fb059",
         "type": "github"
       },
       "original": {
         "owner": "IntersectMBO",
-        "ref": "10.6.4",
+        "ref": "10.7.1",
         "repo": "cardano-node",
         "type": "github"
       }
@@ -504,16 +504,15 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1772334388,
-        "narHash": "sha256-t9QpZLgek7gLoIecIwk4ZZn7x+yhF27cbaAdshyrKSo=",
+        "lastModified": 1774280402,
+        "narHash": "sha256-bHp3Ji7c0T0RCor9FVo6yvjSPT0bVQE5EFw5JxvqZDM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "5be2a889c7747675313d18e326e256188207ceba",
+        "rev": "f444d972c301ddd9f23eac4325ffcc8b5766eee9",
         "type": "github"
       },
       "original": {
         "owner": "input-output-hk",
-        "ref": "jl/dijkstra-respin-2026-02-19",
         "repo": "iohk-nix",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -504,11 +504,11 @@
         "sodium": "sodium"
       },
       "locked": {
-        "lastModified": 1777079841,
-        "narHash": "sha256-yjYY1bn3n6ehfgnoS3chrw9Aiatqzx8s0nZpKpQ8gWI=",
+        "lastModified": 1777602718,
+        "narHash": "sha256-0dESsJW3P+rYirqccJuu1/bINUQoHJEsskrpq5LnFFM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ed347a6368f265587013e3241fd5f7f282f1921a",
+        "rev": "1407b0d0f2245badc0b8c4ea15243de57f1cdce4",
         "type": "github"
       },
       "original": {
@@ -526,11 +526,11 @@
         "sodium": "sodium_2"
       },
       "locked": {
-        "lastModified": 1777079841,
-        "narHash": "sha256-yjYY1bn3n6ehfgnoS3chrw9Aiatqzx8s0nZpKpQ8gWI=",
+        "lastModified": 1777602718,
+        "narHash": "sha256-0dESsJW3P+rYirqccJuu1/bINUQoHJEsskrpq5LnFFM=",
         "owner": "input-output-hk",
         "repo": "iohk-nix",
-        "rev": "ed347a6368f265587013e3241fd5f7f282f1921a",
+        "rev": "1407b0d0f2245badc0b8c4ea15243de57f1cdce4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";
 
-    iohk-nix.url = "github:input-output-hk/iohk-nix";
+    iohk-nix.url = "github:input-output-hk/iohk-nix/leios";
     iohk-nix-ng.url = "github:input-output-hk/iohk-nix/leios";
 
     # For tmp local testing pins

--- a/flake.nix
+++ b/flake.nix
@@ -75,7 +75,7 @@
     };
 
     cardano-db-sync-schema-ng = {
-      url = "github:IntersectMBO/cardano-db-sync/13.7.0.2";
+      url = "github:IntersectMBO/cardano-db-sync/13.7.0.4";
       flake = false;
     };
 
@@ -89,7 +89,7 @@
     };
 
     cardano-db-sync-service-ng = {
-      url = "github:IntersectMBO/cardano-db-sync/13.7.0.2";
+      url = "github:IntersectMBO/cardano-db-sync/13.7.0.4";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -61,7 +61,7 @@
     capkgs.url = "github:input-output-hk/capkgs";
 
     iohk-nix.url = "github:input-output-hk/iohk-nix";
-    iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
+    iohk-nix-ng.url = "github:input-output-hk/iohk-nix/leios";
 
     # For tmp local testing pins
     # cardano-faucet.url = "github:input-output-hk/cardano-faucet/feature/upgrade-node-10.6";

--- a/flake.nix
+++ b/flake.nix
@@ -60,7 +60,7 @@
     # Cardano related inputs
     capkgs.url = "github:input-output-hk/capkgs";
 
-    iohk-nix.url = "github:input-output-hk/iohk-nix/jl/dijkstra-respin-2026-02-19";
+    iohk-nix.url = "github:input-output-hk/iohk-nix";
     iohk-nix-ng.url = "github:input-output-hk/iohk-nix";
 
     # For tmp local testing pins
@@ -94,7 +94,7 @@
     };
 
     cardano-node-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.4";
+      url = "github:IntersectMBO/cardano-node/10.7.1";
       flake = false;
     };
 
@@ -119,7 +119,7 @@
     };
 
     cardano-submit-api-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.4";
+      url = "github:IntersectMBO/cardano-node/10.7.1";
       flake = false;
     };
 
@@ -129,7 +129,7 @@
     };
 
     cardano-tracer-service = {
-      url = "github:IntersectMBO/cardano-node/10.6.4";
+      url = "github:IntersectMBO/cardano-node/10.7.1";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -99,7 +99,7 @@
     };
 
     cardano-node-service-ng = {
-      url = "github:IntersectMBO/cardano-node/10.7.0";
+      url = "github:IntersectMBO/cardano-node/10.7.1";
       flake = false;
     };
 
@@ -124,7 +124,7 @@
     };
 
     cardano-submit-api-service-ng = {
-      url = "github:IntersectMBO/cardano-node/10.7.0";
+      url = "github:IntersectMBO/cardano-node/10.7.1";
       flake = false;
     };
 
@@ -134,7 +134,7 @@
     };
 
     cardano-tracer-service-ng = {
-      url = "github:IntersectMBO/cardano-node/10.7.0";
+      url = "github:IntersectMBO/cardano-node/10.7.1";
       flake = false;
     };
 

--- a/flake.nix
+++ b/flake.nix
@@ -70,7 +70,7 @@
     # versioning of the release and pre-release (-ng) dbsync
     # definitions found in flakeModule/pkgs.nix.
     cardano-db-sync-schema = {
-      url = "github:IntersectMBO/cardano-db-sync/13.6.0.8";
+      url = "github:IntersectMBO/cardano-db-sync/13.7.0.4";
       flake = false;
     };
 
@@ -84,7 +84,7 @@
     # flakeModule options and do not necessarily reflect the software
     # versions running on those nixos services.
     cardano-db-sync-service = {
-      url = "github:IntersectMBO/cardano-db-sync/13.6.0.8";
+      url = "github:IntersectMBO/cardano-db-sync/13.7.0.4";
       flake = false;
     };
 

--- a/flake/nixosModules/profile-common.nix
+++ b/flake/nixosModules/profile-common.nix
@@ -36,6 +36,12 @@
       key = ./profile-common.nix;
 
       config = {
+        # Cardano-node >= 10.7.0 requires kernel >= 6.15 for LSM, without which
+        # large IOWAIT will be observed.
+        #
+        # Kernel 6.18 is the most recent kernel which is compatible with ZFS.
+        boot.kernelPackages = mkDefault pkgs.linuxPackages_6_18;
+
         environment = {
           # Enable terminfo for common terminal types like `xterm-256color` and `tmux-256color`.
           enableAllTerminfo = mkDefault true;

--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -6,6 +6,7 @@
 #   config.services.alloy.enableLiveDebugging
 #   config.services.alloy.enableLoki
 #   config.services.alloy.extraAlloyConfig
+#   config.services.alloy.extraJournalReceivers
 #   config.services.alloy.labels
 #   config.services.alloy.logLevel
 #   config.services.alloy.prometheusExporterUnixNodeSetCollectors
@@ -223,7 +224,13 @@ flake @ {moduleWithSystem, ...}: {
 
         '';
 
-        loki = ''
+        loki = let
+          e = "${
+            if (length cfg.extraJournalReceivers == 0)
+            then ""
+            else ", "
+          }${(concatMapStringsSep ", " (r: r) cfg.extraJournalReceivers)}";
+        in ''
           loki.write "default" {
             endpoint {
               url = local.file.remote_write_url_logs.content
@@ -237,7 +244,7 @@ flake @ {moduleWithSystem, ...}: {
 
           loki.source.journal "default" {
             relabel_rules = discovery.relabel.journal.rules
-            forward_to    = [loki.write.default.receiver]
+            forward_to    = [loki.write.default.receiver${e}]
             labels        = {
               job = "systemd-journal",
               group = "${groupName}",
@@ -488,6 +495,14 @@ flake @ {moduleWithSystem, ...}: {
             default = "";
             description = ''
               Extra configuration appended to the /etc/alloy/config.alloy file prior to formatting.
+            '';
+          };
+
+          extraJournalReceivers = mkOption {
+            type = listOf str;
+            default = [];
+            description = ''
+              Extra alloy receivers for loki journald log data.
             '';
           };
 

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -36,18 +36,21 @@ in {
           );
       in ''
         # Prepare standard env configs
-        ENVS=(${escapeShellArgs (attrNames environments)})
-        for ENV in "''${ENVS[@]}"; do
-          cp -r "${envCfgs}/config/$ENV" "$DATA_DIR/config/"
-        done
+        if [ -z "''${NODE_CONFIG_SKIP_COPY:-}" ]; then
+          ENVS=(${escapeShellArgs (attrNames environments)})
 
-        # Required for direct entrypoint access.
-        # Can be removed once the find command below is removed
-        chmod -R +w "$DATA_DIR"
+          for ENV in "''${ENVS[@]}"; do
+            cp -r "${envCfgs}/config/$ENV" "$DATA_DIR/config/"
+          done
 
-        # Until https://github.com/IntersectMBO/cardano-node/pull/6282 is merged and released,
-        # remove PrometheusSimple from configs so multiple instances can be started without fatal error.
-        find "$DATA_DIR" -name 'config*.json' -type f -exec sed -i '/PrometheusSimple/d' {} +
+          # Required for direct entrypoint access.
+          # Can be removed once the find command below is removed
+          chmod -R +w "$DATA_DIR"
+
+          # Until https://github.com/IntersectMBO/cardano-node/pull/6282 is merged and released,
+          # remove PrometheusSimple from configs so multiple instances can be started without fatal error.
+          find "$DATA_DIR" -name 'config*.json' -type f -exec sed -i '/PrometheusSimple/d' {} +
+        fi
 
         # Prepare mithril client env configs
         ${

--- a/flakeModules/entrypoints.nix
+++ b/flakeModules/entrypoints.nix
@@ -257,8 +257,13 @@ in {
             args+=("--topology" "$NODE_TOPOLOGY")
             echo "Running node as:"
             if [ "''${USE_SHELL_BINS:-}" = "true" ]; then
-              echo "cardano-node run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
-              exec cardano-node run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
+              if [ -n "''${CARDANO_NODE_SHELL_BIN:-}" ]; then
+                echo "$CARDANO_NODE_SHELL_BIN run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
+                exec $CARDANO_NODE_SHELL_BIN run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
+              else
+                echo "cardano-node run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
+                exec cardano-node run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}
+              fi
             elif [ "''${UNSTABLE:-}" = "true" ]; then
               echo "${getExe cfgPkgs.cardano-node-ng} run ''${args[*]} ''${RTS_FLAGS:+''${RTS_FLAGS[*]}}"
               exec ${getExe cfgPkgs.cardano-node-ng} run "''${args[@]}" ''${RTS_FLAGS:+''${RTS_FLAGS[@]}}

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -748,7 +748,7 @@ in {
             fi
 
             if [ -z "''${PROTOCOL_VERSION_MINOR:-}" ]; then
-              PROTOCOL_VERSION_MAJOR="0"
+              PROTOCOL_VERSION_MINOR="0"
             fi
 
             # cardano-cli "$ERA_CMD" genesis create-testnet-data doesn't provide args for these

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -600,6 +600,8 @@ in {
             #   [$MAX_SUPPLY]
             #   [$NUM_CC_KEYS]
             #   [$NUM_GENESIS_KEYS]
+            #   [$PROTOCOL_VERSION_MAJOR]
+            #   [$PROTOCOL_VERSION_MINOR]
             #   [$SECURITY_PARAM]
             #   [$SLOT_LENGTH]
             #   [$START_TIME]
@@ -741,6 +743,14 @@ in {
               < "$GENESIS_DIR/shelley-genesis.json" \
               | sponge "$GENESIS_DIR/shelley-genesis.json"
 
+            if [ -z "''${PROTOCOL_VERSION_MAJOR:-}" ]; then
+              PROTOCOL_VERSION_MAJOR="9"
+            fi
+
+            if [ -z "''${PROTOCOL_VERSION_MINOR:-}" ]; then
+              PROTOCOL_VERSION_MAJOR="0"
+            fi
+
             # cardano-cli "$ERA_CMD" genesis create-testnet-data doesn't provide args for these
             jq --sort-keys \
               --argjson jsonUpdates "{
@@ -748,7 +758,9 @@ in {
                 \"epochLength\": $EPOCH_LENGTH,
                 \"securityParam\": $SECURITY_PARAM,
                 \"slotLength\": $SLOT_LENGTH_SEC}" \
-              '. += $jsonUpdates | .protocolParams.protocolVersion = {"major": 9, "minor": 0}' \
+                --argjson PROTOCOL_VERSION_MAJOR "$PROTOCOL_VERSION_MAJOR" \
+                --argjson PROTOCOL_VERSION_MINOR "$PROTOCOL_VERSION_MINOR" \
+              '. += $jsonUpdates | .protocolParams.protocolVersion = {"major": $PROTOCOL_VERSION_MAJOR, "minor": $PROTOCOL_VERSION_MINOR}' \
               < "$GENESIS_DIR/shelley-genesis.json" \
               | sponge "$GENESIS_DIR/shelley-genesis.json"
 

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -1846,6 +1846,7 @@ in {
             #   $PROPOSAL_ARGS
             #   [$PROPOSAL_HASH]
             #   [$PROPOSAL_URL]
+            #   [$SCRIPT_FILE]
             #   [$SCRIPT_FILE_URL]
             #   $STAKE_KEY
             #   [$SUBMIT_TX]
@@ -1884,7 +1885,7 @@ in {
 
             ACTION_ARGS+=()
             if [ -n "''${USE_GUARDRAILS:-}" ]; then
-              if [ -z "''${SCRIPT_FILE_URL:-}" ]; then
+              if [ -z "''${SCRIPT_FILE:-}" ] && [ -z "''${SCRIPT_FILE_URL:-}" ]; then
                 case "$TESTNET_MAGIC" in
                   764824073)
                     SCRIPT_FILE_URL="https://book.play.dev.cardano.org/environments/mainnet/guardrails-script.plutus"
@@ -1903,7 +1904,12 @@ in {
 
               if [[ "$ACTION" =~ ^(create-constitution|create-protocol-parameters-update|create-treasury-withdrawal)$ ]]; then
                 # The CONSTITUTION_SCRIPT hash should match the calculated policyId hash of the --proposal-script-file arg
-                CONSTITUTION_SCRIPT=$("''${CARDANO_CLI_NO_ERA[@]}" latest transaction policyid --script-file <(curl -sL "$SCRIPT_FILE_URL"))
+                if [ -n "''${SCRIPT_FILE:-}" ]; then
+                  CONSTITUTION_SCRIPT=$("''${CARDANO_CLI_NO_ERA[@]}" latest transaction policyid --script-file "$SCRIPT_FILE")
+                else
+                  CONSTITUTION_SCRIPT=$("''${CARDANO_CLI_NO_ERA[@]}" latest transaction policyid --script-file <(curl -sL "$SCRIPT_FILE_URL"))
+                fi
+
                 ACTION_ARGS+=("--constitution-script-hash" "$CONSTITUTION_SCRIPT")
               fi
             fi
@@ -1937,11 +1943,15 @@ in {
                   ' <<< "$UTXO"
               )
 
-              BUILD_TX_ARGS+=(
-                "--tx-in-collateral" "$TXIN_COLLATERAL"
-                "--proposal-script-file" "<(curl -sL \"$SCRIPT_FILE_URL\")"
-                "--proposal-redeemer-value" "{}"
-              )
+              BUILD_TX_ARGS+=("--tx-in-collateral" "$TXIN_COLLATERAL")
+
+              if [ -n "''${SCRIPT_FILE:-}" ]; then
+                BUILD_TX_ARGS+=("--proposal-script-file" "$SCRIPT_FILE")
+              else
+                BUILD_TX_ARGS+=("--proposal-script-file" "<(curl -sL \"$SCRIPT_FILE_URL\")")
+              fi
+
+              BUILD_TX_ARGS+=("--proposal-redeemer-value" "{}")
             fi
 
             # Generate arrays needed for build/sign commands

--- a/flakeModules/jobs.nix
+++ b/flakeModules/jobs.nix
@@ -1194,8 +1194,8 @@ in {
             #   [$POOL_METADATA_URL]
             #   $POOL_NAMES
             #   [$POOL_PLEDGE]
-            #   $POOL_RELAY
-            #   $POOL_RELAY_PORT
+            #   [$POOL_RELAY]
+            #   [$POOL_RELAY_PORT]
             #   [$STAKE_ADDRESS_DEPOSIT]
             #   [$STAKE_POOL_DEPOSIT]
             #   [$STAKE_POOL_DIR]
@@ -1210,6 +1210,7 @@ in {
 
             export STAKE_POOL_DIR=''${STAKE_POOL_DIR:-stake-pools}
             METADATA_ARGS=()
+            POOL_ARGS=()
 
             ${secretsFns}
             ${selectCardanoCli}
@@ -1270,6 +1271,14 @@ in {
                 METADATA_ARGS+=("--metadata-url" "$POOL_METADATA_URL" "--metadata-hash" "$POOL_METADATA_HASH")
               fi
 
+              if [ -n "''${POOL_RELAY:-}" ]; then
+                POOL_ARGS+=(--single-host-pool-relay "$POOL_RELAY")
+              fi
+
+              if [ -n "''${POOL_RELAY_PORT:-}" ]; then
+                POOL_ARGS+=(--pool-relay-port "$POOL_RELAY_PORT")
+              fi
+
               # Generate stake registration and delegation certificate
               if [ "$ERA_CMD" = "conway" ]; then
                 eraArgs=("--key-reg-deposit-amt" "$STAKE_ADDRESS_DEPOSIT")
@@ -1310,8 +1319,7 @@ in {
                   --pool-margin "$POOL_MARGIN" \
                   --pool-owner-stake-verification-key-file "$(decrypt_check "$NO_DEPLOY_FILE"-owner-stake.vkey)" \
                   --pool-pledge "$POOL_PLEDGE" \
-                  --single-host-pool-relay "$POOL_RELAY" \
-                  --pool-relay-port "$POOL_RELAY_PORT" \
+                  "''${POOL_ARGS[@]}" \
                   --pool-reward-account-verification-key-file "$(decrypt_check "$NO_DEPLOY_FILE"-reward-stake.vkey)" \
                   --vrf-verification-key-file "$(decrypt_check "$DEPLOY_FILE"-vrf.vkey)" \
                   "''${METADATA_ARGS[@]}" \
@@ -1329,8 +1337,7 @@ in {
                   --pool-margin "$POOL_MARGIN" \
                   --pool-owner-stake-verification-key-file "$(decrypt_check "$NO_DEPLOY_FILE"-owner-stake.vkey)" \
                   --pool-pledge "$POOL_PLEDGE" \
-                  --single-host-pool-relay "$POOL_RELAY" \
-                  --pool-relay-port "$POOL_RELAY_PORT" \
+                  "''${POOL_ARGS[@]}" \
                   --pool-reward-account-verification-key-file "$(decrypt_check "$NO_DEPLOY_FILE"-reward-stake.vkey)" \
                   --vrf-verification-key-file "$(decrypt_check "$DEPLOY_FILE"-vrf.vkey)" \
                   "''${METADATA_ARGS[@]}" \

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -478,12 +478,12 @@ in
           mithril-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
           # The current mithril unstable tag has broken nix builds, so set to the current release until fixed
           # mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
-          mithril-pre-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
+          mithril-pre-release = "input-output-hk-mithril-unstable-c064115";
 
           node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-4-5a4dcd1";
           # node-release = pkg: localFlake.inputs.cardano-node-10-6-3.packages.x86_64-linux.${pkg};
 
-          node-pre-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-0-1e6d822";
+          node-pre-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-1-045bc18";
           # node-pre-release = pkg: localFlake.inputs.cardano-node-10-7-0.packages.x86_64-linux.${pkg};
         in
           submodule {
@@ -493,7 +493,7 @@ in
               (mkPkg "blockperf" blockperf)
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-2-5c00d7b")
               (mkPkg "cardano-cli" ((node-release "cardano-cli") // {version = "10.15.0.0";}))
-              (mkPkg "cardano-cli-ng" ((node-pre-release "cardano-cli") // {version = "10.15.1.0";}))
+              (mkPkg "cardano-cli-ng" ((node-pre-release "cardano-cli") // {version = "10.16.0.0";}))
               (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-release}")
               (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-pre-release}")
               (mkPkg "cardano-db-tool" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-release}")
@@ -501,7 +501,7 @@ in
               (mkPkg "cardano-faucet" faucet)
               (mkPkg "cardano-faucet-ng" faucet-ng)
               (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.6.4";}))
-              (mkPkg "cardano-node-ng" ((node-pre-release "cardano-node") // {version = "10.7.0";}))
+              (mkPkg "cardano-node-ng" ((node-pre-release "cardano-node") // {version = "10.7.1";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-14-0-5752501)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-34-0-4108dd3)
               (mkPkg "cardano-smash" caPkgs."cardano-smash-server-no-basic-auth-${dbsync-release}")

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -465,7 +465,7 @@ in
           blockperf = caPkgs.blockperf-cardano-foundation-blockperf-main-626ad7b;
 
           credential-manager-release = "IntersectMBO-credential-manager-0-1-5-0-ba221bd";
-          dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-8-2017bda";
+          dbsync-release = "input-output-hk-cardano-db-sync-13-7-0-4-63dbf19";
           dbsync-pre-release = "input-output-hk-cardano-db-sync-13-7-0-4-63dbf19";
 
           faucet = caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-6-762bb26";

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -480,7 +480,7 @@ in
           # mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
           mithril-pre-release = "input-output-hk-mithril-unstable-c064115";
 
-          node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-6-4-5a4dcd1";
+          node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-1-045bc18";
           # node-release = pkg: localFlake.inputs.cardano-node-10-6-3.packages.x86_64-linux.${pkg};
 
           node-pre-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-1-045bc18";
@@ -492,7 +492,7 @@ in
               (mkPkg "blockfrost-platform" caPkgs.default-blockfrost-blockfrost-platform-0-0-3-rc-3-e8da785)
               (mkPkg "blockperf" blockperf)
               (mkPkg "cardano-address" caPkgs."\"cardano-addresses:exe:cardano-address\"-IntersectMBO-cardano-addresses-4-0-2-5c00d7b")
-              (mkPkg "cardano-cli" ((node-release "cardano-cli") // {version = "10.15.0.0";}))
+              (mkPkg "cardano-cli" ((node-release "cardano-cli") // {version = "10.16.0.0";}))
               (mkPkg "cardano-cli-ng" ((node-pre-release "cardano-cli") // {version = "10.16.0.0";}))
               (mkPkg "cardano-db-sync" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-release}")
               (mkPkg "cardano-db-sync-ng" caPkgs."\"cardano-db-sync:exe:cardano-db-sync\"-${dbsync-pre-release}")
@@ -500,7 +500,7 @@ in
               (mkPkg "cardano-db-tool-ng" caPkgs."\"cardano-db-tool:exe:cardano-db-tool\"-${dbsync-pre-release}")
               (mkPkg "cardano-faucet" faucet)
               (mkPkg "cardano-faucet-ng" faucet-ng)
-              (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.6.4";}))
+              (mkPkg "cardano-node" ((node-release "cardano-node") // {version = "10.7.1";}))
               (mkPkg "cardano-node-ng" ((node-pre-release "cardano-node") // {version = "10.7.1";}))
               (mkPkg "cardano-ogmios" caPkgs.ogmios-input-output-hk-cardano-ogmios-v6-14-0-5752501)
               (mkPkg "cardano-signer" caPkgs.cardano-signer-johnalotoski-cardano-signer-v1-34-0-4108dd3)

--- a/flakeModules/pkgs.nix
+++ b/flakeModules/pkgs.nix
@@ -466,7 +466,7 @@ in
 
           credential-manager-release = "IntersectMBO-credential-manager-0-1-5-0-ba221bd";
           dbsync-release = "input-output-hk-cardano-db-sync-13-6-0-8-2017bda";
-          dbsync-pre-release = "input-output-hk-cardano-db-sync-13-7-0-2-0acc69f";
+          dbsync-pre-release = "input-output-hk-cardano-db-sync-13-7-0-4-63dbf19";
 
           faucet = caPkgs."\"cardano-faucet:exe:cardano-faucet\"-input-output-hk-cardano-faucet-10-6-762bb26";
           # faucet = localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet";
@@ -475,10 +475,10 @@ in
           # faucet-ng = localFlake.inputs.cardano-faucet.packages.x86_64-linux."cardano-faucet:exe:cardano-faucet";
 
           metadata-server-release = "input-output-hk-offchain-metadata-tools-ops-1-0-0-f406c6d";
-          mithril-release = "input-output-hk-mithril-2603-1-pre-567a8e8";
+          mithril-release = "input-output-hk-mithril-2617-0-2478748";
           # The current mithril unstable tag has broken nix builds, so set to the current release until fixed
           # mithril-pre-release = "input-output-hk-mithril-unstable-b31ce25";
-          mithril-pre-release = "input-output-hk-mithril-unstable-c064115";
+          mithril-pre-release = "input-output-hk-mithril-unstable-0229ae2";
 
           node-release = pkg: caPkgs."${pkg}-input-output-hk-cardano-node-10-7-1-045bc18";
           # node-release = pkg: localFlake.inputs.cardano-node-10-6-3.packages.x86_64-linux.${pkg};

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -1170,7 +1170,7 @@ update-ips:
   let machineCount = ($ipTable | length)
   let nonNixosMachineCount = ($nonNixosMachines | length)
 
-  print $"Processing ip information for ($nixosNodeCount) nixos machine(s) and ($nonNixosMachineCount) non-nixos machine(s)..."
+  print $"Processing ip information for ($nixosNodeCount) nixos machine\(s) and ($nonNixosMachineCount) non-nixos machine\(s)..."
   print $"Ips were written for a machine count of: ($machineCount)"
 
   if $nixosNodeCount != ($machineCount | $in - $nonNixosMachineCount | into string) {

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -37,8 +37,8 @@ checkEnv := '''
 checkEnvWithoutOverride := '''
   ENV="${1:-}"
 
-  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo$|^sanchonet$ ]]; then
-    >&2 echo "Error: only node environments for demo, dijkstra, mainnet, preprod, preview and sanchonet are supported"
+  if ! [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^demo$|^leios$|^sanchonet$ ]]; then
+    >&2 echo "Error: only node environments for demo, dijkstra, leios, mainnet, preprod, preview and sanchonet are supported"
     >&2 echo "Usage: just set-default-cardano-env <env>"
     exit 1
   fi
@@ -53,6 +53,8 @@ checkEnvWithoutOverride := '''
     MAGIC="4"
   elif [ "$ENV" = "dijkstra" ]; then
     MAGIC="6"
+  elif [ "$ENV" = "leios" ]; then
+    MAGIC="164"
   elif [ "$ENV" = "demo" ]; then
     MAGIC="42"
   fi
@@ -388,8 +390,8 @@ dedelegate-pools ENV *IDXS=null:
   set -euo pipefail
   {{checkEnvWithoutOverride}}
 
-  if ! [[ "$ENV" =~ ^preprod$|^preview$|^dijkstra$|^sanchonet$ ]]; then
-    echo "Error: only node environments for preprod, preview, dijkstra and sanchonet are supported"
+  if ! [[ "$ENV" =~ ^dijkstra$|^leios$|^preprod$|^preview$|^sanchonet$ ]]; then
+    echo "Error: only node environments for preprod, preview, dijkstra, leios and sanchonet are supported"
     exit 1
   fi
 
@@ -551,7 +553,7 @@ query-tip-all:
   #!/usr/bin/env bash
   set -euo pipefail
   QUERIED=0
-  for i in mainnet preprod preview dijkstra demo sanchonet; do
+  for i in mainnet preprod preview dijkstra demo leios sanchonet; do
     TIP=$(just query-tip $i 2>&1) && {
       echo "Environment: $i"
       echo "$TIP"
@@ -574,7 +576,7 @@ query-tip ENV TESTNET_MAGIC=null:
     CARDANO_CLI="cardano-cli"
   elif [ "${UNSTABLE:-}" = "true" ]; then
     CARDANO_CLI="cardano-cli-ng"
-  elif [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$ ]]; then
+  elif [[ "$ENV" =~ ^mainnet$|^preprod$|^preview$|^leios$ ]]; then
     CARDANO_CLI="cardano-cli"
   elif [[ "$ENV" =~ ^dijkstra$|^demo$|^sanchonet$ ]]; then
     CARDANO_CLI="cardano-cli-ng"
@@ -830,8 +832,8 @@ start-node ENV:
   set -euo pipefail
   {{stateDir}}
 
-  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^sanchonet$ ]]; then
-    echo "Error: only node environments for mainnet, preprod, preview, dijkstra and sanchonet are supported for start-node recipe"
+  if ! [[ "{{ENV}}" =~ ^mainnet$|^preprod$|^preview$|^dijkstra$|^leios$|^sanchonet$ ]]; then
+    echo "Error: only node environments for mainnet, preprod, preview, dijkstra, leios and sanchonet are supported for start-node recipe"
     exit 1
   fi
 
@@ -845,6 +847,14 @@ start-node ENV:
     UNSTABLE_LIB=false
     UNSTABLE_MITHRIL=false
     USE_NODE_CONFIG_BP=false
+  elif [[ "{{ENV}}" == leios ]]; then
+    export CARDANO_NODE_SHELL_BIN="$(nix build -Lv github:IntersectMBO/cardano-node/leios-prototype#cardano-node --no-link --print-out-paths)/bin/cardano-node"
+    export USE_SHELL_BINS=true
+    export LEIOS_DB_PATH="$STATEDIR/db-leios/node/leios.db"
+    UNSTABLE=false
+    UNSTABLE_LIB=true
+    UNSTABLE_MITHRIL=false
+    USE_NODE_CONFIG_BP=false
   else
     UNSTABLE=true
     UNSTABLE_LIB=true
@@ -854,13 +864,13 @@ start-node ENV:
 
   # Set required entrypoint vars and run node in a new nohup background session
   ENVIRONMENT="{{ENV}}" \
-  UNSTABLE="$UNSTABLE" \
-  UNSTABLE_LIB="$UNSTABLE_LIB" \
-  UNSTABLE_MITHRIL="$UNSTABLE_MITHRIL" \
-  USE_NODE_CONFIG_BP="$USE_NODE_CONFIG_BP" \
-  DATA_DIR="$STATEDIR" \
-  SOCKET_PATH="$STATEDIR/node-{{ENV}}.socket" \
-  nohup setsid nix run .#run-cardano-node &> "$STATEDIR/node-{{ENV}}.log" & echo $! > "$STATEDIR/node-{{ENV}}.pid" &
+    UNSTABLE="$UNSTABLE" \
+    UNSTABLE_LIB="$UNSTABLE_LIB" \
+    UNSTABLE_MITHRIL="$UNSTABLE_MITHRIL" \
+    USE_NODE_CONFIG_BP="$USE_NODE_CONFIG_BP" \
+    DATA_DIR="$STATEDIR" \
+    SOCKET_PATH="$STATEDIR/node-{{ENV}}.socket" \
+    nohup setsid nix run .#run-cardano-node &> "$STATEDIR/node-{{ENV}}.log" & echo $! > "$STATEDIR/node-{{ENV}}.pid" &
   echo "Node started for {{ENV}}"
   echo ""
   echo "Set up your shell environment with:"
@@ -870,7 +880,7 @@ start-node ENV:
 stop-all:
   #!/usr/bin/env bash
   set -euo pipefail
-  for i in mainnet preprod preview dijkstra demo sanchonet; do
+  for i in mainnet preprod preview dijkstra demo leios sanchonet; do
     just stop-node $i
   done
 

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -526,41 +526,6 @@ list-machines:
       | each { |r| { index: ($r.index + 1) } | merge $r.item }
   }
 
-# Check mimir required config
-mimir-alertmanager-bootstrap:
-  #!/usr/bin/env bash
-  set -euo pipefail
-  echo "Enter the mimir admin username: "
-  read -s MIMIR_USER
-  echo
-
-  echo "Enter the mimir admin token: "
-  read -s MIMIR_TOKEN
-  echo
-
-  echo "Enter the mimir base monitoring fqdn without the HTTPS:// scheme: "
-  read URL
-  echo
-
-  echo "Obtaining current mimir alertmanager config:"
-  echo "-----------"
-  mimirtool alertmanager get --address "https://$MIMIR_USER:$MIMIR_TOKEN@$URL/mimir" --id 1
-  echo "-----------"
-
-  echo
-  echo "If the output between the dashed lines above is blank, you may need to preload an initial alertmanager ruleset"
-  echo "for the mimir TF plugin to succeed, where the command to preload alertmanager is:"
-  echo
-  echo "mimirtool alertmanager load --address \"https://\$MIMIR_USER:\$MIMIR_TOKEN@$URL/mimir\" --id 1 alertmanager-bootstrap-config.yaml"
-  echo
-  echo "The contents of alertmanager-bootstrap-config.yaml can be:"
-  echo
-  echo "route:"
-  echo "  group_wait: 0s"
-  echo "  receiver: empty-receiver"
-  echo "receivers:"
-  echo "  - name: 'empty-receiver'"
-
 # Query the tip of all running envs
 query-tip-all:
   #!/usr/bin/env bash

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -255,7 +255,7 @@ apply-bootstrap *ARGS:
 
   [ -f .ssh_key ] || just save-bootstrap-ssh-key
 
-  sed '2i \ \ IdentityFile .ssh_key' .ssh_config > .ssh_config_bootstrap
+  sed '/^Host /a\  IdentityFile .ssh_key\n  IdentitiesOnly yes' .ssh_config > .ssh_config_bootstrap
   SSH_CONFIG_FILE=".ssh_config_bootstrap" just apply {{ARGS}}
   rm .ssh_config_bootstrap
 
@@ -740,7 +740,7 @@ ssh-bootstrap HOSTNAME *ARGS:
   #!/usr/bin/env nu
   {{checkSshConfig}}
   {{checkSshKey}}
-  ssh -o LogLevel=ERROR -F .ssh_config -i .ssh_key "{{HOSTNAME}}" {{ARGS}}
+  ssh -o LogLevel=ERROR -o IdentitiesOnly=yes -F .ssh_config -i .ssh_key "{{HOSTNAME}}" {{ARGS}}
 
 # Ssh to all
 ssh-for-all *ARGS:

--- a/templates/cardano-parts-project/Justfile
+++ b/templates/cardano-parts-project/Justfile
@@ -526,6 +526,26 @@ list-machines:
       | each { |r| { index: ($r.index + 1) } | merge $r.item }
   }
 
+# Copy a nix store path to a machine and pin it with a gc root
+nix-copy-to-machine MACHINE STORE_PATH:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Copying {{STORE_PATH}} to {{MACHINE}}..."
+  NIX_SSHOPTS="-F $(pwd)/.ssh_config" nix copy --to "ssh://{{MACHINE}}" "{{STORE_PATH}}"
+  echo "Creating GC root on {{MACHINE}}..."
+  just ssh {{MACHINE}} "nix-store --add-root /nix/var/nix/gcroots/$(basename {{STORE_PATH}}) --realise {{STORE_PATH}}"
+  echo "Done. Store path pinned on {{MACHINE}}."
+
+# Pin a path to the local nix store
+nix-store-pin PATH:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  echo "Adding {{PATH}} to the nix store..."
+  STORE_PATH=$(nix store add "{{PATH}}")
+  echo "Creating GC root..."
+  sudo nix-store --add-root "/nix/var/nix/gcroots/$(basename "$STORE_PATH")" --realise "$STORE_PATH"
+  echo "Done. Stored and pinned at: $STORE_PATH"
+
 # Query the tip of all running envs
 query-tip-all:
   #!/usr/bin/env bash

--- a/templates/cardano-parts-project/README.md
+++ b/templates/cardano-parts-project/README.md
@@ -127,6 +127,11 @@ All other cluster resource configuration is in `./flake/opentofu/cluster.nix`
 The wrapper to setup the state, workspace, evaluate the config, and run `tofu`
 for cluster resources is:
 
+    # Required for AMI generation
+    just tofu bootstrap plan
+    just tofu bootstrap apply
+
+    # Uses the AMI generated above
     just tofu [cluster] plan
     just tofu [cluster] apply
 

--- a/templates/cardano-parts-project/README.md
+++ b/templates/cardano-parts-project/README.md
@@ -106,7 +106,8 @@ go into OpenTofu since they are harder to configure and reuse otherwise.
 All configuration is in `./flake/cloudFormation/terraformState.nix`
 
 We use [Rain](https://github.com/aws-cloudformation/rain) to apply the
-configuration. There is a wrapper that evaluates the config and deploys it:
+configuration. Before running Cloudformation, update and encrypt any tf
+secrets. There is a wrapper that evaluates the config and deploys it:
 
     just cf terraformState
 

--- a/templates/cardano-parts-project/README.md
+++ b/templates/cardano-parts-project/README.md
@@ -127,6 +127,10 @@ All other cluster resource configuration is in `./flake/opentofu/cluster.nix`
 The wrapper to setup the state, workspace, evaluate the config, and run `tofu`
 for cluster resources is:
 
+    # Ensure tf secrets are created and encrypted
+    # Follow the instructions in the secrets/tf/*.tfvars files
+    # See additional encryption instructions below
+
     # Required for AMI generation
     just tofu bootstrap plan
     just tofu bootstrap apply

--- a/templates/cardano-parts-project/flake/cloudFormation/terraformState.nix
+++ b/templates/cardano-parts-project/flake/cloudFormation/terraformState.nix
@@ -139,30 +139,6 @@ with lib; {
           };
         };
 
-        S3BucketPolicyS3ServerAccessLogs = {
-          Type = "AWS::S3::BucketPolicy";
-          DependsOn = "S3BucketS3ServerAccessLogsPolicySecureTransport";
-          Properties = {
-            Bucket.Ref = "S3BucketS3ServerAccessLogs";
-            PolicyDocument = {
-              Version = "2012-10-17";
-              Statement = [
-                {
-                  Sid = "S3ServerAccessLogsPolicy";
-                  Effect = "Allow";
-                  Principal.Service = "logging.s3.amazonaws.com";
-                  Action = "s3:PutObject";
-                  Resource = "arn:aws:s3:::${s3ServerAccessLogsBucket}/*";
-                  Condition = {
-                    ArnLike."aws:SourceArn" = "arn:aws:s3:::*";
-                    StringEquals."aws:SourceAccount" = orgId;
-                  };
-                }
-              ];
-            };
-          };
-        };
-
         DynamoDB = {
           Type = "AWS::DynamoDB::Table";
           DependsOn = "kmsKeyAlias";
@@ -203,34 +179,56 @@ with lib; {
         };
       }
       // lib.mapAttrs' (
-        resourceName: bucketName:
+        resourceName: {
+          bucketName,
+          extraStatements ? [],
+        }:
           lib.nameValuePair
-          "${resourceName}PolicySecureTransport"
+          "${resourceName}Policy"
           {
             Type = "AWS::S3::BucketPolicy";
             Properties = {
               Bucket.Ref = resourceName;
               PolicyDocument = {
                 Version = "2012-10-17";
-                Statement = [
-                  {
-                    Sid = "RestrictToTLSRequestsOnly";
-                    Effect = "Deny";
-                    Action = "s3:*";
-                    Resource = [
-                      "arn:aws:s3:::${bucketName}"
-                      "arn:aws:s3:::${bucketName}/*"
-                    ];
-                    Condition.Bool."aws:SecureTransport" = "false";
-                    Principal = "*";
-                  }
-                ];
+                Statement =
+                  [
+                    {
+                      Sid = "RestrictToTLSRequestsOnly";
+                      Effect = "Deny";
+                      Action = "s3:*";
+                      Resource = [
+                        "arn:aws:s3:::${bucketName}"
+                        "arn:aws:s3:::${bucketName}/*"
+                      ];
+                      Condition.Bool."aws:SecureTransport" = "false";
+                      Principal = "*";
+                    }
+                  ]
+                  ++ extraStatements;
               };
             };
           }
       ) {
-        S3BucketS3ServerAccessLogs = s3ServerAccessLogsBucket;
-        S3Bucket = bucketName;
+        S3BucketS3ServerAccessLogs = {
+          bucketName = s3ServerAccessLogsBucket;
+          extraStatements = [
+            {
+              Sid = "S3ServerAccessLogsPolicy";
+              Effect = "Allow";
+              Principal.Service = "logging.s3.amazonaws.com";
+              Action = "s3:PutObject";
+              Resource = "arn:aws:s3:::${s3ServerAccessLogsBucket}/*";
+              Condition = {
+                ArnLike."aws:SourceArn" = "arn:aws:s3:::*";
+                StringEquals."aws:SourceAccount" = orgId;
+              };
+            }
+          ];
+        };
+        S3Bucket = {
+          inherit bucketName;
+        };
       };
   };
 }

--- a/templates/cardano-parts-project/flake/cloudFormation/terraformState.nix
+++ b/templates/cardano-parts-project/flake/cloudFormation/terraformState.nix
@@ -141,6 +141,7 @@ with lib; {
 
         S3BucketPolicyS3ServerAccessLogs = {
           Type = "AWS::S3::BucketPolicy";
+          DependsOn = "S3BucketS3ServerAccessLogsPolicySecureTransport";
           Properties = {
             Bucket.Ref = "S3BucketS3ServerAccessLogs";
             PolicyDocument = {
@@ -164,6 +165,7 @@ with lib; {
 
         DynamoDB = {
           Type = "AWS::DynamoDB::Table";
+          DependsOn = "kmsKeyAlias";
           DeletionPolicy = "RetainExceptOnCreate";
           Properties = {
             Tags = tagWith "terraform-DynamoDB";

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -23,6 +23,7 @@ in
 
       # Helper fns:
       ebs = size: {aws.instance.root_block_device.volume_size = mkDefault size;};
+      # noBPerf = {services.blockperf.enable = false;};
       # ebsIops = iops: {aws.instance.root_block_device.iops = mkDefault iops;};
       # ebsTp = tp: {aws.instance.root_block_device.throughput = mkDefault tp;};
       # ebsHighPerf = recursiveUpdate (ebsIops 10000) (ebsTp 1000);
@@ -59,24 +60,6 @@ in
           # To continue using legacy tracing, this option will be available for a few
           # more cardano-node and cardano-parts releases.
           # {services.cardano-node.useLegacyTracing = true;}
-
-          # By default, the new tracing system will forward metrics and logs to
-          # cardano-tracer. To use only the native logging and PrometheusSimple
-          # metrics from cardano-node, cardano-tracer can be disabled with the
-          # following options.
-          #
-          # Note that in the new tracing system, blockperf service will *not*
-          # work without cardano-tracer, as node cannot export logs in a
-          # blockperf consumable manner, so blockperf service should also be
-          # disabled if imported.
-          # {
-          #   services = {
-          #     # If blockperf is also enabled, disable it:
-          #     # blockperf.enable = false;
-          #     cardano-node.tracerSocketPathConnect = null;
-          #     cardano-tracer.enable = false;
-          #   };
-          # }
         ];
       };
 

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -238,22 +238,27 @@ in
           foldl'
           (acc: node: let
             instanceType = node: nixosConfigurations.${node}.config.aws.instance.instance_type;
+
+            # Handle when cardano-parts isn't fully initialized (new machines)
+            hasCardanoParts = config.flake ? cardano-parts && config.flake.cardano-parts ? aws;
           in
-            recursiveUpdate acc {
-              ${node} = {
-                nodeResources = {
-                  inherit
-                    (config.flake.cardano-parts.aws.ec2.spec.${instanceType node})
-                    provider
-                    coreCount
-                    cpuCount
-                    memMiB
-                    nodeType
-                    threadsPerCore
-                    ;
+            recursiveUpdate acc (
+              optionalAttrs hasCardanoParts {
+                ${node} = {
+                  nodeResources = {
+                    inherit
+                      (config.flake.cardano-parts.aws.ec2.spec.${instanceType node})
+                      provider
+                      coreCount
+                      cpuCount
+                      memMiB
+                      nodeType
+                      threadsPerCore
+                      ;
+                  };
                 };
-              };
-            })
+              }
+            ))
           {} (attrNames nixosConfigurations);
       };
 

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -44,23 +44,6 @@ in
         };
       };
 
-      # Declare a static ipv6. This should only be used for public machines
-      # where ip exposure in committed code is acceptable and a vanity address
-      # is needed. Ie: don't use this for bps.
-      #
-      # In the case that a staticIpv6 is not declared, aws will assign one
-      # automatically.
-      #
-      # NOTE: As of aws provider 5.66.0, switching from ipv6_address_count to
-      # ipv6_addresses will force an instance replacement. If a self-declared
-      # ipv6 is required but destroying and re-creating instances to change
-      # ipv6 is not acceptable, then until the bug is fixed, continue using
-      # auto-assignment only, manually change the ipv6 in the console ui, and
-      # run tf apply to update state.
-      #
-      # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/39433
-      # staticIpv6 = ipv6: {aws.instance.ipv6 = ipv6;};
-
       # Cardano-node modules for group deployment
       node = {
         imports = [

--- a/templates/cardano-parts-project/flake/nixosModules/ami.nix
+++ b/templates/cardano-parts-project/flake/nixosModules/ami.nix
@@ -44,10 +44,21 @@
     config = let
       arcMaxBytes = calcArcMaxBytes config.boot.zfs.zfsArcPct;
     in {
-      # Set ZFS ARC max size via kernel parameter
-      boot.kernelParams = mkIf (config.boot.zfs.zfsArcPct != null) [
-        "zfs.zfs_arc_max=${toString arcMaxBytes}"
-      ];
+      boot = {
+        # Cardano-node >= 10.7.0 requires kernel >= 6.15 for LSM, without which
+        # large IOWAIT will be observed.
+        kernelPackages = pkgs.linuxPackages_6_18;
+
+        # Set ZFS ARC max size via kernel parameter
+        kernelParams = mkIf (config.boot.zfs.zfsArcPct != null) [
+          "zfs.zfs_arc_max=${toString arcMaxBytes}"
+        ];
+
+        # Use ZFS 2.4 with the latest compatible kernel (6.18)
+        # ZFS 2.3.5 only supports up to 6.17, and no 6.15-6.17 kernels are packaged.
+        # ZFS 2.4.0 supports up to 6.18, and linuxPackages_6_18 is available.
+        zfs.package = pkgs.zfs_2_4;
+      };
 
       ec2 = {
         efi = true;

--- a/templates/cardano-parts-project/flake/nixosModules/ami.nix
+++ b/templates/cardano-parts-project/flake/nixosModules/ami.nix
@@ -44,6 +44,17 @@
     config = let
       arcMaxBytes = calcArcMaxBytes config.boot.zfs.zfsArcPct;
     in {
+      # The nixpkgs AMI image builder (make-multi-disk-zfs-image.nix) uses
+      # pkgs.zfs for the build VM's kernel modules and userspace tools.
+      # Since we use a non-default kernel (6.18), the default ZFS (2.3.5)
+      # is incompatible and marked broken. This overlay aligns pkgs.zfs
+      # with our boot.zfs.package so the build VM can load ZFS modules.
+      nixpkgs.overlays = [
+        (final: _: {
+          zfs = final.zfs_2_4;
+        })
+      ];
+
       boot = {
         # Cardano-node >= 10.7.0 requires kernel >= 6.15 for LSM, without which
         # large IOWAIT will be observed.

--- a/templates/cardano-parts-project/flake/nixosModules/ami.nix
+++ b/templates/cardano-parts-project/flake/nixosModules/ami.nix
@@ -50,7 +50,7 @@
         kernelPackages = pkgs.linuxPackages_6_18;
 
         # Set ZFS ARC max size via kernel parameter
-        kernelParams = mkIf (config.boot.zfs.zfsArcPct != null) [
+        kernelParams = mkIf (arcMaxBytes != null) [
           "zfs.zfs_arc_max=${toString arcMaxBytes}"
         ];
 

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -443,20 +443,7 @@ in {
               // optionalAttrs (node.aws.instance ? availability_zone) {
                 inherit (node.aws.instance) availability_zone;
               }
-              # Use nix declared ipv6 if available.  This should only be used
-              # for public machines where ip exposure in committed code is
-              # acceptable and a vanity address is needed. Ie: don't use this
-              # for bps.
-              #
-              # NOTE: As of aws provider 5.66.0, switching from
-              # ipv6_address_count to ipv6_addresses will force an instance
-              # replacement. If a self-declared ipv6 is required but
-              # destroying and re-creating instances to change ipv6 is not
-              # acceptable, then until the bug is fixed, continue using
-              # auto-assignment only, manually change the ipv6 in the console
-              # ui, and run tf apply to update state.
-              #
-              # Ref: https://github.com/hashicorp/terraform-provider-aws/issues/39433
+              # Use declared ipv6 if set
               // optionalAttrs (node.aws.instance ? ipv6) {
                 ipv6_addresses = "\${data.aws_vpc.${underscore region}.ipv6_cidr_block == \"\" ? null : tolist([\"${node.aws.instance.ipv6}\"])}";
               }

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -435,7 +435,7 @@ in {
                 metadata_options = {
                   http_endpoint = "enabled";
                   http_put_response_hop_limit = 2;
-                  http_tokens = "optional";
+                  http_tokens = "required";
                 };
 
                 lifecycle = [{ignore_changes = ["ami" "user_data"];}];

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -642,13 +642,11 @@ in {
             )
             dnsEnabledNodes
             // mapAttrs' (
-              nodeName: _:
+              nodeName: node:
                 nameValuePair "${nodeName}-AAAA" {
-                  # When transitioning into ipv6 dual stack and some instances still have ipv4 only, include the following line.
-                  # count = "\${length(aws_instance.${nodeName}[0].ipv6_addresses) > 0 ? 1 : 0}";
-                  #
-                  # When migration to ipv4/ipv6 dual stack is complete, comment the above line and uncomment the following line.
-                  count = "1";
+                  # When tofu applying a new aws org, tofu will need to be
+                  # applied twice to create the ipv6 dns record.
+                  count = "\${data.aws_vpc.${underscore node.aws.region}.ipv6_cidr_block != \"\" ? 1 : 0}";
 
                   zone_id = "\${data.aws_route53_zone.selected.zone_id}";
                   name = "${nodeName}.\${data.aws_route53_zone.selected.name}";

--- a/templates/cardano-parts-project/flake/opentofu/grafana.nix
+++ b/templates/cardano-parts-project/flake/opentofu/grafana.nix
@@ -130,7 +130,7 @@ in {
                     receiver = "deadmanssnitch";
                     matchers = [''alertname="DeadMansSnitch"''];
                     group_wait = "30s";
-                    group_interval = "5m";
+                    group_interval = "1m";
                     repeat_interval = "5m";
                   }
                 ];

--- a/templates/cardano-parts-project/scripts/bash-fns.sh
+++ b/templates/cardano-parts-project/scripts/bash-fns.sh
@@ -229,24 +229,49 @@ faucet() (
 )
 
 run-node-faketime() (
-  if [ "${UNSTABLE:-}" = "true" ]; then
+  if [ "${USE_SHELL_BINS:-}" = "true" ]; then
+    CMD=$(alias cardano-node | cut -d"'" -f2)
+  elif [ "${UNSTABLE:-}" = "true" ]; then
     CMD="cardano-node-ng"
   else
     CMD="cardano-node"
   fi
 
-  # If an older glibc is needed, obtain it from the correct nixpkgs:
-  # nix run github:nixos/nixpkgs/nixos-23.05#libfaketime -- "$1" "$CMD" run \
-  faketime "$1" "$CMD" run \
-    --config "$DATA_DIR"/node-config.json \
-    --database-path "$DATA_DIR"/db \
-    --topology "$DATA_DIR"/topology.json \
-    +RTS -N2 -A16m -qg -qb -M3584M -RTS \
-    --socket-path "$DATA_DIR"/node.socket \
-    --host-addr 0.0.0.0 \
-    --port 3001 \
-    --bulk-credentials-file "$GENESIS_DIR"/bulk.creds.all.json \
+  if [ -n "${DEBUG:-}" ]; then
+    echo "Node command: $CMD"
+    "$CMD" --version
+
+    if [ -n "${FAKETIME_FLAKE:-}" ]; then
+      echo "Using faketime from nixpkgs pin: $FAKETIME_FLAKE"
+    fi
+  fi
+
+  ARGS=(
+    "$1" "$CMD" "run"
+    "--config" "$DATA_DIR/node-config.json"
+    "--database-path" "$DATA_DIR/db"
+    "--topology" "$DATA_DIR/topology.json"
+    "+RTS" "-N2" "-A16m" "-qg" "-qb" "-M3584M" "-RTS"
+    "--socket-path" "$DATA_DIR/node.socket"
+    "--host-addr" "0.0.0.0"
+    "--port" "3001"
+    "--bulk-credentials-file" "$GENESIS_DIR/bulk.creds.all.json"
+  )
+
+  # If an older glibc is needed, obtain it from the correct nixpkgs.
+  # To do so, set FAKETIME_FLAKE in the caller, example:
+  #
+  # export FAKETIME_FLAKE="github:nixos/nixpkgs/nixos-23.05"
+  #
+  if [ -n "${FAKETIME_FLAKE:-}" ]; then
+    nix run "$FAKETIME_FLAKE"#libfaketime -- \
+      "${ARGS[@]}" \
     | tee -a "$DATA_DIR"/node.log
+  else
+    faketime \
+      "${ARGS[@]}" \
+    | tee -a "$DATA_DIR"/node.log
+  fi
 )
 
 synth-prep() (
@@ -261,7 +286,9 @@ synth-restore() (
 )
 
 synth-slots() (
-  if [ "${UNSTABLE:-}" = "true" ]; then
+  if [ "${USE_SHELL_BINS:-}" = "true" ]; then
+    CMD=$(alias db-synthesizer | cut -d"'" -f2)
+  elif [ "${UNSTABLE:-}" = "true" ]; then
     CMD="db-synthesizer-ng"
   else
     CMD="db-synthesizer"
@@ -278,7 +305,9 @@ synth-slots() (
 )
 
 synth-epochs() (
-  if [ "${UNSTABLE:-}" = "true" ]; then
+  if [ "${USE_SHELL_BINS:-}" = "true" ]; then
+    CMD=$(alias db-synthesizer | cut -d"'" -f2)
+  elif [ "${UNSTABLE:-}" = "true" ]; then
     CMD="db-synthesizer-ng"
   else
     CMD="db-synthesizer"

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-loki-url.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-loki-url.enc
@@ -1,7 +1,7 @@
 # To enable nixos grafana-alloy monitoring functionality:
 #   * update the following with a grafana alloy loki url
 #   * remove these comments
-#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol binary` and save)
 #   * encrypt this file with sops as a binary type using KMS
 #   * see the repo README.md file for an example encryption command using sops and KMS
 #

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-password.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-password.enc
@@ -1,7 +1,7 @@
 # To enable nixos grafana-alloy monitoring functionality:
 #   * update the following with a grafana alloy metrics password
 #   * remove these comments
-#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol binary` and save)
 #   * encrypt this file with sops as a binary type using KMS
 #   * see the repo README.md file for an example encryption command using sops and KMS
 #

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-url.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-url.enc
@@ -1,7 +1,7 @@
 # To enable nixos grafana-alloy monitoring functionality:
 #   * update the following with a grafana alloy metrics url
 #   * remove these comments
-#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol binary` and save)
 #   * encrypt this file with sops as a binary type using KMS
 #   * see the repo README.md file for an example encryption command using sops and KMS
 #

--- a/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-username.enc
+++ b/templates/cardano-parts-project/secrets/monitoring/grafana-alloy-metrics-username.enc
@@ -1,7 +1,7 @@
 # To enable nixos grafana-alloy monitoring functionality:
 #   * update the following with a grafana alloy metrics username
 #   * remove these comments
-#   * ensure there is no end of file newline (ex: in vim, `:set noeol nofixeol` and save)
+#   * ensure there is no end of file newline (ex: in vim, `:set noeol binary` and save)
 #   * encrypt this file with sops as a binary type using KMS
 #   * see the repo README.md file for an example encryption command using sops and KMS
 #


### PR DESCRIPTION
## Overview

This release updates cardano-node to `10.7.1`, cardano-db-sync to `13.7.0.4`, mithril to `2617.0` and mithril pre-release to `unstable`. Leios testnet environment support was added. The default Linux kernel is set to `6.18` for cardano-node LSM compatibility and ZFS is updated to `2.4` accordingly. Other miscellaneous improvements and fixes are detailed below.

## Details

Important versioning updates in this release are underlined:

| Component | Release | Pre-release |
|:---------:|:-------:|:-----------:|
| blockperf | 2.0.3 | N/A |
| cardano-address | 4.0.2 | N/A |
| cardano-cli | **10.16.0.0** | **10.16.0.0** |
| cardano-db-sync | **13.7.0.4** | **13.7.0.4** |
| cardano-faucet | 10.6 | 10.6 |
| cardano-node | **10.7.1** | **10.7.1** |
| cardano-ogmios | 6.14.0 | N/A |
| cardano-signer | 1.34.0 | N/A |
| cardano-wallet | v2025-12-15 | N/A |
| credential-manager | 0.1.5.0 | N/A |
| mithril | **2617.0** | **unstable** |
| nix* | 2.33.5 | N/A |
| nixpkgs* | 25.11 | N/A |

\* = For nixos machine deployments

### Key Changes

- Bumps cardano-node to `10.7.1`, cardano-cli to `10.16.0.0`, cardano-db-sync to `13.7.0.4` and mithril to `2617.0`
- Sets the default Linux kernel to `6.18` for cardano-node >= 10.7.0 LSM compatibility (avoids large IOWAIT)
- Updates ZFS to `2.4` and applies a nixpkgs overlay in the AMI module for kernel 6.18 compatibility
- Fixes the ZFS ARC max null check in the AMI module
- Adds `extraJournalReceivers` option to the Grafana Alloy nixosModule for additional loki journal forwarding targets
- Adds `NODE_CONFIG_SKIP_COPY` env var to the entrypoint to skip re-copying environment configs
- Adds `CARDANO_NODE_SHELL_BIN` support to the entrypoint for shell binary overrides when `USE_SHELL_BINS=true`
- Adds `PROTOCOL_VERSION_MAJOR` and `PROTOCOL_VERSION_MINOR` args to `job-gen-custom-node-config-data-ng`
- Makes `POOL_RELAY` and `POOL_RELAY_PORT` optional in `job-register-stake-pools`
- Adds local `SCRIPT_FILE` option to `job-submit-gov-action` (previously only remote `SCRIPT_FILE_URL` was supported)
- Adds cardano-node binary override support via `flakeModules/pkgs.nix`
- Changes EC2 `http_tokens` from `optional` to `required` (IMDSv2 enforcement)
- Fixes IPv6 AAAA DNS record chicken-egg bootstrap error by conditioning on VPC ipv6 CIDR
- Changes DeadMansSnitch `group_interval` from `5m` to `1m` to allow posting at the declared repeat interval
- Adds leios environment support to the Justfile with `start-node`, `stop-all`, `query-tip` recipes
- Adds `nix-copy-to-machine` and `nix-store-pin` recipes to the Justfile
- Removes deprecated `mimir-alertmanager-bootstrap` recipe
- Refactors `run-node-faketime`, `synth-slots` and `synth-epochs` bash functions for `USE_SHELL_BINS` support
- Fixes `update-ips` recipe missing escape characters
- Fixes bootstrap SSH config to use `IdentitiesOnly yes`
- Adds `hasCardanoParts` guard in colmena so CI builds don't fail when cardano-parts isn't present
- Removes deprecated `staticIpv6` helper and stale comments from colmena
- Improves cloudFormation bucket policy
- Updates README with flake customization instructions and encryption/AMI generation steps

## Breaking Changes, Recommended Updates and Action Items

### Breaking
- EC2 IMDSv2 is now required (`http_tokens = "required"`). Ensure any instance metadata usage supports IMDSv2.
- Linux kernel default is now `6.18` with ZFS `2.4`. AMI rebuilds are required for new deployments.

### Recommended Updates
- Update your cardano-parts pin to this release version.
- Complete Action Items below.

### Action Items

Diff and patch the following files with `just template-diff "$FILE"` and then `just template-patch "$FILE"`. Looking at the short PR diff for these files found at directory `templates/cardano-parts-project/` prior to diffing and patching against your own repo can also be helpful.

Alternatively, if you know you would just like to mirror any of these template files without diffing or patching, use the `just template-clone "$FILE"` recipe.

```
Justfile                                   # For leios support, nix-copy/pin recipes, bootstrap fixes, removed mimir recipe
README.md                                  # For flake customization, encryption and AMI generation instructions
flake/cloudFormation/terraformState.nix    # For improved bucket policy handling
flake/colmena.nix                          # For hasCardanoParts guard, removed staticIpv6, tracing cleanup
flake/nixosModules/ami.nix                 # For kernel 6.18, ZFS 2.4 overlay, ARC max fix
flake/opentofu/cluster.nix                 # For IMDSv2 enforcement, IPv6 bootstrap fix, removed vanity comments
flake/opentofu/grafana.nix                 # For DeadMansSnitch group_interval update
scripts/bash-fns.sh                        # For USE_SHELL_BINS support in faketime, synth-slots, synth-epochs
```

Additionally:
- Execute `just cf terraformState` to apply the updated bucket policy
- Rebuild AMIs with `just tofu bootstrap plan` and `just tofu bootstrap apply` for kernel 6.18 and ZFS 2.4 support
- Execute `just tofu apply` to update EC2 IMDSv2 enforcement and IPv6 DNS fixes
- Execute `just tofu grafana apply` to update the DeadMansSnitch group interval

## Known Issues

N/A
