### PR TITLE
nixosModule: add profile-cardano-committee-monitor for constitutional-committee state alerting

### DIFF
--- a/flake/nixosModules/profile-cardano-committee-monitor.nix
+++ b/flake/nixosModules/profile-cardano-committee-monitor.nix
@@ -1,0 +1,133 @@
+# nixosModule: profile-cardano-committee-monitor
+#
+# TODO: Move this to a docs generator
+#
+# Attributes available on nixos module import:
+#   config.services.cardano-committee-monitor.enable
+#
+# Tips:
+#   * Periodic collector for cardano constitutional-committee state metrics
+#   * Publishes a .prom file into the alloy textfile-collector directory
+#   * Requires profile-grafana-alloy with services.alloy.textfileCollectorDirectory set
+#   * Requires profile-cardano-node-group and services.cardano-node.shareNodeSocket = true
+#   * Import on exactly one host per environment to avoid duplicate alerts
+#   * Cadence is paired with cardano_cc_metrics_stale in cardano-committee.nix-import
+{
+  flake.nixosModules.profile-cardano-committee-monitor = {
+    config,
+    pkgs,
+    lib,
+    ...
+  }:
+    with builtins;
+    with lib; let
+      inherit (perNodeCfg.lib) cardanoLib;
+      inherit (perNodeCfg.pkgs) cardano-cli;
+      inherit (groupCfg.meta) environmentName;
+      inherit (cardanoLib.environments.${environmentName}.nodeConfig) ShelleyGenesisFile;
+      inherit (fromJSON (readFile ShelleyGenesisFile)) epochLength slotLength;
+
+      groupCfg = config.cardano-parts.cluster.group;
+      perNodeCfg = config.cardano-parts.perNode;
+      cfg = config.services.cardano-committee-monitor;
+      secondsPerEpoch = epochLength * slotLength;
+      collect = pkgs.callPackage ../../flakeModules/lib/cardano-committee-monitor-collect.nix {inherit cardano-cli;};
+
+      # attrByPath rather than a direct attr access: a direct
+      # `config.services.alloy.textfileCollectorDirectory` would throw at
+      # eval time when profile-grafana-alloy isn't imported, before any
+      # friendlier error can surface.
+      textfileDirectory = attrByPath ["services" "alloy" "textfileCollectorDirectory"] null config;
+
+      # NixOS assertions only fire AFTER full config eval, so an eager
+      # `"${null}/…"` interpolation in the unit body would throw "cannot
+      # coerce null to string" first and hide the assertion message. The
+      # throw lives in a let-binding so it's deferred until first use,
+      # which only happens inside `mkIf cfg.enable`.
+      textfileDirectoryOrThrow =
+        if textfileDirectory == null
+        then
+          throw ''
+            profile-cardano-committee-monitor requires
+            services.alloy.textfileCollectorDirectory to be non-null.
+            Import profile-grafana-alloy on this host and set the
+            option to a directory path (e.g. "/var/lib/node-textfile").
+          ''
+        else textfileDirectory;
+    in {
+      key = ./profile-cardano-committee-monitor.nix;
+
+      options.services.cardano-committee-monitor = {
+        enable = mkEnableOption "Cardano constitutional-committee state metrics collector";
+      };
+
+      config = mkIf cfg.enable {
+        services.alloy.extraPrometheusRelabelNodeKeepRegex = ["^cardano_cc_.*$"];
+
+        # No assertion on services.cardano-node.enable: the `inherit
+        # (config.environment.variables) CARDANO_NODE_*` below is eager
+        # and throws first, leaving any such assertion dead.
+        # profile-cardano-node-group is documented (not asserted).
+        assertions = [
+          {
+            assertion = config.services.cardano-node.shareNodeSocket;
+            message = ''
+              profile-cardano-committee-monitor requires
+              services.cardano-node.shareNodeSocket = true so the
+              collector can read the cardano-node socket via its
+              supplementary group.
+            '';
+          }
+        ];
+
+        systemd.services.cardano-committee-monitor = {
+          description = "Collect cardano constitutional-committee state metrics";
+
+          # Soft Wants= (not Requires=) so the timer still fires if
+          # cardano-node is wedged, surfacing as cardano_cc_metrics_stale
+          # rather than silently skipped runs.
+          after = ["cardano-node.service" "cardano-node-socket-share.service"];
+          wants = ["cardano-node.service"];
+
+          environment = {
+            OUT = "${textfileDirectoryOrThrow}/cardano-committee.prom";
+            ENVIRONMENT_NAME = environmentName;
+            SECONDS_PER_EPOCH = toString secondsPerEpoch;
+            inherit
+              (config.environment.variables)
+              CARDANO_NODE_NETWORK_ID
+              CARDANO_NODE_SOCKET_PATH
+              ;
+          };
+
+          serviceConfig = {
+            Type = "oneshot";
+            ExecStart = "${collect}/bin/cardano-committee-monitor-collect";
+            DynamicUser = true;
+            SupplementaryGroups = ["cardano-node" "node-textfile"];
+            ReadWritePaths = [textfileDirectoryOrThrow];
+            ProtectSystem = "strict";
+            NoNewPrivileges = true;
+            PrivateTmp = true;
+            # cardano-cli on a backpressured node can take minutes; cap
+            # so a hung run doesn't silently delay the next.
+            TimeoutStartSec = "300s";
+          };
+        };
+
+        systemd.timers.cardano-committee-monitor = {
+          wantedBy = ["timers.target"];
+          timerConfig = {
+            Unit = "cardano-committee-monitor.service";
+            # Paired with cardano_cc_metrics_stale (5400s) in
+            # cardano-committee.nix-import. The two live in separate
+            # evaluations and can't be cross-checked; change together.
+            OnCalendar = "hourly";
+            # Spread cardano-cli load across the first 10m of the hour
+            # so synchronised redeploys don't queue queries.
+            RandomizedDelaySec = "600";
+          };
+        };
+      };
+    };
+}

