### PR TITLE
nixosModule: add profile-monitoring for in-cluster Grafana stack

### DIFF
--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -16,6 +16,7 @@
 #   config.services.alloy.systemdEnableTaskMetrics
 #   config.services.alloy.systemdUnitExclude
 #   config.services.alloy.systemdUnitInclude
+#   config.services.alloy.useClusterMonitoring
 #   config.services.alloy.useSopsSecrets
 #
 # Tips:
@@ -39,6 +40,28 @@ flake @ {moduleWithSystem, ...}: {
       groupCfg = config.cardano-parts.cluster.group;
       groupOutPath = groupFlake.self.outPath;
       opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
+
+      clusterMonitoringFqdn = let
+        # Read through groupFlake (consumer's `self`) instead of
+        # `flake.config`; the latter closes over cardano-parts' own
+        # eval where these options carry their declared null defaults.
+        inherit (groupFlake.config.flake.cardano-parts.cluster.infra) aws monitoring;
+      in "${monitoring.subdomain}.${aws.domain}";
+
+      # Alloy HCL expressions for the remote_write target URLs. When
+      # useClusterMonitoring is true we substitute literal interpolated URLs
+      # so the matching `grafana-alloy-{metrics,loki}-url` sops secrets
+      # become unnecessary; otherwise the URLs are read at runtime from those
+      # sops files via local.file references.
+      metricsUrlExpr =
+        if cfg.useClusterMonitoring
+        then "\"https://${clusterMonitoringFqdn}/mimir/api/v1/push\""
+        else "local.file.remote_write_url.content";
+
+      logsUrlExpr =
+        if cfg.useClusterMonitoring
+        then "\"https://${clusterMonitoringFqdn}/loki/api/v1/push\""
+        else "local.file.remote_write_url_logs.content";
 
       mkSopsSecretParams = secretName: {
         inherit groupOutPath groupName name secretName;
@@ -70,14 +93,16 @@ flake @ {moduleWithSystem, ...}: {
 
         secrets = ''
           // Secrets
-          local.file "remote_write_url" {
-            filename = "/run/secrets/grafana-alloy-metrics-url"
-          }
-
-          ${optionalString cfg.enableLoki ''
+          ${optionalString (!cfg.useClusterMonitoring) ''
+            local.file "remote_write_url" {
+              filename = "/run/secrets/grafana-alloy-metrics-url"
+            }
+          ''}
+          ${optionalString (cfg.enableLoki && !cfg.useClusterMonitoring) ''
             local.file "remote_write_url_logs" {
               filename = "/run/secrets/grafana-alloy-loki-url"
-            }''}
+            }
+          ''}
 
           local.file "remote_write_username" {
             filename = "/run/secrets/grafana-alloy-metrics-username"
@@ -93,7 +118,7 @@ flake @ {moduleWithSystem, ...}: {
           // Default prometheus remote write target
           prometheus.remote_write "integrations" {
             endpoint {
-              url = local.file.remote_write_url.content
+              url = ${metricsUrlExpr}
 
               basic_auth {
                 username = local.file.remote_write_username.content
@@ -233,7 +258,7 @@ flake @ {moduleWithSystem, ...}: {
         in ''
           loki.write "default" {
             endpoint {
-              url = local.file.remote_write_url_logs.content
+              url = ${logsUrlExpr}
 
               basic_auth {
                 username = local.file.remote_write_username.content
@@ -645,6 +670,28 @@ flake @ {moduleWithSystem, ...}: {
             '';
           };
 
+          useClusterMonitoring = mkOption {
+            type = bool;
+            default = groupFlake.config.flake.cardano-parts.cluster.infra.monitoring.enable;
+            description = ''
+              Whether to default the alloy remote_write target to the
+              in-cluster monitoring node.
+
+              When true, the metrics and logs URLs are derived from
+              `flake.cardano-parts.cluster.infra.monitoring.subdomain` and
+              `flake.cardano-parts.cluster.infra.aws.domain`, and the matching
+              `grafana-alloy-metrics-url` / `grafana-alloy-loki-url` sops
+              secrets are not required.
+
+              The default tracks the cluster-level
+              `infra.monitoring.enable` so that enabling an in-cluster
+              monitoring node automatically retargets all alloy collectors.
+
+              Username and password basic-auth credentials are still required
+              regardless of this option.
+            '';
+          };
+
           useSopsSecrets = mkOption {
             type = bool;
             default = true;
@@ -657,9 +704,14 @@ flake @ {moduleWithSystem, ...}: {
               will need to be provided to the target machine either by
               additional module code or out of band:
 
-                /run/secrets/grafana-alloy-metrics-url
                 /run/secrets/grafana-alloy-metrics-username
                 /run/secrets/grafana-alloy-metrics-password
+
+              Additionally, when useClusterMonitoring is false, these files
+              are also required:
+
+                /run/secrets/grafana-alloy-metrics-url
+                /run/secrets/grafana-alloy-loki-url       (when enableLoki)
             '';
           };
         };
@@ -732,10 +784,14 @@ flake @ {moduleWithSystem, ...}: {
         };
 
         sops.secrets = mkIf cfg.useSopsSecrets (
-          mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-url")
-          // mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-username")
+          mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-username")
           // mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-password")
-          // (optionalAttrs cfg.enableLoki (mkSopsSecret (mkSopsSecretParams "grafana-alloy-loki-url")))
+          // optionalAttrs (!cfg.useClusterMonitoring) (
+            mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-url")
+          )
+          // optionalAttrs (cfg.enableLoki && !cfg.useClusterMonitoring) (
+            mkSopsSecret (mkSopsSecretParams "grafana-alloy-loki-url")
+          )
         );
       };
     });

--- a/flake/nixosModules/profile-monitoring.nix
+++ b/flake/nixosModules/profile-monitoring.nix
@@ -200,8 +200,12 @@ flake: {
           # Avoid mimir failing on reboot due to a network interface not yet
           # being available when it tries to bind.
           mimir = {
-            startLimitIntervalSec = 10;
-            startLimitBurst = 10;
+            # Cap retries so a permanently-broken mimir doesn't generate
+            # boot-loop journal noise. RestartSec=10s combined with these
+            # bounds gives ~5 attempts per 10-minute window before failing
+            # the unit and waiting for operator intervention.
+            startLimitIntervalSec = 600;
+            startLimitBurst = 5;
 
             serviceConfig = {
               Restart = "always";
@@ -406,6 +410,10 @@ flake: {
 
             virtualHosts."${fqdn}".extraConfig =
               ''
+                # Caddy `handle` blocks are mutually exclusive and most-specific
+                # wins. The narrower `/mimir/api/v1/push` and `/loki/api/v1/push`
+                # write-hash routes must remain split from the broader
+                # `/mimir/*` and `/loki/*` admin-hash routes; do not collapse them.
                 encode zstd gzip
 
                 handle /blackbox/* {

--- a/flake/nixosModules/profile-monitoring.nix
+++ b/flake/nixosModules/profile-monitoring.nix
@@ -1,0 +1,543 @@
+# nixosModule: profile-monitoring
+#
+# TODO: Move this to a docs generator
+#
+# Attributes available on nixos module import:
+#   (None — this profile reads its configuration from flake-level
+#   `flake.cardano-parts.cluster.infra.monitoring` options.)
+#
+# Tips:
+#   * This module provides an in-cluster Grafana + Mimir + Loki + Prometheus
+#     monitoring stack, fronted by Caddy with ACME-issued TLS.
+#   * It is intended to be imported on the single Colmena machine matching
+#     `flake.cardano-parts.cluster.infra.monitoring.hostname` (default
+#     "monitoring"). Group separation is handled at the alloy label level
+#     in `profile-grafana-alloy`.
+#   * The downstream consuming repo must provide the following sops secrets
+#     under `secrets/monitoring/` of the consuming repo:
+#       - grafana-password.enc
+#       - grafana-oauth-client-id.enc
+#       - grafana-oauth-client-secret.enc
+#       - caddy-environment-${machineName}.enc
+flake: {
+  flake.nixosModules.profile-monitoring = {
+    config,
+    lib,
+    name,
+    pkgs,
+    ...
+  }:
+    with lib; let
+      # Cluster infra is read through groupFlake (the consuming flake's
+      # `self`) rather than `flake.config`. `flake` here closes over
+      # cardano-parts' OWN flake-parts evaluation, where these options
+      # carry their declared defaults (null), not the consumer's values.
+      inherit (groupFlake.config.flake.cardano-parts.cluster.infra) aws monitoring;
+      inherit (aws) domain region;
+      inherit (monitoring) bucketLoki bucketMimir email provisionPath retentionLogsDays retentionMetricsDays subdomain;
+
+      # Derive duration strings for the apps. The S3-side retention is
+      # driven by the same day-int through the bucket lifecycle config in
+      # opentofu/bootstrap.nix, so app-level and storage-level retention
+      # cannot drift.
+      retentionLogs = "${toString retentionLogsDays}d";
+      retentionMetrics = "${toString retentionMetricsDays}d";
+
+      inherit (groupCfg) groupName groupFlake;
+      inherit (opsLib) mkSopsSecret parseDir readNixImport;
+
+      groupCfg = config.cardano-parts.cluster.group;
+      groupOutPath = groupFlake.self.outPath;
+      opsLib = flake.config.flake.cardano-parts.lib.opsLib pkgs;
+
+      fqdn = "${subdomain}.${domain}";
+
+      mimirHttpPort = config.services.mimir.configuration.server.http_listen_port;
+      lokiHttpPort = config.services.loki.configuration.server.http_listen_port;
+
+      # Translate a tofu-mimir-provider rule_group attrset into the shape
+      # mimirtool's `rules sync` expects. Existing files in downstream repos
+      # were authored against the tofu provider schema and must keep working
+      # there; this transform stays at eval-time so the on-disk files don't
+      # need to change.
+      transformRuleGroup = src: {
+        inherit (src) namespace;
+        groups = [
+          {
+            inherit (src) name;
+            rules = src.rule;
+          }
+        ];
+      };
+
+      readRuleFile = readNixImport groupFlake.self;
+
+      ruleFiles = lib.optionals (provisionPath != null) (
+        parseDir "${provisionPath}/alerts" ".nix-import"
+        ++ parseDir "${provisionPath}/recording-rules" ".nix-import"
+      );
+
+      mimirRulesDir = pkgs.linkFarm "mimir-rules" (map (f: let
+          rule = readRuleFile f;
+          filename = "${rule.namespace}-${rule.name}.json";
+        in {
+          name = filename;
+          path = pkgs.writeText filename (builtins.toJSON (transformRuleGroup rule));
+        })
+        ruleFiles);
+
+      # Mimir alertmanager refuses to start with empty config, so a stub is
+      # always written. When the consumer provides
+      # `${provisionPath}/alertmanager.nix-import`, that replaces the stub.
+      # The expected schema is upstream Prometheus alertmanager (single
+      # `route` object, plural `receivers` list); secrets should reference
+      # sops-managed files via the `*_file` suffix fields documented at
+      # https://prometheus.io/docs/alerting/latest/configuration/.
+      alertmanagerConfig = let
+        path = "${provisionPath}/alertmanager.nix-import";
+      in
+        if provisionPath != null && builtins.pathExists path
+        then readRuleFile path
+        else {
+          route = {
+            group_wait = "0s";
+            receiver = "empty-receiver";
+          };
+          receivers = [{name = "empty-receiver";}];
+        };
+
+      alertmanagerConfigFile = pkgs.writeText "alertmanager.yaml" (builtins.toJSON alertmanagerConfig);
+
+      mimirRulesSync = pkgs.writeShellScript "mimir-rules-sync" ''
+        set -euo pipefail
+        # mimir runs single-tenant when multitenancy_enabled = false; the
+        # implicit tenant id is "anonymous", which mimirtool needs explicitly.
+        exec ${config.services.mimir.package}/bin/mimirtool rules sync \
+          --address http://127.0.0.1:${toString mimirHttpPort}/mimir \
+          --id anonymous \
+          ${mimirRulesDir}/*.json
+      '';
+
+      mkSopsSecretParams = {
+        secretName,
+        keyName,
+        fileOwner,
+        restartUnit,
+      }: {
+        inherit groupOutPath groupName name secretName keyName fileOwner;
+        fileGroup = fileOwner;
+        pathPrefix = "${groupOutPath}/secrets/monitoring/";
+        restartUnits = [restartUnit];
+      };
+
+      grafanaSecret = secretName:
+        mkSopsSecret (mkSopsSecretParams {
+          inherit secretName;
+          keyName = "${secretName}.enc";
+          fileOwner = "grafana";
+          restartUnit = "grafana.service";
+        });
+
+      caddySecret = mkSopsSecret (mkSopsSecretParams {
+        secretName = "caddy-environment";
+        keyName = "caddy-environment-${name}.enc";
+        fileOwner = "caddy";
+        restartUnit = "caddy.service";
+      });
+
+      googleDomains = monitoring.oauth.google.allowedDomains;
+    in {
+      key = ./profile-monitoring.nix;
+
+      config = {
+        assertions = [
+          {
+            assertion = googleDomains != [];
+            message = ''
+              profile-monitoring requires a non-empty
+              `flake.cardano-parts.cluster.infra.monitoring.oauth.google.allowedDomains`
+              so that Grafana Google OAuth is restricted to a known tenant.
+            '';
+          }
+          {
+            assertion = email != null;
+            message = ''
+              profile-monitoring requires
+              `flake.cardano-parts.cluster.infra.monitoring.email` to be set;
+              Caddy uses it as the ACME contact for the Grafana virtual host.
+            '';
+          }
+        ];
+
+        sops.secrets =
+          grafanaSecret "grafana-password"
+          // grafanaSecret "grafana-oauth-client-id"
+          // grafanaSecret "grafana-oauth-client-secret"
+          // caddySecret;
+
+        # Allow HTTP (for ACME) and HTTPS.
+        networking.firewall.allowedTCPPorts = [80 443];
+
+        systemd.services = {
+          # No existing NixOS option exposes Caddy environment files cleanly.
+          # Inject sops-managed secrets here; reference them in the Caddyfile
+          # as e.g. {$ADMIN_HASH}.
+          caddy.serviceConfig.EnvironmentFile = config.sops.secrets.caddy-environment.path;
+
+          # Avoid grafana failing on reboot due to a secrets utilization race
+          # condition. Cap the wait so a misconfigured sops setup fails the
+          # unit instead of stalling multi-user.target indefinitely.
+          grafana.preStart = ''
+            for _ in $(seq 1 60); do
+              [ -f ${config.sops.secrets.grafana-password.path} ] && exit 0
+              echo "Waiting for grafana secrets to become available..."
+              sleep 5
+            done
+            echo "ERROR: grafana sops secrets did not appear within 5 minutes" >&2
+            exit 1
+          '';
+
+          # Avoid mimir failing on reboot due to a network interface not yet
+          # being available when it tries to bind.
+          mimir = {
+            startLimitIntervalSec = 10;
+            startLimitBurst = 10;
+
+            serviceConfig = {
+              Restart = "always";
+              RestartSec = "10s";
+            };
+          };
+
+          # Push provisioned alerting + recording rule_groups into Mimir on
+          # boot. Idempotent: mimirtool diff/sync is content-addressed.
+          mimir-rules-sync = mkIf (ruleFiles != []) {
+            description = "Sync Mimir rules from cardano-parts provisionPath";
+            after = ["mimir.service" "network-online.target"];
+            requires = ["mimir.service"];
+            wants = ["network-online.target"];
+            wantedBy = ["multi-user.target"];
+
+            # Cap retries so a permanently-broken mimir doesn't generate
+            # boot-loop journal noise. The 10s RestartSec would otherwise
+            # reset the default 10s start-limit window before it accumulates.
+            startLimitIntervalSec = 600;
+            startLimitBurst = 5;
+
+            serviceConfig = {
+              Type = "oneshot";
+              RemainAfterExit = true;
+              ExecStart = mimirRulesSync;
+              # Retry briefly if mimir hasn't bound its listener yet.
+              Restart = "on-failure";
+              RestartSec = "10s";
+            };
+          };
+        };
+
+        services = {
+          grafana = {
+            enable = true;
+
+            settings = {
+              # AlertManager (via Mimir) is the alerting source of truth.
+              alerting.enabled = false;
+
+              analytics.reporting_enabled = false;
+
+              "auth.anonymous".enabled = false;
+
+              security.admin_password = "$__file{${config.sops.secrets.grafana-password.path}}";
+
+              unified_alerting.enabled = true;
+
+              users.auto_assign_org_role = "Editor";
+
+              server = {
+                domain = fqdn;
+                root_url = "https://${fqdn}/";
+
+                # Caddy already does compression.
+                enable_gzip = false;
+
+                # Block DNS rebinding.
+                enforce_domain = true;
+              };
+
+              "auth.google" = {
+                enabled = true;
+                allow_sign_up = true;
+                auto_login = false;
+                client_id = "$__file{${config.sops.secrets.grafana-oauth-client-id.path}}";
+                client_secret = "$__file{${config.sops.secrets.grafana-oauth-client-secret.path}}";
+                scopes = "openid email profile";
+                auth_url = "https://accounts.google.com/o/oauth2/v2/auth";
+                token_url = "https://oauth2.googleapis.com/token";
+                api_url = "https://openidconnect.googleapis.com/v1/userinfo";
+                allowed_domains = concatStringsSep " " googleDomains;
+                hosted_domain = head googleDomains;
+                use_pkce = true;
+              };
+            };
+
+            provision = {
+              enable = true;
+
+              dashboards.settings = mkIf (provisionPath != null) {
+                apiVersion = 1;
+                providers = [
+                  {
+                    name = "default";
+                    type = "file";
+                    options.path = "${provisionPath}/dashboards";
+                    # Use the directory tree under `dashboards/` as Grafana folder structure.
+                    foldersFromFilesStructure = true;
+                    # Allow operators to edit provisioned dashboards in the UI.
+                    # Edits are reverted on each redeploy.
+                    allowUiUpdates = true;
+                  }
+                ];
+              };
+
+              datasources.settings.datasources =
+                [
+                  {
+                    type = "prometheus";
+                    name = "Mimir";
+                    uid = "mimir";
+                    isDefault = true;
+                    url = "http://127.0.0.1:${toString mimirHttpPort}/mimir/prometheus";
+                    jsonData.timeInterval = "60s";
+                  }
+                  {
+                    type = "alertmanager";
+                    name = "Alertmanager";
+                    uid = "alertmanager_mimir";
+                    url = "http://127.0.0.1:${toString mimirHttpPort}/mimir";
+                    jsonData = {
+                      implementation = "mimir";
+                      handleGrafanaManagedAlerts = true;
+                    };
+                  }
+                ]
+                ++ optional config.services.loki.enable {
+                  type = "loki";
+                  name = "Loki";
+                  uid = "loki";
+                  url = "http://127.0.0.1:${toString lokiHttpPort}";
+                  jsonData.manageAlerts = true;
+                };
+            };
+          };
+
+          mimir = {
+            enable = true;
+
+            configuration = {
+              common.storage = {
+                backend = "s3";
+                s3 = {
+                  inherit region;
+                  bucket_name = bucketMimir;
+                  endpoint = "s3.amazonaws.com";
+                };
+              };
+
+              target = "all,alertmanager";
+
+              blocks_storage.storage_prefix = "blocks";
+
+              ruler.alertmanager_url = "http://127.0.0.1:${toString mimirHttpPort}/mimir/alertmanager";
+
+              limits = {
+                compactor_blocks_retention_period = retentionMetrics;
+                # Allow ingestion of out-of-order samples up to 5 minutes since
+                # the latest received sample for the series.
+                out_of_order_time_window = "5m";
+              };
+
+              compactor = {
+                # Persistent path: compactor stages multi-GB blocks before
+                # uploading. /tmp on systemd is tmpfs (RAM-backed), which
+                # would OOM the host once retention windows accumulate.
+                data_dir = "/var/lib/mimir/compactor";
+                sharding_ring.kvstore.store = "memberlist";
+              };
+
+              distributor.ring = {
+                instance_addr = "127.0.0.1";
+                kvstore.store = "memberlist";
+              };
+
+              ingester.ring = {
+                instance_addr = "127.0.0.1";
+                kvstore.store = "memberlist";
+                replication_factor = 1;
+              };
+
+              multitenancy_enabled = false;
+
+              # Help prevent "too many outstanding requests" errors.
+              frontend.max_outstanding_per_tenant = 256;
+
+              server = {
+                http_listen_port = 8080;
+                http_listen_address = "127.0.0.1";
+                http_path_prefix = "/mimir";
+                log_request_headers = true;
+              };
+
+              store_gateway.sharding_ring.replication_factor = 1;
+
+              usage_stats.enabled = false;
+
+              alertmanager = {
+                external_url = "https://${fqdn}/mimir/alertmanager";
+                data_dir = "/var/lib/mimir/alertmanager";
+                fallback_config_file = alertmanagerConfigFile;
+              };
+            };
+          };
+
+          caddy = {
+            enable = true;
+            enableReload = true;
+            inherit email;
+
+            virtualHosts."${fqdn}".extraConfig =
+              ''
+                encode zstd gzip
+
+                handle /blackbox/* {
+                  basicauth { admin {$ADMIN_HASH} }
+                  reverse_proxy 127.0.0.1:9115
+                }
+
+                handle /mimir/api/v1/push {
+                  basicauth { write {$WRITE_HASH} }
+                  reverse_proxy 127.0.0.1:${toString mimirHttpPort}
+                }
+
+                handle /mimir/* {
+                  basicauth { admin {$ADMIN_HASH} }
+                  reverse_proxy 127.0.0.1:${toString mimirHttpPort}
+                }
+              ''
+              + optionalString config.services.loki.enable ''
+                handle /loki/api/v1/push {
+                  basicauth { write {$WRITE_HASH} }
+                  reverse_proxy 127.0.0.1:${toString lokiHttpPort}
+                }
+
+                handle /loki/* {
+                  basicauth { admin {$ADMIN_HASH} }
+                  uri strip_prefix /loki
+                  reverse_proxy 127.0.0.1:${toString lokiHttpPort}
+                }
+
+                handle /otlp/v1/logs {
+                  basicauth { write {$WRITE_HASH} }
+                  reverse_proxy 127.0.0.1:${toString lokiHttpPort}
+                }
+              ''
+              + ''
+                handle /* {
+                  reverse_proxy 127.0.0.1:${toString config.services.grafana.settings.server.http_port}
+                }
+              '';
+          };
+
+          prometheus = {
+            enable = true;
+
+            alertmanagers = [
+              {
+                scheme = "http";
+                path_prefix = "/mimir";
+                static_configs = [{targets = ["127.0.0.1:${toString mimirHttpPort}"];}];
+              }
+            ];
+
+            exporters.blackbox = {
+              enable = true;
+              configFile = pkgs.writeText "blackbox-exporter.json" (builtins.toJSON {
+                modules.https_2xx = {
+                  prober = "http";
+                  timeout = "5s";
+                  http.fail_if_not_ssl = true;
+                  http.preferred_ip_protocol = "ip4";
+                };
+              });
+            };
+          };
+
+          loki = {
+            enable = mkDefault true;
+
+            configuration = {
+              auth_enabled = false;
+
+              limits_config.retention_period = retentionLogs;
+
+              common = {
+                ring.kvstore.store = "inmemory";
+                replication_factor = 1;
+              };
+
+              server = {
+                http_listen_port = 3100;
+                grpc_listen_port = 3101;
+              };
+
+              compactor = {
+                working_directory = "/var/lib/loki/compactor";
+                compaction_interval = "10m";
+                retention_enabled = true;
+                retention_delete_delay = "2h";
+                retention_delete_worker_count = 150;
+                delete_request_store = "s3";
+              };
+
+              storage_config = {
+                tsdb_shipper = {
+                  active_index_directory = "/var/lib/loki/index/active";
+                  cache_location = "/var/lib/loki/index/cache";
+                };
+
+                aws = {
+                  s3 = "s3://${region}";
+                  bucketnames = bucketLoki;
+                };
+              };
+
+              schema_config.configs = [
+                {
+                  from = "2024-07-16";
+                  store = "tsdb";
+                  object_store = "s3";
+                  schema = "v13";
+                  index = {
+                    prefix = "index_";
+                    period = "24h";
+                  };
+                }
+              ];
+
+              ruler = {
+                alertmanager_url = "http://127.0.0.1:${toString mimirHttpPort}/mimir/alertmanager";
+                storage = {
+                  type = "s3";
+                  s3 = {
+                    s3 = "s3://${region}";
+                    bucketnames = bucketLoki;
+                  };
+                };
+                rule_path = "/var/lib/loki/rules";
+                ring.kvstore.store = "inmemory";
+              };
+            };
+          };
+        };
+      };
+    };
+}

--- a/flake/nixosModules/profile-monitoring.nix
+++ b/flake/nixosModules/profile-monitoring.nix
@@ -145,18 +145,18 @@ flake: {
         restartUnit = "caddy.service";
       });
 
-      googleDomains = monitoring.oauth.google.allowedDomains;
+      googleAllowedDomain = monitoring.oauth.google.allowedDomain;
     in {
       key = ./profile-monitoring.nix;
 
       config = {
         assertions = [
           {
-            assertion = googleDomains != [];
+            assertion = googleAllowedDomain != null;
             message = ''
-              profile-monitoring requires a non-empty
-              `flake.cardano-parts.cluster.infra.monitoring.oauth.google.allowedDomains`
-              so that Grafana Google OAuth is restricted to a known tenant.
+              profile-monitoring requires
+              `flake.cardano-parts.cluster.infra.monitoring.oauth.google.allowedDomain`
+              to be set so that Grafana Google OAuth is restricted to a known tenant.
             '';
           }
           {
@@ -278,8 +278,8 @@ flake: {
                 auth_url = "https://accounts.google.com/o/oauth2/v2/auth";
                 token_url = "https://oauth2.googleapis.com/token";
                 api_url = "https://openidconnect.googleapis.com/v1/userinfo";
-                allowed_domains = concatStringsSep " " googleDomains;
-                hosted_domain = head googleDomains;
+                allowed_domains = googleAllowedDomain;
+                hosted_domain = googleAllowedDomain;
                 use_pkce = true;
               };
             };
@@ -455,28 +455,24 @@ flake: {
               '';
           };
 
-          prometheus = {
+          # Blackbox-exporter only — no Prometheus server. Alloy is the
+          # universal scrape-and-forward agent in this stack (imported via
+          # the consuming repo's `defaults.imports`), and on the monitoring
+          # node `useClusterMonitoring = true` causes alloy to remote_write
+          # directly into local Mimir. Blackbox is reached on-demand via
+          # the Caddy `/blackbox/*` route for ad-hoc HTTPS probes;
+          # continuous uptime probing belongs in a follow-up that adds a
+          # `prometheus.scrape` block to profile-grafana-alloy.
+          prometheus.exporters.blackbox = {
             enable = true;
-
-            alertmanagers = [
-              {
-                scheme = "http";
-                path_prefix = "/mimir";
-                static_configs = [{targets = ["127.0.0.1:${toString mimirHttpPort}"];}];
-              }
-            ];
-
-            exporters.blackbox = {
-              enable = true;
-              configFile = pkgs.writeText "blackbox-exporter.json" (builtins.toJSON {
-                modules.https_2xx = {
-                  prober = "http";
-                  timeout = "5s";
-                  http.fail_if_not_ssl = true;
-                  http.preferred_ip_protocol = "ip4";
-                };
-              });
-            };
+            configFile = pkgs.writeText "blackbox-exporter.json" (builtins.toJSON {
+              modules.https_2xx = {
+                prober = "http";
+                timeout = "5s";
+                http.fail_if_not_ssl = true;
+                http.preferred_ip_protocol = "ip4";
+              };
+            });
           };
 
           loki = {

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -26,7 +26,7 @@
 #   flake.cardano-parts.cluster.infra.monitoring.email
 #   flake.cardano-parts.cluster.infra.monitoring.enable
 #   flake.cardano-parts.cluster.infra.monitoring.hostname
-#   flake.cardano-parts.cluster.infra.monitoring.oauth.google.allowedDomains
+#   flake.cardano-parts.cluster.infra.monitoring.oauth.google.allowedDomain
 #   flake.cardano-parts.cluster.infra.monitoring.objectLockMode
 #   flake.cardano-parts.cluster.infra.monitoring.provisionPath
 #   flake.cardano-parts.cluster.infra.monitoring.retentionLogsDays
@@ -381,17 +381,21 @@ flake @ {
 
   monitoringOauthGoogleSubmodule = submodule {
     options = {
-      allowedDomains = mkOption {
-        type = listOf str;
+      allowedDomain = mkOption {
+        type = nullOr (optionCheck "string" "infra.monitoring.oauth.google.allowedDomain" "str");
         description = mdDoc ''
-          Email domains permitted to log into Grafana via Google OAuth.
+          Email domain permitted to log into Grafana via Google OAuth.
 
-          Each entry is applied to both the `allowed_domains` and
-          `hosted_domain` Grafana settings so the login is restricted to a
-          single Google Workspace tenant.
+          Applied to both Grafana's `hosted_domain` and `allowed_domains`
+          settings, so login is restricted to a single Google Workspace
+          tenant. Single-valued because Google's `hd` OAuth parameter is
+          single-valued; cross-tenant access is intentionally not
+          supported by this profile.
+
+          Required when monitoring is enabled.
         '';
-        default = [];
-        example = ["iohk.io"];
+        default = null;
+        example = "iohk.io";
       };
     };
   };

--- a/flakeModules/cluster.nix
+++ b/flakeModules/cluster.nix
@@ -21,6 +21,17 @@
 #   flake.cardano-parts.cluster.infra.generic.tribe
 #   flake.cardano-parts.cluster.infra.generic.warnOnMissingIpModule
 #   flake.cardano-parts.cluster.infra.grafana.stackName
+#   flake.cardano-parts.cluster.infra.monitoring.bucketLoki
+#   flake.cardano-parts.cluster.infra.monitoring.bucketMimir
+#   flake.cardano-parts.cluster.infra.monitoring.email
+#   flake.cardano-parts.cluster.infra.monitoring.enable
+#   flake.cardano-parts.cluster.infra.monitoring.hostname
+#   flake.cardano-parts.cluster.infra.monitoring.oauth.google.allowedDomains
+#   flake.cardano-parts.cluster.infra.monitoring.objectLockMode
+#   flake.cardano-parts.cluster.infra.monitoring.provisionPath
+#   flake.cardano-parts.cluster.infra.monitoring.retentionLogsDays
+#   flake.cardano-parts.cluster.infra.monitoring.retentionMetricsDays
+#   flake.cardano-parts.cluster.infra.monitoring.subdomain
 #   flake.cardano-parts.cluster.groups.<default|name>.bookRelayMultivalueDns
 #   flake.cardano-parts.cluster.groups.<default|name>.generic.abortOnMissingIpModule
 #   flake.cardano-parts.cluster.groups.<default|name>.generic.warnOnMissingIpModule
@@ -80,10 +91,11 @@ flake @ {
   ...
 }: let
   inherit (lib) mdDoc mkDefault mkOption types;
-  inherit (types) addCheck anything attrsOf bool enum functionTo listOf nullOr oneOf package port raw str submodule;
+  inherit (types) addCheck anything attrsOf bool enum functionTo listOf nullOr oneOf package path port raw str submodule;
 
   cfg = config.flake.cardano-parts;
   cfgAws = cfg.cluster.infra.aws;
+  cfgMon = cfg.cluster.infra.monitoring;
 
   # TODO: improved function to do real type checking while still providing a useful message
   optionCheck = type: optionName: typeName:
@@ -129,6 +141,12 @@ flake @ {
       grafana = mkOption {
         type = grafanaSubmodule;
         description = mdDoc "Cardano-parts cluster infra grafana submodule.";
+        default = {};
+      };
+
+      monitoring = mkOption {
+        type = monitoringSubmodule;
+        description = mdDoc "Cardano-parts cluster infra in-cluster monitoring submodule.";
         default = {};
       };
 
@@ -201,6 +219,179 @@ flake @ {
         type = optionCheck "string" "infra.grafana.stackName" "str";
         description = mdDoc "The cardano-parts cluster infra grafana cloud stack name.";
         default = null;
+      };
+    };
+  };
+
+  monitoringSubmodule = submodule {
+    options = {
+      enable = mkOption {
+        type = bool;
+        description = mdDoc ''
+          Whether to enable the in-cluster monitoring stack profile.
+
+          When true, downstream:
+
+          * Provisions an S3 bucket pair via opentofu for Mimir blocks and Loki chunks.
+          * Provisions DNS for the monitoring node based on `hostname` and `infra.aws.domain`.
+          * Auto-targets profile-grafana-alloy at the in-cluster monitoring node when no explicit remote write URL is configured.
+
+          A Colmena machine matching `hostname` is expected to import the
+          `nixosModules.profile-monitoring` module from cardano-parts.
+        '';
+        default = false;
+      };
+
+      hostname = mkOption {
+        type = optionCheck "string" "infra.monitoring.hostname" "str";
+        description = mdDoc ''
+          The Colmena machine name expected to host the in-cluster monitoring stack.
+          Used by opentofu to provision DNS, and by profile-grafana-alloy to
+          derive the default remote write target.
+        '';
+        default = "monitoring";
+      };
+
+      subdomain = mkOption {
+        type = optionCheck "string" "infra.monitoring.subdomain" "str";
+        description = mdDoc ''
+          The DNS label under `infra.aws.domain` at which Grafana is published.
+          Defaults to `hostname` so the FQDN is `''${hostname}.''${infra.aws.domain}`.
+        '';
+        default = cfgMon.hostname;
+      };
+
+      bucketMimir = mkOption {
+        type = optionCheck "string" "infra.monitoring.bucketMimir" "str";
+        description = mdDoc ''
+          The S3 bucket name used to store Mimir blocks and ruler state.
+          Created by opentofu in the bootstrap workspace when monitoring is enabled.
+        '';
+        default = "${cfgAws.profile}-mimir";
+      };
+
+      bucketLoki = mkOption {
+        type = optionCheck "string" "infra.monitoring.bucketLoki" "str";
+        description = mdDoc ''
+          The S3 bucket name used to store Loki chunks and indexes.
+          Created by opentofu in the bootstrap workspace when monitoring is enabled.
+        '';
+        default = "${cfgAws.profile}-loki";
+      };
+
+      retentionMetricsDays = mkOption {
+        type = optionCheck "int" "infra.monitoring.retentionMetricsDays" "int";
+        description = mdDoc ''
+          Mimir block retention in days. Drives both Mimir's compactor
+          block retention and the S3 lifecycle expiration on the mimir
+          bucket, so app-level and storage-level retention stay in lockstep.
+        '';
+        default = 365;
+      };
+
+      retentionLogsDays = mkOption {
+        type = optionCheck "int" "infra.monitoring.retentionLogsDays" "int";
+        description = mdDoc ''
+          Loki retention in days. Drives both Loki's retention period and
+          the S3 lifecycle expiration on the loki bucket.
+        '';
+        default = 180;
+      };
+
+      objectLockMode = mkOption {
+        type = enum ["soft" "governance"];
+        description = mdDoc ''
+          S3 Object Lock policy applied to the mimir and loki buckets.
+          Both options use GOVERNANCE-mode locks so a separately-permissioned
+          ops role holding `s3:BypassGovernanceRetention` can break-glass for
+          legitimate recovery (e.g. accidental secret leak); the EC2 role
+          attached to monitoring nodes does not get that permission.
+
+          * `"soft"` (default) — 1-day default retention. Stops a same-day
+            compromise of the monitoring node from wiping fresh data.
+            Compaction-driven source-block deletes succeed once objects
+            age past the lock. Storage stays roughly 1× retention.
+
+          * `"governance"` — default retention spans the full app
+            retention window (`retentionMetricsDays` / `retentionLogsDays`).
+            Compaction's source-block deletes fail until expiry, so storage
+            roughly doubles during the retention window.
+
+          Only the lock duration differs between modes. Switching modes
+          after initial deploy applies to newly written objects only;
+          existing locks are immutable.
+        '';
+        default = "soft";
+      };
+
+      email = mkOption {
+        type = nullOr (optionCheck "string" "infra.monitoring.email" "str");
+        description = mdDoc ''
+          ACME contact email used by Caddy for the Grafana virtual host.
+
+          Required when monitoring is enabled.
+        '';
+        default = null;
+      };
+
+      oauth = mkOption {
+        type = monitoringOauthSubmodule;
+        description = mdDoc ''
+          Cardano-parts cluster infra monitoring oauth submodule.
+
+          Currently only Google OAuth is exposed. Settings beyond what this
+          submodule covers can be applied directly to
+          `services.grafana.settings."auth.google"` on the monitoring machine.
+        '';
+        default = {};
+      };
+
+      provisionPath = mkOption {
+        type = nullOr path;
+        description = mdDoc ''
+          Path to a directory containing monitoring assets to provision on
+          the monitoring node.
+
+          Currently the following layout is consumed:
+
+          * `''${provisionPath}/dashboards/` — Grafana dashboard JSON files.
+            All `*.json` files in this directory are picked up by Grafana
+            file-based provisioning. Subdirectories are honored as folders.
+
+          When null, no provisioning is configured; dashboards and alerts
+          can still be edited in the Grafana UI but will not be persisted
+          across redeploys.
+
+          A typical downstream value is `''${self.outPath}/monitoring`.
+        '';
+        default = null;
+      };
+    };
+  };
+
+  monitoringOauthSubmodule = submodule {
+    options = {
+      google = mkOption {
+        type = monitoringOauthGoogleSubmodule;
+        description = mdDoc "Google OAuth submodule.";
+        default = {};
+      };
+    };
+  };
+
+  monitoringOauthGoogleSubmodule = submodule {
+    options = {
+      allowedDomains = mkOption {
+        type = listOf str;
+        description = mdDoc ''
+          Email domains permitted to log into Grafana via Google OAuth.
+
+          Each entry is applied to both the `allowed_domains` and
+          `hosted_domain` Grafana settings so the login is restricted to a
+          single Google Workspace tenant.
+        '';
+        default = [];
+        example = ["iohk.io"];
       };
     };
   };

--- a/flakeModules/lib.nix
+++ b/flakeModules/lib.nix
@@ -4,6 +4,7 @@
 #
 # Attributes available on flakeModule import:
 #   flake.cardano-parts.lib.opsLib
+#   flake.cardano-parts.lib.opsTf
 #   flake.cardano-parts.lib.topologyLib
 #
 # Tips:
@@ -49,6 +50,20 @@
           cardano environment.
         '';
         default = import ./lib/topology.nix lib;
+      };
+
+      opsTf = mkOption {
+        type = attrsOf anything;
+        description = mdDoc ''
+          The cardano-parts opentofu helper library.
+
+          Pure helpers (no `pkgs` dependency) that return terraform
+          configuration fragments suitable for inclusion in any
+          terranix-driven workspace. Includes the AWS provider alias
+          helper, the secure-transport bucket policy statement, and
+          the Mimir + Loki monitoring bucket / IAM policy builders.
+        '';
+        default = import ./lib/opsTf.nix lib;
       };
     };
   };

--- a/flakeModules/lib/ops.nix
+++ b/flakeModules/lib/ops.nix
@@ -49,6 +49,26 @@ with lib; rec {
     })
     .cardanoLib;
 
+  # Walk a directory non-recursively, returning a list of absolute paths
+  # to regular files matching the given suffix. Returns [] if dir is missing.
+  parseDir = dirPath: suffix:
+    if !pathExists dirPath
+    then []
+    else
+      mapAttrsToList (n: _: "${dirPath}/${n}") (
+        filterAttrs (n: v: hasSuffix suffix n && v == "regular") (readDir dirPath)
+      );
+
+  # Read a `.nix-import` file. Files may evaluate to either a plain attrset
+  # or a function of a caller-supplied argument (typically the consuming
+  # repo's flake `self`).
+  readNixImport = arg: path: let
+    raw = import path;
+  in
+    if isFunction raw
+    then raw arg
+    else raw;
+
   mkSopsSecret = {
     name ? "unknown",
     secretName,

--- a/flakeModules/lib/opsTf.nix
+++ b/flakeModules/lib/opsTf.nix
@@ -149,6 +149,18 @@ with lib; rec {
               noncurrent_version_expiration.noncurrent_days = 1;
               abort_incomplete_multipart_upload.days_after_initiation = 7;
             }
+            # Mimir / Loki compactors call DeleteObject; under versioning
+            # that creates a delete marker rather than purging the object.
+            # Without this rule the markers accumulate forever once their
+            # underlying versions expire. Must be a separate rule because
+            # `expired_object_delete_marker` cannot coexist with `days` /
+            # `date` in the same `expiration` block.
+            {
+              id = "expire-delete-markers-${n}";
+              status = "Enabled";
+              filter = {};
+              expiration.expired_object_delete_marker = true;
+            }
           ];
         });
 
@@ -184,6 +196,17 @@ with lib; rec {
           Effect = "Allow";
           Action = [
             "s3:AbortMultipartUpload"
+            # `s3:DeleteObject` is granted but Object Lock GOVERNANCE
+            # rejects pre-expiry deletes at the API layer — defense in
+            # depth. The grant lets the compactor create delete markers
+            # under versioning, which is the legitimate path for
+            # retention-driven deletion.
+            #
+            # `s3:DeleteObjectVersion` is intentionally omitted: the
+            # compactor only needs to mark current versions as deleted,
+            # not purge underlying versions. Version purges happen
+            # automatically via the bucket's lifecycle
+            # `noncurrent_version_expiration` rule.
             "s3:DeleteObject"
             "s3:GetBucketLocation"
             "s3:GetObject"

--- a/flakeModules/lib/opsTf.nix
+++ b/flakeModules/lib/opsTf.nix
@@ -10,6 +10,9 @@ with lib; rec {
   # Translate a region like `eu-central-1` into `eu_central_1` for use
   # in the `aws.<region>` provider alias names that downstream tofu
   # workspaces declare.
+  #
+  # Local copy (not config.flake.lib.strings.dashToSnake) so opsTf stays
+  # callable from any terranix workspace without a cardano-parts flake closure.
   dashToSnake = replaceStrings ["-"] ["_"];
 
   # Provider alias for an AWS region. Workspaces declare one provider

--- a/flakeModules/lib/opsTf.nix
+++ b/flakeModules/lib/opsTf.nix
@@ -43,6 +43,18 @@ with lib; rec {
     };
   };
 
+  # Object Lock retention duration, by mode.
+  # "soft" → minimum 1 day (AWS API floor). Survives same-day
+  # compromise; compaction-driven deletes succeed once objects age
+  # past the lock.
+  # "governance" → full app retention. Compaction sources cannot be
+  # deleted before expiry, so storage roughly doubles during the
+  # retention window.
+  lockDaysFor = objectLockMode: retentionDays:
+    if objectLockMode == "governance"
+    then retentionDays
+    else 1;
+
   # Mimir + Loki S3 bucket resources for the in-cluster monitoring
   # stack. Returns a workspace fragment ({data, resource}) suitable for
   # merging via `imports = [... (mkMonitoringBucketResources {...})]`.
@@ -61,27 +73,16 @@ with lib; rec {
   }: let
     inherit (monitoring) bucketLoki bucketMimir objectLockMode retentionLogsDays retentionMetricsDays;
 
-    # "soft" → minimum 1 day (AWS API floor). Survives same-day
-    # compromise; compaction-driven deletes succeed once objects age
-    # past the lock.
-    # "governance" → full app retention. Compaction sources cannot be
-    # deleted before expiry, so storage roughly doubles during the
-    # retention window.
-    lockDaysFor = retentionDays:
-      if objectLockMode == "governance"
-      then retentionDays
-      else 1;
-
     bucketSpecs = {
       mimir = {
         bucket = bucketMimir;
         retentionDays = retentionMetricsDays;
-        lockDays = lockDaysFor retentionMetricsDays;
+        lockDays = lockDaysFor objectLockMode retentionMetricsDays;
       };
       loki = {
         bucket = bucketLoki;
         retentionDays = retentionLogsDays;
-        lockDays = lockDaysFor retentionLogsDays;
+        lockDays = lockDaysFor objectLockMode retentionLogsDays;
       };
     };
 
@@ -168,58 +169,65 @@ with lib; rec {
     };
   };
 
-  # IAM policy granting the EC2 role data-plane access on the Mimir +
-  # Loki monitoring buckets. Returns a single tofu policy attrset
-  # suitable for placement under `aws_iam_policy.<name>`. The default
-  # name is `monitoringS3`; the resource attribute key is the caller's
-  # decision.
+  # Pre-JSON IAM policy document for the Mimir + Loki monitoring
+  # buckets. Returned as a plain attrset so callers (and tests) can
+  # inspect the structure directly without round-tripping through
+  # JSON. `mkMonitoringIamPolicy` wraps this for placement under
+  # `aws_iam_policy.<name>`.
   #
   # Action list excludes bucket-management calls (DeleteBucket,
   # PutBucketPolicy, PutBucketPublicAccessBlock, …) and governance
   # bypass so a compromised monitoring node cannot destroy or
   # republish historical data.
-  mkMonitoringIamPolicy = {
-    monitoring,
-    defaultTags ? {},
-    name ? "monitoringS3",
-  }: let
+  mkMonitoringIamPolicyDoc = monitoring: let
     bucketArns = bucket: [
       "arn:aws:s3:::${bucket}"
       "arn:aws:s3:::${bucket}/*"
     ];
   in {
+    Version = "2012-10-17";
+    Statement = [
+      {
+        Effect = "Allow";
+        Action = [
+          "s3:AbortMultipartUpload"
+          # `s3:DeleteObject` is granted but Object Lock GOVERNANCE
+          # rejects pre-expiry deletes at the API layer — defense in
+          # depth. The grant lets the compactor create delete markers
+          # under versioning, which is the legitimate path for
+          # retention-driven deletion.
+          #
+          # `s3:DeleteObjectVersion` is intentionally omitted: the
+          # compactor only needs to mark current versions as deleted,
+          # not purge underlying versions. Version purges happen
+          # automatically via the bucket's lifecycle
+          # `noncurrent_version_expiration` rule.
+          "s3:DeleteObject"
+          "s3:GetBucketLocation"
+          "s3:GetObject"
+          "s3:ListBucket"
+          "s3:ListMultipartUploadParts"
+          "s3:PutObject"
+        ];
+        Resource =
+          bucketArns monitoring.bucketMimir
+          ++ bucketArns monitoring.bucketLoki;
+      }
+    ];
+  };
+
+  # IAM policy granting the EC2 role data-plane access on the Mimir +
+  # Loki monitoring buckets. Returns a single tofu policy attrset
+  # suitable for placement under `aws_iam_policy.<name>`. The default
+  # name is `monitoringS3`; the resource attribute key is the caller's
+  # decision.
+  mkMonitoringIamPolicy = {
+    monitoring,
+    defaultTags ? {},
+    name ? "monitoringS3",
+  }: {
     inherit name;
-    policy = builtins.toJSON {
-      Version = "2012-10-17";
-      Statement = [
-        {
-          Effect = "Allow";
-          Action = [
-            "s3:AbortMultipartUpload"
-            # `s3:DeleteObject` is granted but Object Lock GOVERNANCE
-            # rejects pre-expiry deletes at the API layer — defense in
-            # depth. The grant lets the compactor create delete markers
-            # under versioning, which is the legitimate path for
-            # retention-driven deletion.
-            #
-            # `s3:DeleteObjectVersion` is intentionally omitted: the
-            # compactor only needs to mark current versions as deleted,
-            # not purge underlying versions. Version purges happen
-            # automatically via the bucket's lifecycle
-            # `noncurrent_version_expiration` rule.
-            "s3:DeleteObject"
-            "s3:GetBucketLocation"
-            "s3:GetObject"
-            "s3:ListBucket"
-            "s3:ListMultipartUploadParts"
-            "s3:PutObject"
-          ];
-          Resource =
-            bucketArns monitoring.bucketMimir
-            ++ bucketArns monitoring.bucketLoki;
-        }
-      ];
-    };
+    policy = builtins.toJSON (mkMonitoringIamPolicyDoc monitoring);
     tags = defaultTags;
   };
 }

--- a/flakeModules/lib/opsTf.nix
+++ b/flakeModules/lib/opsTf.nix
@@ -1,0 +1,199 @@
+lib:
+# Argument `lib` is provided by the lib flakeModule opsTf option default:
+#   flake.cardano-parts.lib.opsTf
+#
+# Pure helpers for opentofu (terranix) workspaces. Functions here return
+# attrset fragments suitable for merging into a workspace's `imports`
+# list — they do not depend on `pkgs`, so they can be called from any
+# workspace regardless of how that workspace acquires nixpkgs.
+with lib; rec {
+  # Translate a region like `eu-central-1` into `eu_central_1` for use
+  # in the `aws.<region>` provider alias names that downstream tofu
+  # workspaces declare.
+  dashToSnake = replaceStrings ["-"] ["_"];
+
+  # Provider alias for an AWS region. Workspaces declare one provider
+  # per active region, so resources targeting that region must use the
+  # matching alias.
+  awsProviderFor = region: "aws.${dashToSnake region}";
+
+  # Bucket policy statement that denies any non-TLS request. Apply to
+  # every bucket the workspace creates so requests over plain HTTP are
+  # rejected at the bucket level (defence in depth on top of the
+  # provider's TLS-enforced endpoint).
+  bucketPolicyStatementSecureTransport = bucketArn: {
+    sid = "RestrictToTLSRequestsOnly";
+    effect = "Deny";
+    actions = ["s3:*"];
+    resources = [
+      bucketArn
+      "${bucketArn}/*"
+    ];
+    condition = {
+      test = "Bool";
+      variable = "aws:SecureTransport";
+      values = ["false"];
+    };
+    principals = {
+      type = "*";
+      identifiers = ["*"];
+    };
+  };
+
+  # Mimir + Loki S3 bucket resources for the in-cluster monitoring
+  # stack. Returns a workspace fragment ({data, resource}) suitable for
+  # merging via `imports = [... (mkMonitoringBucketResources {...})]`.
+  #
+  # Object Lock + lifecycle pin app-level and storage-level retention
+  # together: lifecycle expires objects on day N (matching the app's
+  # configured retention), while Object Lock prevents the EC2 role
+  # from deleting objects pre-expiry. Both modes use GOVERNANCE locks
+  # so a separately-permissioned ops role with
+  # s3:BypassGovernanceRetention can break-glass; the EC2 role itself
+  # is not granted that permission.
+  mkMonitoringBucketResources = {
+    monitoring,
+    awsRegion,
+    awsOrgId,
+  }: let
+    inherit (monitoring) bucketLoki bucketMimir objectLockMode retentionLogsDays retentionMetricsDays;
+
+    # "soft" → minimum 1 day (AWS API floor). Survives same-day
+    # compromise; compaction-driven deletes succeed once objects age
+    # past the lock.
+    # "governance" → full app retention. Compaction sources cannot be
+    # deleted before expiry, so storage roughly doubles during the
+    # retention window.
+    lockDaysFor = retentionDays:
+      if objectLockMode == "governance"
+      then retentionDays
+      else 1;
+
+    bucketSpecs = {
+      mimir = {
+        bucket = bucketMimir;
+        retentionDays = retentionMetricsDays;
+        lockDays = lockDaysFor retentionMetricsDays;
+      };
+      loki = {
+        bucket = bucketLoki;
+        retentionDays = retentionLogsDays;
+        lockDays = lockDaysFor retentionLogsDays;
+      };
+    };
+
+    forBuckets = genAttrs (attrNames bucketSpecs);
+
+    mkBucketAttr = resourceAttr: {
+      provider = awsProviderFor awsRegion;
+      bucket = "\${aws_s3_bucket.${resourceAttr}.id}";
+    };
+
+    loggingTarget = {
+      target_bucket = "s3-server-access-logs-${awsOrgId}-${awsRegion}";
+      target_prefix = "logs/";
+      target_object_key_format.partitioned_prefix.partition_date_source = "EventTime";
+    };
+  in {
+    data.aws_iam_policy_document =
+      mapAttrs' (n: _: {
+        name = "s3_bucket_policy-${n}";
+        value.statement = bucketPolicyStatementSecureTransport "\${aws_s3_bucket.${n}.arn}";
+      })
+      bucketSpecs;
+
+    resource = {
+      aws_s3_bucket = forBuckets (n: {
+        provider = awsProviderFor awsRegion;
+        inherit (bucketSpecs.${n}) bucket;
+        # Object Lock must be enabled at bucket creation; cannot be
+        # toggled later.
+        object_lock_enabled = true;
+      });
+
+      aws_s3_bucket_policy = forBuckets (n:
+        mkBucketAttr n
+        // {policy = "\${data.aws_iam_policy_document.s3_bucket_policy-${n}.minified_json}";});
+
+      # Object Lock requires versioning enabled.
+      aws_s3_bucket_versioning = forBuckets (n:
+        mkBucketAttr n
+        // {versioning_configuration.status = "Enabled";});
+
+      aws_s3_bucket_object_lock_configuration = forBuckets (n:
+        mkBucketAttr n
+        // {
+          rule.default_retention = {
+            mode = "GOVERNANCE";
+            days = bucketSpecs.${n}.lockDays;
+          };
+        });
+
+      aws_s3_bucket_server_side_encryption_configuration = forBuckets (n:
+        mkBucketAttr n
+        // {rule.apply_server_side_encryption_by_default.sse_algorithm = "AES256";});
+
+      aws_s3_bucket_lifecycle_configuration = forBuckets (n:
+        mkBucketAttr n
+        // {
+          rule = [
+            {
+              id = "expire-${n}";
+              status = "Enabled";
+              # Empty filter = applies to every object.
+              filter = {};
+              expiration.days = bucketSpecs.${n}.retentionDays;
+              noncurrent_version_expiration.noncurrent_days = 1;
+              abort_incomplete_multipart_upload.days_after_initiation = 7;
+            }
+          ];
+        });
+
+      aws_s3_bucket_logging = forBuckets (n: mkBucketAttr n // loggingTarget);
+    };
+  };
+
+  # IAM policy granting the EC2 role data-plane access on the Mimir +
+  # Loki monitoring buckets. Returns a single tofu policy attrset
+  # suitable for placement under `aws_iam_policy.<name>`. The default
+  # name is `monitoringS3`; the resource attribute key is the caller's
+  # decision.
+  #
+  # Action list excludes bucket-management calls (DeleteBucket,
+  # PutBucketPolicy, PutBucketPublicAccessBlock, …) and governance
+  # bypass so a compromised monitoring node cannot destroy or
+  # republish historical data.
+  mkMonitoringIamPolicy = {
+    monitoring,
+    defaultTags ? {},
+    name ? "monitoringS3",
+  }: let
+    bucketArns = bucket: [
+      "arn:aws:s3:::${bucket}"
+      "arn:aws:s3:::${bucket}/*"
+    ];
+  in {
+    inherit name;
+    policy = builtins.toJSON {
+      Version = "2012-10-17";
+      Statement = [
+        {
+          Effect = "Allow";
+          Action = [
+            "s3:AbortMultipartUpload"
+            "s3:DeleteObject"
+            "s3:GetBucketLocation"
+            "s3:GetObject"
+            "s3:ListBucket"
+            "s3:ListMultipartUploadParts"
+            "s3:PutObject"
+          ];
+          Resource =
+            bucketArns monitoring.bucketMimir
+            ++ bucketArns monitoring.bucketLoki;
+        }
+      ];
+    };
+    tags = defaultTags;
+  };
+}

--- a/perSystem/checks/test.nix
+++ b/perSystem/checks/test.nix
@@ -1,10 +1,141 @@
-{
+flake: {
   perSystem = {
     lib,
+    pkgs,
     system,
     ...
   }:
     lib.optionalAttrs (system == "x86_64-linux") {
-      # TODO: add some useful tests
+      checks.opsTf-lib = let
+        ops = flake.config.flake.cardano-parts.lib.opsTf;
+
+        monitoring = {
+          bucketMimir = "test-mimir";
+          bucketLoki = "test-loki";
+          objectLockMode = "soft";
+          retentionMetricsDays = 365;
+          retentionLogsDays = 180;
+        };
+
+        buckets = ops.mkMonitoringBucketResources {
+          inherit monitoring;
+          awsRegion = "eu-central-1";
+          awsOrgId = "123456789012";
+        };
+
+        iamStatement = lib.elemAt (ops.mkMonitoringIamPolicyDoc monitoring).Statement 0;
+        iamActions = iamStatement.Action;
+        iamResources = iamStatement.Resource;
+
+        mimirLock = buckets.resource.aws_s3_bucket_object_lock_configuration.mimir.rule.default_retention;
+        lokiLock = buckets.resource.aws_s3_bucket_object_lock_configuration.loki.rule.default_retention;
+        mimirLifecycle = buckets.resource.aws_s3_bucket_lifecycle_configuration.mimir.rule;
+        lokiLifecycle = buckets.resource.aws_s3_bucket_lifecycle_configuration.loki.rule;
+        secureTransport = buckets.data.aws_iam_policy_document."s3_bucket_policy-mimir".statement;
+
+        requiredActions = ["s3:GetObject" "s3:PutObject" "s3:DeleteObject" "s3:ListBucket"];
+        forbiddenActions = [
+          "s3:*"
+          "s3:DeleteBucket"
+          "s3:PutBucketPolicy"
+          "s3:PutBucketPublicAccessBlock"
+          "s3:DeleteObjectVersion"
+          "s3:BypassGovernanceRetention"
+        ];
+
+        failures = lib.runTests {
+          testBucketsPresent = {
+            expr = lib.attrNames buckets.resource.aws_s3_bucket;
+            expected = ["loki" "mimir"];
+          };
+          testVersioningEnabled = {
+            expr = buckets.resource.aws_s3_bucket_versioning.mimir.versioning_configuration.status;
+            expected = "Enabled";
+          };
+          testObjectLockEnabled = {
+            expr = buckets.resource.aws_s3_bucket.mimir.object_lock_enabled;
+            expected = true;
+          };
+          testSseAlgorithm = {
+            expr = buckets.resource.aws_s3_bucket_server_side_encryption_configuration.mimir.rule.apply_server_side_encryption_by_default.sse_algorithm;
+            expected = "AES256";
+          };
+          testLoggingTargetBucket = {
+            expr = buckets.resource.aws_s3_bucket_logging.mimir.target_bucket;
+            expected = "s3-server-access-logs-123456789012-eu-central-1";
+          };
+
+          testLockModeIsGovernance = {
+            expr = mimirLock.mode;
+            expected = "GOVERNANCE";
+          };
+          testMimirLockDays = {
+            expr = mimirLock.days;
+            expected = 1;
+          };
+          testLokiLockDays = {
+            expr = lokiLock.days;
+            expected = 1;
+          };
+          testLockDaysForGovernanceMetrics = {
+            expr = ops.lockDaysFor "governance" 365;
+            expected = 365;
+          };
+          testLockDaysForGovernanceLogs = {
+            expr = ops.lockDaysFor "governance" 180;
+            expected = 180;
+          };
+
+          testMimirLifecycleDays = {
+            expr = (lib.elemAt mimirLifecycle 0).expiration.days;
+            expected = 365;
+          };
+          testLokiLifecycleDays = {
+            expr = (lib.elemAt lokiLifecycle 0).expiration.days;
+            expected = 180;
+          };
+          testDeleteMarkerRule = {
+            expr = (lib.elemAt mimirLifecycle 1).expiration.expired_object_delete_marker;
+            expected = true;
+          };
+
+          testSecureTransportValue = {
+            expr = lib.elemAt secureTransport.condition.values 0;
+            expected = "false";
+          };
+          testSecureTransportEffect = {
+            expr = secureTransport.effect;
+            expected = "Deny";
+          };
+
+          testIamMissingActions = {
+            expr = lib.subtractLists iamActions requiredActions;
+            expected = [];
+          };
+          testIamForbiddenActions = {
+            expr = lib.intersectLists forbiddenActions iamActions;
+            expected = [];
+          };
+          testIamCoversMimirObjects = {
+            expr = lib.elem "arn:aws:s3:::test-mimir/*" iamResources;
+            expected = true;
+          };
+          testIamCoversLokiObjects = {
+            expr = lib.elem "arn:aws:s3:::test-loki/*" iamResources;
+            expected = true;
+          };
+
+          testAwsProviderFor = {
+            expr = ops.awsProviderFor "eu-central-1";
+            expected = "aws.eu_central_1";
+          };
+        };
+      in
+        # `throwTestFailures` returns null on pass, throws with a
+        # pretty-printed diff on fail. The throw aborts `nix flake
+        # check` at eval time before any builder runs.
+        builtins.seq
+        (lib.debug.throwTestFailures {inherit failures;})
+        pkgs.emptyFile;
     };
 }

--- a/templates/cardano-parts-project/README.md
+++ b/templates/cardano-parts-project/README.md
@@ -134,6 +134,60 @@ Similarly, for monitoring resources:
     just tofu grafana plan
     just tofu grafana apply
 
+## Optional: in-cluster monitoring
+
+By default, monitoring metrics and logs are pushed to a centralized
+[cardano-monitoring](https://github.com/input-output-hk/cardano-monitoring)
+stack. To run an in-cluster monitoring machine instead (or in addition),
+set `flake.cardano-parts.cluster.infra.monitoring.enable = true` in
+`./flake/cluster.nix` and uncomment the `monitoring` machine declaration
+in `./flake/colmena.nix`.
+
+When enabled, opentofu/bootstrap creates `${profile}-mimir` and
+`${profile}-loki` S3 buckets with Object Lock + lifecycle wired
+together so app-level retention and storage-level retention stay in
+lockstep. The EC2 role gets least-privilege data-plane access (no
+`s3:DeleteBucket`, `s3:PutBucketPolicy`, no governance bypass).
+`profile-grafana-alloy` on every other machine auto-targets the
+in-cluster monitoring node — the `grafana-alloy-{metrics,loki}-url`
+sops secrets become optional. Username/password basic-auth credentials
+are still required.
+
+Retention is configured in days via
+`infra.monitoring.retentionMetricsDays` (default 365) and
+`infra.monitoring.retentionLogsDays` (default 180). The same number
+drives both Mimir/Loki retention and S3 lifecycle expiration on the
+matching bucket.
+
+`infra.monitoring.objectLockMode` controls the S3 Object Lock policy:
+
+  * `"soft"` (default) — 1-day GOVERNANCE lock. Stops a same-day
+    compromise of the monitoring node from wiping fresh data;
+    compaction-driven deletes succeed once objects age past the lock.
+    Storage stays ~1× retention.
+  * `"governance"` — lock spans the full retention window. A compromised
+    monitoring node cannot delete data pre-expiry; storage roughly
+    doubles during the retention window because compaction sources
+    cannot be deleted. A separately-permissioned operator role holding
+    `s3:BypassGovernanceRetention` can break-glass for legitimate
+    recovery.
+
+Required sops-managed secrets at `./secrets/monitoring/`:
+
+  * `grafana-password.enc`
+  * `grafana-oauth-client-id.enc`
+  * `grafana-oauth-client-secret.enc`
+  * `caddy-environment-monitoring.enc` (provides `ADMIN_HASH` and
+    `WRITE_HASH` env vars consumed by the monitoring machine's Caddyfile)
+
+Dashboards, alert rules, and recording rules are read from the directory
+specified by `infra.monitoring.provisionPath`. Pointing it at the
+existing `./flake/opentofu/grafana` directory shares the same
+`.nix-import` files between the in-cluster Mimir/Grafana and any
+external tofu-driven cardano-monitoring workspace; both consumers
+transform from the tofu-mimir-provider schema to their respective
+target formats at evaluation time.
+
 ## SSH
 
 If your credentials are correct, and the cluster is already provisioned with

--- a/templates/cardano-parts-project/flake/cluster.nix
+++ b/templates/cardano-parts-project/flake/cluster.nix
@@ -69,7 +69,7 @@
     # infra.monitoring = {
     #   enable = true;
     #   email = "devops+monitoring@UPDATE_ME";
-    #   oauth.google.allowedDomains = ["UPDATE_ME"];
+    #   oauth.google.allowedDomain = "UPDATE_ME";
     #
     #   # Reuse the existing tofu grafana directory so dashboards, alerts,
     #   # and recording rules feed both the in-cluster Mimir/Grafana and

--- a/templates/cardano-parts-project/flake/cluster.nix
+++ b/templates/cardano-parts-project/flake/cluster.nix
@@ -50,6 +50,46 @@
     # If using grafana cloud stack based monitoring.
     # infra.grafana.stackName = "UPDATE_ME";
 
+    # Optional: in-cluster monitoring stack (Grafana + Mimir + Loki + Caddy).
+    # Deploys a single monitoring machine that consumes metrics and logs
+    # from the rest of the cluster via profile-grafana-alloy.
+    #
+    # When enabled:
+    #   * opentofu/bootstrap creates `${profile}-mimir` and `${profile}-loki`
+    #     S3 buckets with Object Lock + lifecycle. The EC2 role gets
+    #     least-privilege data-plane access (no bucket-management actions,
+    #     no governance bypass).
+    #   * profile-grafana-alloy auto-targets the in-cluster monitoring node;
+    #     `grafana-alloy-{metrics,loki}-url` sops secrets become optional.
+    #   * A Colmena machine matching `infra.monitoring.hostname` (default
+    #     "monitoring") must be declared with `profile-monitoring` imported
+    #     and `enableDns = true` so the DNS A record is created at
+    #     `${subdomain}.${infra.aws.domain}`.
+    #
+    # infra.monitoring = {
+    #   enable = true;
+    #   email = "devops+monitoring@UPDATE_ME";
+    #   oauth.google.allowedDomains = ["UPDATE_ME"];
+    #
+    #   # Reuse the existing tofu grafana directory so dashboards, alerts,
+    #   # and recording rules feed both the in-cluster Mimir/Grafana and
+    #   # any external tofu-driven cardano-monitoring workspace.
+    #   provisionPath = ./opentofu/grafana;
+    #
+    #   # Storage retention. Drives both app-level retention and S3
+    #   # lifecycle expiration so they cannot drift.
+    #   # retentionMetricsDays = 365;
+    #   # retentionLogsDays = 180;
+    #
+    #   # S3 Object Lock policy. "soft" (default) gives a 1-day immutability
+    #   # window — cheap, blocks same-day mass-delete from a compromised
+    #   # node. "governance" locks for the full retention window — roughly
+    #   # doubles storage cost but a compromised node cannot delete pre-
+    #   # expiry. Both modes are GOVERNANCE-mode; a separately-permissioned
+    #   # operator role with `s3:BypassGovernanceRetention` can break-glass.
+    #   # objectLockMode = "soft";
+    # };
+
     # For defining deployment groups with varying configuration.  Adjust as needed.
     groups = {
       preview1 = {

--- a/templates/cardano-parts-project/flake/colmena.nix
+++ b/templates/cardano-parts-project/flake/colmena.nix
@@ -228,6 +228,18 @@ in
           {services.cardano-faucet.acmeEmail = "devops@iohk.io";}
         ];
       };
+      # Optional in-cluster monitoring node. Use only when
+      # `flake.cardano-parts.cluster.infra.monitoring.enable = true`.
+      # The machine name must match `infra.monitoring.hostname` (default
+      # "monitoring") so the DNS A record lands at the expected subdomain.
+      # Uncomment together with the host declaration below.
+      #
+      # monitoring = {
+      #   imports = [
+      #     inputs.cardano-parts.nixosModules.profile-monitoring
+      #     {cardano-parts.perNode.meta.enableDns = true;}
+      #   ];
+      # };
     in {
       meta = {
         nixpkgs = import inputs.nixpkgs {
@@ -284,6 +296,10 @@ in
       preview1-rel-c-1 = {imports = [eu-central-1 t3a-small (ebs 40) (group "preview1") node rel tcpTxOpt];};
       preview1-dbsync-a-1 = {imports = [eu-central-1 m5a-large (ebs 40) (group "preview1") dbsync smash];};
       preview1-faucet-a-1 = {imports = [eu-central-1 t3a-medium (ebs 40) (group "preview1") node faucet pre];};
+
+      # Optional in-cluster monitoring host; uncomment together with
+      # `infra.monitoring.enable = true` in flake/cluster.nix.
+      # monitoring = {imports = [eu-central-1 t3a-medium (ebs 50) (group "preview1") monitoring];};
     };
 
     flake.colmenaHive = inputs.cardano-parts.inputs.colmena.lib.makeHive self.outputs.colmena;

--- a/templates/cardano-parts-project/flake/opentofu/bootstrap.nix
+++ b/templates/cardano-parts-project/flake/opentofu/bootstrap.nix
@@ -15,6 +15,8 @@
 
   system = "x86_64-linux";
 
+  # All `forEach unmanagedBuckets` loops below scope to this list only;
+  # opsTf-managed buckets (mimir, loki) flow through mkMonitoringBucketResources.
   unmanagedBuckets = ["rain_artifacts"];
 
   workspace = "bootstrap";

--- a/templates/cardano-parts-project/flake/opentofu/bootstrap.nix
+++ b/templates/cardano-parts-project/flake/opentofu/bootstrap.nix
@@ -5,35 +5,20 @@
   ...
 }: let
   inherit (config.flake.lib.strings) dashToSnake;
-
   inherit (config.flake.cardano-parts.cluster) infra;
+  inherit
+    (config.flake.cardano-parts.lib.opsTf)
+    awsProviderFor
+    bucketPolicyStatementSecureTransport
+    mkMonitoringBucketResources
+    ;
 
   system = "x86_64-linux";
-
-  bucketPolicyStatementSecureTransport = bucketArn: {
-    sid = "RestrictToTLSRequestsOnly";
-    effect = "Deny";
-    actions = ["s3:*"];
-    resources = [
-      bucketArn
-      "${bucketArn}/*"
-    ];
-    condition = {
-      test = "Bool";
-      variable = "aws:SecureTransport";
-      values = ["false"];
-    };
-    principals = {
-      type = "*";
-      identifiers = ["*"];
-    };
-  };
 
   unmanagedBuckets = ["rain_artifacts"];
 
   workspace = "bootstrap";
 
-  awsProviderFor = region: "aws.${dashToSnake region}";
   awsccProviderFor = region: "awscc.${dashToSnake region}";
 
   sensitiveString = {
@@ -436,6 +421,18 @@ in {
           };
         };
       }
+
+      # Monitoring (Mimir + Loki) S3 buckets, only when monitoring is
+      # enabled. Bucket access for the EC2 role is granted in the
+      # cluster workspace. Construction lives in
+      # `cardano-parts.lib.opsTf` so existing downstream repos that
+      # don't use this template's bootstrap workspace can still pull
+      # in the same Object Lock + lifecycle wiring.
+      (lib.mkIf infra.monitoring.enable (mkMonitoringBucketResources {
+        inherit (infra) monitoring;
+        awsRegion = infra.aws.region;
+        awsOrgId = infra.aws.orgId;
+      }))
     ];
   };
 }

--- a/templates/cardano-parts-project/flake/opentofu/cluster.nix
+++ b/templates/cardano-parts-project/flake/opentofu/cluster.nix
@@ -509,34 +509,49 @@ in {
               policyList);
           in
             foldl' recursiveUpdate {} [
-              (mkRoleAttachments "ec2_role" [
-                "kms_user"
-                {
-                  name = "ssm";
-                  arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore";
-                }
-              ])
+              (mkRoleAttachments "ec2_role" (
+                [
+                  "kms_user"
+                  {
+                    name = "ssm";
+                    arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore";
+                  }
+                ]
+                ++ optional infra.monitoring.enable "monitoring_s3"
+              ))
             ];
 
-          aws_iam_policy.kms_user = {
-            name = "kmsUser";
-            policy = toJSON {
-              Version = "2012-10-17";
-              Statement = [
-                {
-                  Effect = "Allow";
-                  Action = ["kms:Decrypt" "kms:DescribeKey"];
+          aws_iam_policy =
+            {
+              kms_user = {
+                name = "kmsUser";
+                policy = toJSON {
+                  Version = "2012-10-17";
+                  Statement = [
+                    {
+                      Effect = "Allow";
+                      Action = ["kms:Decrypt" "kms:DescribeKey"];
 
-                  # KMS `kmsKey` is bootstrapped by cloudFormation rain.
-                  # Scope this policy to a specific resource to allow for multiple keys and key policies.
-                  Resource = "arn:aws:kms:*:\${data.aws_caller_identity.current.account_id}:key/*";
-                  Condition."ForAnyValue:StringLike"."kms:ResourceAliases" = "alias/kmsKey";
-                }
-              ];
+                      # KMS `kmsKey` is bootstrapped by cloudFormation rain.
+                      # Scope this policy to a specific resource to allow for multiple keys and key policies.
+                      Resource = "arn:aws:kms:*:\${data.aws_caller_identity.current.account_id}:key/*";
+                      Condition."ForAnyValue:StringLike"."kms:ResourceAliases" = "alias/kmsKey";
+                    }
+                  ];
+                };
+
+                tags = defaultTags;
+              };
+            }
+            // optionalAttrs infra.monitoring.enable {
+              # Built in `cardano-parts.lib.opsTf` so existing downstream
+              # repos can attach the same least-privilege policy without
+              # copying it.
+              monitoring_s3 = config.flake.cardano-parts.lib.opsTf.mkMonitoringIamPolicy {
+                inherit (infra) monitoring;
+                inherit defaultTags;
+              };
             };
-
-            tags = defaultTags;
-          };
 
           tls_private_key.bootstrap.algorithm = "ED25519";
 


### PR DESCRIPTION
## What

Adds an opt-in monitoring profile (`profile-monitoring`) running Grafana + Mimir + Loki + Prometheus + blackbox-exporter on a single Colmena machine, fronted by Caddy with ACME-issued TLS and Google OAuth on Grafana. Cluster-wide configuration lives under `flake.cardano-parts.cluster.infra.monitoring`, read by the bootstrap opentofu workspace, `profile-grafana-alloy`, and `profile-monitoring` itself so all three stay in lockstep.

## Storage retention + immutability

`cardano-parts.lib.opsTf.mkMonitoringBucketResources` provisions per-cluster Mimir and Loki S3 buckets with **Object Lock + lifecycle wired together** so app-level retention and storage-level retention cannot drift. `objectLockMode` picks between:

- `"soft"` (default) — 1-day GOVERNANCE lock. Stops a same-day compromise of the monitoring node from wiping fresh data; compaction-driven deletes succeed once objects age past the lock. ~1× storage.
- `"governance"` — lock spans the full retention window. Compromised monitoring node cannot delete pre-expiry; compaction sources cannot be deleted, so storage roughly doubles during the retention window. A separately-permissioned operator role with `s3:BypassGovernanceRetention` can break-glass.

The EC2 role attached to the monitoring node gets least-privilege data-plane access only via `mkMonitoringIamPolicy` — no `DeleteBucket`, `PutBucketPolicy`, `PutBucketPublicAccessBlock`, or governance bypass.

## opsTf library

Both bucket / IAM builders live in a new pure helper library at `flakeModules/lib/opsTf.nix` (no `pkgs` dependency). Existing downstream repos that don't use this template's bootstrap workspace (e.g. cardano-playground, which keeps everything in one workspace) can call `config.flake.cardano-parts.lib.opsTf.{mkMonitoringBucketResources,mkMonitoringIamPolicy}` directly from any terranix-driven workspace without copying code. The template's `bootstrap.nix` and `cluster.nix` are now the canonical callers.

`opsTf` also exports the `awsProviderFor` and `bucketPolicyStatementSecureTransport` helpers it uses internally, so they're available to other workspaces too.

## profile-grafana-alloy

When `infra.monitoring.enable = true`, alloy auto-targets the in-cluster monitoring node, making the `grafana-alloy-{metrics,loki}-url` sops secrets optional. Username / password basic-auth credentials are still required.

## opsLib additions

`parseDir` and `readNixImport` were added so monitoring rule files and the existing tofu grafana workspace can share the same `.nix-import` corpus without duplicating helpers.

## Cluster-flake config access fix

`profile-monitoring` and the new code in `profile-grafana-alloy` read cluster infra through `groupFlake.config` (the consuming flake's `self`) rather than `flake.config`. The latter closes over cardano-parts' own flake-parts evaluation where these options carry their declared null defaults, not the consumer's values.

## Template additions

- Optional monitoring host stub in `colmena.nix` (fully commented; uncomment along with the `infra.monitoring` stanza)
- `infra.monitoring` stanza in `cluster.nix` documenting all options
- S3 bucket + IAM policy hooks in opentofu workspaces
- README section covering retention, lock modes, and the required sops secrets

## Validation

Built end-to-end in cardano-playground via local path-override:

```
$ nix build .#nixosConfigurations.monitoring1-mon-a-1.config.system.build.toplevel --fallback
/nix/store/...-nixos-system-monitoring1-mon-a-1-25.11pre-git
```

opsTf returns expected attrsets verified directly:

| | |
|---|---|
| bucket keys | `["loki" "mimir"]` |
| Object Lock mode | `GOVERNANCE` |
| soft lock days | `1` |
| loki lifecycle days | `180` (matches `retentionLogsDays` default) |
| IAM policy contains `s3:*` | `false` |
| IAM policy contains `s3:GetObject` | `true` |

Sops secrets, IP module, and actual deploy intentionally not exercised for this PR.

## Required sops secrets at the consuming repo's `secrets/monitoring/`

- `grafana-password.enc`
- `grafana-oauth-client-id.enc`
- `grafana-oauth-client-secret.enc`
- `caddy-environment-${machineName}.enc` (provides `ADMIN_HASH` and `WRITE_HASH` env vars consumed by Caddy)
