### PR TITLE
opentofu: bake strongdm/sdm into the wrapper

### DIFF
--- a/perSystem/packages/terraform.nix
+++ b/perSystem/packages/terraform.nix
@@ -75,6 +75,7 @@
           (providerFor "opentofu" "null")
           (providerFor "opentofu" "tls")
           (providerFor "loafoe" "ssh")
+          (providerFor "strongdm" "sdm")
         ]);
     };
 }


### PR DESCRIPTION
## Summary

Adds the [StrongDM Terraform provider](https://github.com/strongdm/terraform-provider-sdm) to the \`opentofu.withPlugins\` list in \`perSystem/packages/terraform.nix\`. Same pattern as the existing entries (loafoe/ssh, grafana/grafana, etc.) — the provider is vendored into \`libexec/terraform-providers\` at build time so it works in network-restricted environments (self-hosted runners, sandboxed nix shells) where the consumer can't reach \`registry.opentofu.org\` to pull it via \`tofu init\`.

## Motivation

Concrete use case: [shieldedtech/midnight-performance#123](https://github.com/shieldedtech/midnight-performance/pull/123) ports the StrongDM resource pattern from \`shielded-iac-modules/app/midnight\` into perfnet's terranix-driven tofu config. CI runs on a self-hosted beast runner that uses the cardano-parts ops dev shell — which today bakes in aws/null/local/tls/etc. but not strongdm/sdm, so every \`tofu init\` blocks waiting for an unreachable registry call:

\`\`\`
Error: Failed to query available provider packages
Could not retrieve the list of available versions for provider
strongdm/sdm: provider registry.opentofu.org/strongdm/sdm was not found
in any of the search locations
  - /nix/store/.../libexec/terraform-providers
\`\`\`

StrongDM is the org-standard SSH/database access proxy across the shielded-tech infra, so other consumer flakes (shielded-iac, shielded-iac-modules) already pin it; bringing it into the wrapper aligns the dev shell with the actual usage pattern.

## Testing

- \`nix build .#opentofu\` succeeds on x86_64-linux.
- Resulting binary's \`libexec/terraform-providers/registry.opentofu.org/strongdm/sdm/<ver>/\` contains the provider.
- \`tofu init\` against a config with \`sdm = { source = "strongdm/sdm"; version = "~> 15.0"; }\` resolves from the local mirror without hitting the registry.

## Risks

- Adds one more provider derivation to the wrapper build (~25 MB) — negligible relative to the existing set.
- Provider tracked through opentofu-registry input the same way all the others are; updates flow automatically with the existing input bump cadence.