--- a/flake/nixosModules/profile-grafana-alloy.nix
+++ b/flake/nixosModules/profile-grafana-alloy.nix
@@ -7,6 +7,7 @@
 #   config.services.alloy.enableLoki
 #   config.services.alloy.extraAlloyConfig
 #   config.services.alloy.extraJournalReceivers
+#   config.services.alloy.extraPrometheusRelabelNodeKeepRegex
 #   config.services.alloy.labels
 #   config.services.alloy.logLevel
 #   config.services.alloy.prometheusExporterUnixNodeSetCollectors
@@ -16,6 +17,7 @@
 #   config.services.alloy.systemdEnableTaskMetrics
 #   config.services.alloy.systemdUnitExclude
 #   config.services.alloy.systemdUnitInclude
+#   config.services.alloy.textfileCollectorDirectory
 #   config.services.alloy.useSopsSecrets
 #
 # Tips:
@@ -30,7 +32,7 @@ flake @ {moduleWithSystem, ...}: {
   }:
     with builtins;
     with lib; let
-      inherit (lib.types) attrsOf bool enum listOf str lines;
+      inherit (lib.types) attrsOf bool enum listOf nullOr str lines;
       inherit (config.cardano-parts.perNode.meta) cardanoDbSyncPrometheusExporterPort cardanoNodePrometheusExporterPort hostAddr;
       inherit (groupCfg) groupName groupFlake;
       inherit (groupCfg.meta) environmentName;
