### PR TITLE
nixosModule: fix cardano-custom-metrics ping latency var name typo

### DIFF
--- a/flake/nixosModules/profile-cardano-custom-metrics.nix
+++ b/flake/nixosModules/profile-cardano-custom-metrics.nix
@@ -108,7 +108,7 @@
             return 0
           }
 
-          if CARDANO_NODE_PING_OUPUT=$(cardano-cli ping \
+          if CARDANO_NODE_PING_OUTPUT=$(cardano-cli ping \
               --count=1 \
               --host=${hostAddr} \
               --port=${toString cardanoNodePort} \


### PR DESCRIPTION
## Problem

`cardano-custom-metrics` pushes ping latency to netdata statsd as a **gauge** (last-value-wins). The `cardano-cli ping` output is **assigned** to `CARDANO_NODE_PING_OUPUT` (misspelled) but **read** as `CARDANO_NODE_PING_OUTPUT`, so `CARDANO_NODE_PING_LATENCY` is always empty (`cardano.node_ping_latency_ms:|g`).

Because the metric is a gauge, netdata freezes it at the last good value. Fleet-wide every host reports a constant latency (`distinct=1` over days); `leios3-rel-c-3` latched at `689.054` ms, above the 500 ms threshold, firing a stale `high_cardano_ping_latency` alert that is a false alarm, not a node-health issue.

## Root cause

Commit `96ff2cd` ("update cardano-custom-metrics for new cardano-cli ping json") renamed only the **read** side to the correctly-spelled `OUTPUT`, leaving the **assignment** as `OUPUT` and creating the mismatch. On `main` both sides still use the misspelled `OUPUT`, so main is unaffected — this bug is specific to branches containing `96ff2cd` (i.e. `next-2026-05-15`).

## Fix

One-char rename of the assignment so both sides use `CARDANO_NODE_PING_OUTPUT`.

## Verification

Reproduced locally with bash+jq: mismatched names → empty latency → `cardano.node_ping_latency_ms:|g`; matched names → correct sub-second value. After deploy and the next minutely run, the gauge should unfreeze and the alert resolve.