@@ -153,7 +155,10 @@ flake @ {moduleWithSystem, ...}: {
         exporter = ''
           // Default grafana alloy node exporter integration components, in lowest to highest dependency order
           prometheus.exporter.unix "integrations_node_exporter" {
-            set_collectors = [${concatMapStringsSep ", " (s: "\"${s}\"") cfg.prometheusExporterUnixNodeSetCollectors}]
+            set_collectors = [${concatMapStringsSep ", " (s: "\"${s}\"") (
+            cfg.prometheusExporterUnixNodeSetCollectors
+            ++ optional (cfg.textfileCollectorDirectory != null) "textfile"
+          )}]
 
             systemd {
               enable_restarts = ${boolToString cfg.systemdEnableRestartMetrics}
@@ -162,6 +167,11 @@ flake @ {moduleWithSystem, ...}: {
               unit_exclude = "${cfg.systemdUnitExclude}"
               unit_include = "${cfg.systemdUnitInclude}"
             }
+            ${optionalString (cfg.textfileCollectorDirectory != null) ''
+            textfile {
+              directory = "${cfg.textfileCollectorDirectory}"
+            }
+          ''}
           }
 
           discovery.relabel "integrations_node_exporter" {
@@ -199,7 +209,7 @@ flake @ {moduleWithSystem, ...}: {
 
             rule {
               source_labels = ["__name__"]
-              regex = "${cfg.prometheusRelabelNodeKeepRegex}"
+              regex = "${cfg.prometheusRelabelNodeKeepRegex}${optionalString (cfg.extraPrometheusRelabelNodeKeepRegex != []) "|${concatStringsSep "|" cfg.extraPrometheusRelabelNodeKeepRegex}"}"
               action = "keep"
             }
 
@@ -506,6 +516,18 @@ flake @ {moduleWithSystem, ...}: {
             '';
           };
 
+          extraPrometheusRelabelNodeKeepRegex = mkOption {
+            type = listOf str;
+            default = [];
+            description = ''
+              Additional alternation arms appended to prometheusRelabelNodeKeepRegex.
+
+              Used by sibling profiles (e.g. profile-cardano-committee-monitor) to
+              whitelist their textfile-collector metric series without a recursive
+              mkForce on the base option.
+            '';
+          };
+
           labels = mkOption {
             type = attrsOf str;
             default = {
@@ -599,6 +621,7 @@ flake @ {moduleWithSystem, ...}: {
                 "node_sockstat_(UDP|UDP6|UDPLITE|UDPLITE6)_inuse"
                 "node_softnet_(dropped|processed|times_squeezed)_total"
                 "node_systemd_.*"
+                "node_textfile_(mtime_seconds|scrape_error)"
                 "node_timex_(estimated_error|maxerror|offset)_seconds"
                 "node_timex_sync_status"
                 "node_time_zone_offset_seconds"
@@ -642,6 +665,21 @@ flake @ {moduleWithSystem, ...}: {
             description = ''
               Regexp of systemd units to include.
               Units must both match include and not match exclude to be collected.
+            '';
+          };
+
+          textfileCollectorDirectory = mkOption {
+            type = nullOr str;
+            default = null;
+            description = ''
+              Directory the node-exporter textfile collector scrapes. When set,
+              the alloy module creates the directory group-writable by the
+              `node-textfile` group and enables the node-exporter `textfile`
+              collector. Sibling profiles (e.g. profile-cardano-committee-monitor)
+              write their .prom files here.
+
+              When left at the default `null`, the textfile collector remains
+              unwired and no directory or group is created.
             '';
           };
 
@@ -729,7 +767,17 @@ flake @ {moduleWithSystem, ...}: {
             group = "grafana-alloy";
             isSystemUser = true;
           };
+
+          # Owned by the alloy module so multiple textfile-publishing profiles
+          # (e.g. profile-cardano-committee-monitor) can share a single setgid
+          # directory without fighting over StateDirectory.
+          groups.node-textfile = mkIf (cfg.textfileCollectorDirectory != null) {};
         };
+
+        systemd.tmpfiles.rules = mkIf (cfg.textfileCollectorDirectory != null) [
+          # mode 2775: setgid so files created here inherit the node-textfile group.
+          "d ${cfg.textfileCollectorDirectory} 2775 root node-textfile - -"
+        ];
 
         sops.secrets = mkIf cfg.useSopsSecrets (
           mkSopsSecret (mkSopsSecretParams "grafana-alloy-metrics-url")

--- a/flake/nixosModules/tests/committee-state-expected.prom
+++ b/flake/nixosModules/tests/committee-state-expected.prom
@@ -1,0 +1,50 @@
+# HELP cardano_cc_member_epochs_until_expiration Epochs remaining before this committee member term expires.
+# TYPE cardano_cc_member_epochs_until_expiration gauge
+cardano_cc_member_epochs_until_expiration{environment="preview",cold_credential="keyHash-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} 100
+cardano_cc_member_epochs_until_expiration{environment="preview",cold_credential="scriptHash-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} 200
+cardano_cc_member_epochs_until_expiration{environment="preview",cold_credential="keyHash-cccccccccccccccccccccccccccccccccccccccccccccccccccc"} -100
+cardano_cc_member_epochs_until_expiration{environment="preview",cold_credential="scriptHash-dddddddddddddddddddddddddddddddddddddddddddddddddddd"} 10
+cardano_cc_member_epochs_until_expiration{environment="preview",cold_credential="scriptHash-ffffffffffffffffffffffffffffffffffffffffffffffffffff"} 5
+# HELP cardano_cc_member_seconds_until_expiration Seconds remaining before this committee member term expires (epochs delta times cardano_cc_seconds_per_epoch).
+# TYPE cardano_cc_member_seconds_until_expiration gauge
+cardano_cc_member_seconds_until_expiration{environment="preview",cold_credential="keyHash-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"} 8640000
+cardano_cc_member_seconds_until_expiration{environment="preview",cold_credential="scriptHash-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"} 17280000
+cardano_cc_member_seconds_until_expiration{environment="preview",cold_credential="keyHash-cccccccccccccccccccccccccccccccccccccccccccccccccccc"} -8640000
+cardano_cc_member_seconds_until_expiration{environment="preview",cold_credential="scriptHash-dddddddddddddddddddddddddddddddddddddddddddddddddddd"} 864000
+cardano_cc_member_seconds_until_expiration{environment="preview",cold_credential="scriptHash-ffffffffffffffffffffffffffffffffffffffffffffffffffff"} 432000
+# HELP cardano_cc_member_hot_cred_status Info gauge (value 1) carrying the current hotCredsAuthStatus.tag in the status label.
+# TYPE cardano_cc_member_hot_cred_status gauge
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="keyHash-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",status="MemberAuthorized"} 1
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="scriptHash-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",status="MemberResigned"} 1
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="keyHash-cccccccccccccccccccccccccccccccccccccccccccccccccccc",status="MemberAuthorized"} 1
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="scriptHash-dddddddddddddddddddddddddddddddddddddddddddddddddddd",status="MemberNotAuthorized"} 1
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="keyHash-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",status="MemberAuthorized"} 1
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="scriptHash-ffffffffffffffffffffffffffffffffffffffffffffffffffff",status="MemberAuthorized"} 1
+cardano_cc_member_hot_cred_status{environment="preview",cold_credential="keyHash-11111111111111111111111111111111111111111111111111aa",status="MemberAuthorized"} 1
+# HELP cardano_cc_member_state Info gauge (value 1) carrying the current committee-member status in the state label.
+# TYPE cardano_cc_member_state gauge
+cardano_cc_member_state{environment="preview",cold_credential="keyHash-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",state="Active"} 1
+cardano_cc_member_state{environment="preview",cold_credential="scriptHash-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",state="Active"} 1
+cardano_cc_member_state{environment="preview",cold_credential="keyHash-cccccccccccccccccccccccccccccccccccccccccccccccccccc",state="Expired"} 1
+cardano_cc_member_state{environment="preview",cold_credential="scriptHash-dddddddddddddddddddddddddddddddddddddddddddddddddddd",state="Active"} 1
+cardano_cc_member_state{environment="preview",cold_credential="keyHash-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",state="Unrecognized"} 1
+cardano_cc_member_state{environment="preview",cold_credential="scriptHash-ffffffffffffffffffffffffffffffffffffffffffffffffffff",state="Active"} 1
+cardano_cc_member_state{environment="preview",cold_credential="keyHash-11111111111111111111111111111111111111111111111111aa",state="Active"} 1
+# HELP cardano_cc_member_next_epoch_change Info gauge (value 1) carrying nextEpochChange in the change label.
+# TYPE cardano_cc_member_next_epoch_change gauge
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="keyHash-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",change="NoChangeExpected"} 1
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="scriptHash-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",change="NoChangeExpected"} 1
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="keyHash-cccccccccccccccccccccccccccccccccccccccccccccccccccc",change="ToBeRemoved"} 1
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="scriptHash-dddddddddddddddddddddddddddddddddddddddddddddddddddd",change="ToBeExpired"} 1
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="keyHash-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee",change="NoChangeExpected"} 1
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="scriptHash-ffffffffffffffffffffffffffffffffffffffffffffffffffff",change="TermAdjusted"} 1
+cardano_cc_member_next_epoch_change{environment="preview",cold_credential="keyHash-11111111111111111111111111111111111111111111111111aa",change="ToBeEnacted"} 1
+# HELP cardano_cc_current_epoch Current epoch on this environment.
+# TYPE cardano_cc_current_epoch gauge
+cardano_cc_current_epoch{environment="preview"} 1300
+# HELP cardano_cc_member_count Total committee members on this environment.
+# TYPE cardano_cc_member_count gauge
+cardano_cc_member_count{environment="preview"} 7
+# HELP cardano_cc_seconds_per_epoch Environment constant: epochLength times slotLength from shelley genesis.
+# TYPE cardano_cc_seconds_per_epoch gauge
+cardano_cc_seconds_per_epoch{environment="preview"} 86400

--- a/flake/nixosModules/tests/committee-state-fixture.json
+++ b/flake/nixosModules/tests/committee-state-fixture.json
@@ -1,0 +1,85 @@
+{
+  "epoch": 1300,
+  "threshold": {
+    "numerator": 2,
+    "denominator": 3
+  },
+  "committee": {
+    "keyHash-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberAuthorized",
+        "contents": {
+          "keyHash": "1111111111111111111111111111111111111111111111111111111111111111"
+        }
+      },
+      "status": "Active",
+      "expiration": 1400,
+      "nextEpochChange": { "tag": "NoChangeExpected" }
+    },
+    "scriptHash-bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberResigned",
+        "contents": {
+          "dataHash": "2222222222222222222222222222222222222222222222222222222222222222",
+          "url": "ipfs://bafkresignedreceipt"
+        }
+      },
+      "status": "Active",
+      "expiration": 1500,
+      "nextEpochChange": { "tag": "NoChangeExpected" }
+    },
+    "keyHash-cccccccccccccccccccccccccccccccccccccccccccccccccccc": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberAuthorized",
+        "contents": {
+          "keyHash": "3333333333333333333333333333333333333333333333333333333333333333"
+        }
+      },
+      "status": "Expired",
+      "expiration": 1200,
+      "nextEpochChange": { "tag": "ToBeRemoved" }
+    },
+    "scriptHash-dddddddddddddddddddddddddddddddddddddddddddddddddddd": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberNotAuthorized",
+        "contents": {}
+      },
+      "status": "Active",
+      "expiration": 1310,
+      "nextEpochChange": { "tag": "ToBeExpired" }
+    },
+    "keyHash-eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberAuthorized",
+        "contents": {
+          "keyHash": "4444444444444444444444444444444444444444444444444444444444444444"
+        }
+      },
+      "status": "Unrecognized",
+      "expiration": null,
+      "nextEpochChange": { "tag": "NoChangeExpected" }
+    },
+    "scriptHash-ffffffffffffffffffffffffffffffffffffffffffffffffffff": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberAuthorized",
+        "contents": {
+          "scriptHash": "5555555555555555555555555555555555555555555555555555555555555555"
+        }
+      },
+      "status": "Active",
+      "expiration": 1305,
+      "nextEpochChange": { "tag": "TermAdjusted", "contents": 1310 }
+    },
+    "keyHash-11111111111111111111111111111111111111111111111111aa": {
+      "hotCredsAuthStatus": {
+        "tag": "MemberAuthorized",
+        "contents": {
+          "keyHash": "6666666666666666666666666666666666666666666666666666666666666666"
+        }
+      },
+      "status": "Active",
+      "expiration": null,
+      "nextEpochChange": { "tag": "ToBeEnacted" }
+    }
+  }
+}

--- a/flakeModules/lib/cardano-committee-monitor-collect.nix
+++ b/flakeModules/lib/cardano-committee-monitor-collect.nix
@@ -1,0 +1,89 @@
+# Shared collector script. callPackage'd from both the production unit
+# (profile-cardano-committee-monitor.nix) and the fixture check; the
+# `cardano-cli` parameter lets the check swap in a fixture-driven shim.
+{
+  pkgs,
+  cardano-cli ? pkgs.cardano-cli,
+}:
+pkgs.writeShellApplication {
+  name = "cardano-committee-monitor-collect";
+  runtimeInputs = [cardano-cli pkgs.jq pkgs.coreutils];
+  text = ''
+    set -euo pipefail
+    : "''${OUT:?OUT (output .prom path) must be set}"
+    : "''${ENVIRONMENT_NAME:?ENVIRONMENT_NAME must be set}"
+    : "''${SECONDS_PER_EPOCH:?SECONDS_PER_EPOCH must be set}"
+    TMP="$OUT.tmp"
+
+    # `query committee-state` returns the top-level `epoch` it was
+    # computed against, so a second `query tip` RPC would only open an
+    # epoch-boundary race window.
+    CS=$(cardano-cli latest query committee-state)
+
+    # `environment` is baked in here because alloy's node-exporter
+    # relabel chain sets only `instance` and `job` for textfile-collector
+    # samples — there is no scraper-side label source. The same chain
+    # means `node_textfile_mtime_seconds` does NOT carry `environment`,
+    # which is why `cardano_cc_metrics_stale` keys on `instance` only.
+    #
+    # The `.epoch == null` guard aborts before `mv "$TMP" "$OUT"`, so the
+    # previous .prom stays in place and staleness surfaces as
+    # cardano_cc_metrics_stale rather than as zero values.
+    jq -r --arg     env "$ENVIRONMENT_NAME" \
+          --argjson spe "$SECONDS_PER_EPOCH" '
+      def lbl: "environment=\"\($env)\",cold_credential=\"\(.key)\"";
+      if .epoch == null then error("cardano-cli returned no .epoch") else . end
+      | .epoch as $epoch
+      | .committee
+      | to_entries as $members
+      | (
+          "# HELP cardano_cc_member_epochs_until_expiration Epochs remaining before this committee member term expires.",
+          "# TYPE cardano_cc_member_epochs_until_expiration gauge",
+          # Expiration is null for newly-enacted members; their term
+          # metrics are intentionally absent — alert via
+          # cardano_cc_member_state{state=...} instead.
+          ($members[]
+            | (.value.expiration // null) as $exp
+            | select($exp != null)
+            | "cardano_cc_member_epochs_until_expiration{\(lbl)} \($exp - $epoch)"),
+
+          "# HELP cardano_cc_member_seconds_until_expiration Seconds remaining before this committee member term expires (epochs delta times cardano_cc_seconds_per_epoch).",
+          "# TYPE cardano_cc_member_seconds_until_expiration gauge",
+          ($members[]
+            | (.value.expiration // null) as $exp
+            | select($exp != null)
+            | "cardano_cc_member_seconds_until_expiration{\(lbl)} \(($exp - $epoch) * $spe)"),
+
+          "# HELP cardano_cc_member_hot_cred_status Info gauge (value 1) carrying the current hotCredsAuthStatus.tag in the status label.",
+          "# TYPE cardano_cc_member_hot_cred_status gauge",
+          ($members[]
+            | "cardano_cc_member_hot_cred_status{\(lbl),status=\"\(.value.hotCredsAuthStatus.tag)\"} 1"),
+
+          "# HELP cardano_cc_member_state Info gauge (value 1) carrying the current committee-member status in the state label.",
+          "# TYPE cardano_cc_member_state gauge",
+          ($members[]
+            | "cardano_cc_member_state{\(lbl),state=\"\(.value.status)\"} 1"),
+
+          "# HELP cardano_cc_member_next_epoch_change Info gauge (value 1) carrying nextEpochChange in the change label.",
+          "# TYPE cardano_cc_member_next_epoch_change gauge",
+          ($members[]
+            | "cardano_cc_member_next_epoch_change{\(lbl),change=\"\(.value.nextEpochChange.tag)\"} 1"),
+
+          "# HELP cardano_cc_current_epoch Current epoch on this environment.",
+          "# TYPE cardano_cc_current_epoch gauge",
+          "cardano_cc_current_epoch{environment=\"\($env)\"} \($epoch)",
+
+          "# HELP cardano_cc_member_count Total committee members on this environment.",
+          "# TYPE cardano_cc_member_count gauge",
+          "cardano_cc_member_count{environment=\"\($env)\"} \($members | length)",
+
+          "# HELP cardano_cc_seconds_per_epoch Environment constant: epochLength times slotLength from shelley genesis.",
+          "# TYPE cardano_cc_seconds_per_epoch gauge",
+          "cardano_cc_seconds_per_epoch{environment=\"\($env)\"} \($spe)"
+        )
+    ' <<< "$CS" > "$TMP"
+
+    # Atomic publish via rename(2) on the same filesystem.
+    mv "$TMP" "$OUT"
+  '';
+}

--- a/perSystem/checks/cardano-committee-monitor-fixture.nix
+++ b/perSystem/checks/cardano-committee-monitor-fixture.nix
@@ -1,0 +1,48 @@
+# Golden-output check for the committee-state collector. Builds the same
+# writeShellApplication the production unit uses, with a fixture-driven
+# cardano-cli shim, then diffs against committee-state-expected.prom.
+#
+# When the fixture changes, regenerate the golden from the build failure
+# diff and commit it alongside the fixture change.
+{
+  perSystem = {
+    lib,
+    pkgs,
+    system,
+    ...
+  }:
+    lib.optionalAttrs (system == "x86_64-linux") {
+      checks.cardano-committee-monitor-fixture = let
+        # Match only on the trailing positional so the shim stays
+        # insensitive to --network / --socket-path plumbing changes.
+        cardano-cli = pkgs.writeShellScriptBin "cardano-cli" ''
+          case " $* " in
+            *" committee-state "*)
+              cat ${../../flake/nixosModules/tests/committee-state-fixture.json}
+              ;;
+            *)
+              echo "fixture shim: unsupported cardano-cli invocation: $*" >&2
+              exit 64
+              ;;
+          esac
+        '';
+        collect = pkgs.callPackage ../../flakeModules/lib/cardano-committee-monitor-collect.nix {
+          inherit cardano-cli;
+        };
+      in
+        pkgs.runCommand "cardano-committee-monitor-fixture" {} ''
+          export OUT="$TMPDIR/cardano-committee.prom"
+          export ENVIRONMENT_NAME=preview
+          export SECONDS_PER_EPOCH=86400
+          # Dummies — production unit always sets these, so the check
+          # asserts by their presence (and the shim ignores them).
+          export CARDANO_NODE_NETWORK_ID=2
+          export CARDANO_NODE_SOCKET_PATH=/dev/null
+
+          ${collect}/bin/cardano-committee-monitor-collect
+
+          diff -u ${../../flake/nixosModules/tests/committee-state-expected.prom} "$OUT"
+          touch "$out"
+        '';
+    };
+}

--- a/templates/cardano-parts-project/README.md
+++ b/templates/cardano-parts-project/README.md
@@ -144,6 +144,67 @@ Similarly, for monitoring resources:
     just tofu grafana plan
     just tofu grafana apply
 
+## Constitutional-committee state monitoring
+
+The `profile-cardano-committee-monitor` NixOS profile publishes Prometheus
+metrics about the on-chain constitutional-committee state (per-member term
+expiration, hot-key authorisation status, next-epoch-change signal). The
+metric series are prefixed `cardano_cc_*`. Alerts that consume them live in
+[./flake/opentofu/grafana/alerts/cardano-committee.nix-import](./flake/opentofu/grafana/alerts/cardano-committee.nix-import)
+and are deployed via `just tofu grafana apply` like the rest of the
+monitoring stack.
+
+### Enabling
+
+Import `profile-cardano-committee-monitor` on exactly **one** host per
+environment, alongside `profile-grafana-alloy` and
+`profile-cardano-node-group`:
+
+    {
+      imports = [
+        flake.config.flake.nixosModules.profile-cardano-node-group
+        flake.config.flake.nixosModules.profile-grafana-alloy
+        flake.config.flake.nixosModules.profile-cardano-committee-monitor
+      ];
+
+      services.alloy.textfileCollectorDirectory = "/var/lib/node-textfile";
+      services.cardano-node.shareNodeSocket = true;
+      services.cardano-committee-monitor.enable = true;
+    }
+
+The profile asserts both `services.alloy.textfileCollectorDirectory != null`
+and `services.cardano-node.shareNodeSocket = true`. `profile-cardano-node-group`
+is required but not asserted — without it, the unit's
+`inherit (config.environment.variables) CARDANO_NODE_*` throws a native
+Nix evaluation error before any assertion can fire.
+
+### One host per environment
+
+Importing the profile on more than one host per environment produces
+duplicate Prometheus series differing only by `instance`, and every alert
+fires once per duplicate host. The current implementation does not enforce
+single-host import; it is a documented expectation.
+
+### Tuning thresholds
+
+Alert thresholds are constants in
+[`cardano-committee.nix-import`](./flake/opentofu/grafana/alerts/cardano-committee.nix-import)
+(`warnDays`, `pageDays`). This file is part of the project template — your
+repo owns it after `init`, so edit it in place. For per-environment
+thresholds (e.g. mainnet 60d/14d while testnets stay at 30d/7d), duplicate
+the relevant rules and add an `environment=~"…"` selector on each;
+PromQL has no first-class way to express per-label thresholds.
+
+### Cadence is hardcoded
+
+The collector runs `OnCalendar=hourly` (with `RandomizedDelaySec=600`).
+The cadence is paired with the `cardano_cc_metrics_stale` threshold of
+5400 seconds in the alert file: any miss longer than ~90 minutes trips
+the alert. The two values live in separate Nix evaluations and cannot be
+cross-checked by assertion — if you change the cadence (e.g. via
+`lib.mkForce` on `systemd.timers.cardano-committee-monitor`), change the
+staleness threshold in the alert file in the same PR.
+
 ## SSH
 
 If your credentials are correct, and the cluster is already provisioned with

--- a/templates/cardano-parts-project/flake/opentofu/grafana/alerts/cardano-committee.nix-import
+++ b/templates/cardano-parts-project/flake/opentofu/grafana/alerts/cardano-committee.nix-import
@@ -1,0 +1,134 @@
+let
+  # 30d: operator-schedulable through governance in a non-emergency window.
+  warnDays = 30;
+  # 7d: worst-case epoch transition (5d on mainnet/preprod) + ratification buffer.
+  pageDays = 7;
+
+  warnSeconds = toString (warnDays * 86400);
+  pageSeconds = toString (pageDays * 86400);
+in {
+  namespace = "cardano";
+  name = "cardano-committee";
+  rule = [
+    {
+      # Lower bound `> pageSeconds` carves out the urgent band so a
+      # single member doesn't dual-fire warn + urgent; it also subsumes
+      # the `> 0` exclusion of already-expired members (negative
+      # seconds) that would otherwise dual-fire alongside
+      # cardano_cc_member_expired.
+      alert = "cardano_cc_term_expiring";
+      expr = "cardano_cc_member_seconds_until_expiration > ${pageSeconds} <= ${warnSeconds}";
+      labels.severity = "warning";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} term expires within ${toString warnDays} days.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} term expires within ${toString warnDays} days. Schedule re-activation through governance.";
+      };
+    }
+    {
+      # `> 0` clamp keeps already-expired members from dual-firing
+      # alongside cardano_cc_member_expired.
+      alert = "cardano_cc_term_expiring_urgent";
+      expr = "cardano_cc_member_seconds_until_expiration > 0 <= ${pageSeconds}";
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} term expires within ${toString pageDays} days.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} term expires within ${toString pageDays} days. Re-activate now.";
+      };
+    }
+    {
+      # Both auth states page because both mean "this member cannot
+      # vote right now"; annotations differentiate the runbook.
+      alert = "cardano_cc_hot_key_unauthorized";
+      expr = ''cardano_cc_member_hot_cred_status{status="MemberNotAuthorized"} == 1'';
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} has no authorized hot key.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} hotCredsAuthStatus is MemberNotAuthorized. Submit the hot-key authorization certificate.";
+      };
+    }
+    {
+      alert = "cardano_cc_hot_key_resigned";
+      expr = ''cardano_cc_member_hot_cred_status{status="MemberResigned"} == 1'';
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} has resigned.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} hotCredsAuthStatus is MemberResigned. Governance action required to restore voting.";
+      };
+    }
+    {
+      alert = "cardano_cc_member_expired";
+      expr = ''cardano_cc_member_state{state="Expired"} == 1'';
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} term has expired.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} status is Expired. Re-activation through governance is required to restore voting.";
+      };
+    }
+    {
+      alert = "cardano_cc_member_unrecognized";
+      expr = ''cardano_cc_member_state{state="Unrecognized"} == 1'';
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} status is Unrecognized.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} status is Unrecognized. Check node/ledger consistency.";
+      };
+    }
+    {
+      # Authoritative ledger signal: catches TermAdjusted edge cases
+      # that the bare epoch arithmetic of cardano_cc_term_expiring
+      # would miss.
+      alert = "cardano_cc_to_be_expired_next_epoch";
+      expr = ''cardano_cc_member_next_epoch_change{change="ToBeExpired"} == 1'';
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: CC member {{$labels.cold_credential}} will be Expired at next epoch boundary.";
+        description = "{{$labels.environment}}: constitutional-committee member {{$labels.cold_credential}} will transition to Expired at the next epoch boundary (authoritative ledger signal).";
+      };
+    }
+    {
+      alert = "cardano_cc_no_members";
+      expr = "cardano_cc_member_count == 0";
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.environment}}: committee-state has zero members.";
+        description = "{{$labels.environment}}: collector reports zero constitutional-committee members. Check ledger / environment configuration.";
+      };
+    }
+    {
+      # Per-instance (not absent()) because in a multi-publisher setup
+      # one stalled host wouldn't trip a bare absent.
+      #
+      # 5400s threshold: timer is hourly + RandomizedDelaySec=600s, so
+      # max healthy gap is ~4200s and the first missed run lands at
+      # ~7800s. If you change the collector cadence in
+      # profile-cardano-committee-monitor.nix, change this in lockstep —
+      # they live in separate evaluations.
+      #
+      # 10m for: absorbs alloy restarts and prometheus reloads.
+      # `instance` is the only label alloy's relabel chain sets on
+      # node_textfile_mtime_seconds; operators map it to environment in
+      # Grafana templating.
+      alert = "cardano_cc_metrics_stale";
+      expr = ''time() - max by (instance) (node_textfile_mtime_seconds{file="cardano-committee.prom"}) > 5400'';
+      for = "10m";
+      labels.severity = "page";
+      annotations = {
+        summary = "{{$labels.instance}}: cardano_cc_* metrics have not refreshed in over 90 minutes.";
+        description = "{{$labels.instance}}: the cardano-committee-monitor textfile collector has not produced a fresh .prom file in over 90 minutes. Check the systemd unit cardano-committee-monitor.service on this host.";
+      };
+    }
+    {
+      # absent() complements metrics_stale: catches "the series exists
+      # nowhere" (missed deploy, alloy misconfig, profile disabled).
+      # No $labels.* in the summary — absent() returns no labels.
+      alert = "cardano_cc_collector_absent";
+      expr = ''absent(node_textfile_mtime_seconds{file="cardano-committee.prom"})'';
+      for = "10m";
+      labels.severity = "page";
+      annotations = {
+        summary = "No host is publishing cardano_cc_* metrics.";
+        description = "No host is publishing the cardano-committee.prom textfile collector output. Either no host imports profile-cardano-committee-monitor, or alloy is not scraping the textfile directory.";
+      };
+    }
+  ];
+}


### PR DESCRIPTION
## Why

Constitutional-committee (CC) members must stay `Active` with an authorised hot key to vote on time-sensitive ratifications. A member's term has an `expiration` epoch; once it lapses, re-activation goes through governance — slow, asynchronous, and not something we want to discover in the middle of a vote we were supposed to participate in. Hot-key authorisation can also drift mid-term: a `MemberResigned` certificate is terminal until governance restores voting; a `MemberNotAuthorized` state means an operator never submitted (or rotated incorrectly) the hot-key authorisation cert.

Today there is **no metric or alert** for any of this. The only visibility is the manual `cardano-cli latest query committee-state` recipe in `templates/.../recipes/governance.just`. The first time we'd learn a testnet CC member's term had lapsed is from someone noticing a vote didn't count — which has already happened.

This PR closes the gap by emitting committee-state to Prometheus and alerting 30 days ahead of a term lapse (warning), 7 days ahead (page), and immediately on hot-key auth-status changes. Scope is **any** committee member's term lapsing, not just members we operate — tracking which credentials are "ours" adds configuration burden for no coverage benefit, and the cost of one alert per environment-wide member is trivial.

## What

Adds an opt-in `profile-cardano-committee-monitor` NixOS profile that publishes constitutional-committee state to a prometheus textfile-collector `.prom` file on an hourly systemd timer, plus the matching alert rule group in the project template.

## Architecture

Three pieces, each in its conventional location:

- **`profile-cardano-committee-monitor.nix`** — new profile registered via `flake.nixosModules.*`, mirroring `profile-cardano-custom-metrics.nix`. Only exposes `services.cardano-committee-monitor.enable`. Cadence is hardcoded `OnCalendar = "hourly"` + `RandomizedDelaySec = 600`, paired with the `cardano_cc_metrics_stale` 5400s threshold in the alert file.
- **`flakeModules/lib/cardano-committee-monitor-collect.nix`** — `callPackage`-able `writeShellApplication` shared between the production unit and the fixture check. Lives under `flakeModules/lib/` (not under `./flake` or `./perSystem`) so `recursiveImports` doesn't try to interpret the function as a flake-parts module. The `cardano-cli` argument lets the fixture check swap in a JSON-driven shim.
- **`perSystem/checks/cardano-committee-monitor-fixture.nix`** — golden-output check; builds the exact same writeShellApplication the production unit uses, with the cardano-cli shim, and `diff -u`s against a checked-in golden `.prom`. Auto-imported via `recursiveImports`; no `flake.nix` edit needed.

## profile-grafana-alloy prerequisite

The committee profile depends on two pure-addition options added to `profile-grafana-alloy.nix`:

- `services.alloy.textfileCollectorDirectory` (nullOr str, default `null`). When set: enables the node-exporter `textfile` collector, emits the matching HCL block, creates a `node-textfile` group, and tmpfiles-rules the directory mode `2775` (setgid so multiple textfile publishers can share it). When `null`: behaviour is identical to before.
- `services.alloy.extraPrometheusRelabelNodeKeepRegex` (listOf str, default `[]`). Sibling profiles append their metric-series alternation arms here without needing a recursive `mkForce` on the base option. The committee profile sets `["^cardano_cc_.*$"]`.

Also extends the base `prometheusRelabelNodeKeepRegex` default with `node_textfile_(mtime_seconds|scrape_error)` so textfile-collector self-metrics are scrapeable. This un-breaks the existing `NodeTextFileCollectorScrapeError` alert (which has been silently dead) and is what the new `cardano_cc_metrics_stale` / `cardano_cc_collector_absent` alerts key off.

## Metrics

All series carry `environment="<env>"`. Per-environment scalars are not deduplicated; the profile is intended to be imported on **one host per environment** (documented expectation, not asserted).

- Per-member numeric gauges: `cardano_cc_member_epochs_until_expiration`, `cardano_cc_member_seconds_until_expiration` (both omitted when `expiration` is null, i.e. newly-enacted members).
- Per-member info-style gauges (value `1`, state in a label):
  - `cardano_cc_member_hot_cred_status{status=…}` — `MemberAuthorized | MemberNotAuthorized | MemberResigned`
  - `cardano_cc_member_state{state=…}` — `Active | Expired | Unrecognized`
  - `cardano_cc_member_next_epoch_change{change=…}` — `ToBeEnacted | ToBeRemoved | NoChangeExpected | ToBeExpired | TermAdjusted`
- Per-environment scalars: `cardano_cc_current_epoch`, `cardano_cc_member_count`, `cardano_cc_seconds_per_epoch`.

Tri-state enums are emitted as info-gauges so alerts can tier severity by state (e.g. `MemberNotAuthorized` pages with a recoverable runbook; `MemberResigned` pages with a governance runbook) instead of collapsing every not-OK state to a single boolean.

## Alerts

`templates/cardano-parts-project/flake/opentofu/grafana/alerts/cardano-committee.nix-import` (auto-discovered via `parseDir` on `grafana/alerts`, deployed with the rest of the monitoring stack):

| Rule | Severity | Threshold |
|---|---|---|
| `cardano_cc_term_expiring` | warning | 30 days (default) |
| `cardano_cc_term_expiring_urgent` | page | 7 days (default) |
| `cardano_cc_hot_key_unauthorized` | page | — |
| `cardano_cc_hot_key_resigned` | page | — |
| `cardano_cc_member_expired` | page | — |
| `cardano_cc_member_unrecognized` | page | — |
| `cardano_cc_to_be_expired_next_epoch` | page | — (authoritative ledger signal) |
| `cardano_cc_no_members` | page | — |
| `cardano_cc_metrics_stale` | page | 5400 s, `for=10m` |
| `cardano_cc_collector_absent` | page | `absent()`, `for=10m` |

`warnDays` / `pageDays` are constants in the rule file. Per-environment tuning is done by duplicating rules with an `environment=~"…"` selector. The file is part of the project template, so downstream repos own it after init.

`for:` discipline: value-based alerts carry no `for:` (hourly writer + values that can't flap → would just delay a real page). The two scrape-pipeline alerts carry `for=10m` to absorb routine alloy restarts and prometheus reloads.

## Rollout expectation — alerts that fire on day 1

Real captures already trip several alerts on existing state, so this is expected and informative on first scrape:

- **Mainnet** (epoch 630): 1 page on `cardano_cc_hot_key_resigned` for a member that has resigned but is still `Active`. Term doesn't expire for ~115 days, so no expiry-tier alerts yet.
- **Preview** (epoch 1296): 6 pages on `cardano_cc_member_expired` — five members at `expiration: 1007`, one at `1000`, all already ~290 epochs past expiry. Three remaining members are `Active` with `expiration: 1356`, clear of the 30-day warn threshold.
- **Preprod**: capture and re-evaluate at deploy time.

Recommended: deploy on an off-hours window and let day-1 alerts fire — strongest end-to-end confirmation the pipeline works. Subsequent silences in alertmanager are cheap to apply by `cold_credential` label. Do **not** bake `cold_credential!~"…"` allowlists into the rule file; encoding known-stale into the alert rules hides the signal the rules exist to surface.

## Validation

Local fixture check passes against the golden:

```
$ nix build .#checks.x86_64-linux.cardano-committee-monitor-fixture --no-link
# (no diff; exit 0)
```

Pre-push hooks (`treefmt`, `lint`, and the fixture check) all green.

Fixture covers every jq branch: `Active+MemberAuthorized`, `Active+MemberResigned`, `Expired+MemberAuthorized`, `Active+MemberNotAuthorized` (synthetic), `Unrecognized` (synthetic), `expiration: null` (newly-enacted member), and all five `nextEpochChange` tag variants including `TermAdjusted` with `contents`. Mixed `keyHash-` / `scriptHash-` cold credentials.

## Required at the consuming host

- Import `profile-cardano-committee-monitor` on **exactly one** host per environment.
- Set `services.alloy.textfileCollectorDirectory = "/var/lib/node-textfile"` (or wherever) on the same host. The committee profile asserts this is non-null.
- `services.cardano-node.shareNodeSocket = true` on the same host (asserted) — the collector reads the cardano-node socket via supplementary group.
- `profile-cardano-node-group` must be imported on the same host. Not asserted: the unit's `inherit (config.environment.variables) CARDANO_NODE_*` is eager and throws a native Nix error first, beating any assertion message to the punch. Documented in the README.

## Branching

Targets `next-2026-05-04` (the current dated integration branch), not `main`.
